### PR TITLE
Wire up the ABCI query endpoint

### DIFF
--- a/core/src/loom/examples/experiment/experiment.go
+++ b/core/src/loom/examples/experiment/experiment.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/store"
@@ -69,7 +70,8 @@ func startCmd(cmd *cobra.Command, args []string) error {
 			},
 			&experimentHandler{},
 		),
-		Store: store.GetCommitKVStore(mainStoreKey),
+		QueryHandler: &queryLogger{},
+		Store:        store.GetCommitKVStore(mainStoreKey),
 	}
 	return startTendermint(app)
 }
@@ -100,4 +102,12 @@ func startTendermint(app abci.Application) error {
 	// Trap signal, run forever.
 	n.RunForever()
 	return nil
+}
+
+type queryLogger struct {
+}
+
+func (q *queryLogger) Handle(state loom.State, path string, data []byte) ([]byte, error) {
+	logger.Info(fmt.Sprintf("Query received, path: '%s', data: '%v'", path, data))
+	return nil, fmt.Errorf("Invalid query for path '%s'", path)
 }


### PR DESCRIPTION
This can be used to query app state until a nicer query API is built.
Example usage:
GET http://localhost:46657/abci_query?path="hello"&data="whatever"