### PR TITLE
Add nonce endpoint to query server

### DIFF
--- a/address.go
+++ b/address.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/crypto/ripemd160"
 	"golang.org/x/crypto/sha3"
 
 	"github.com/loomnetwork/loom/types"
@@ -43,6 +44,15 @@ func (a LocalAddress) String() string {
 
 func (a LocalAddress) Compare(other LocalAddress) int {
 	return bytes.Compare([]byte(a), []byte(other))
+}
+
+func LocalAddressFromPublicKey(pubKey []byte) LocalAddress {
+	hasher := ripemd160.New()
+	hasher.Write(pubKey[:]) // does not error
+
+	var addr LocalAddress
+	copy(addr, hasher.Sum(nil))
+	return addr
 }
 
 type Address struct {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"golang.org/x/crypto/ed25519"
-	"golang.org/x/crypto/ripemd160"
 
 	"github.com/loomnetwork/loom"
 	lp "github.com/loomnetwork/loom-plugin"
@@ -22,15 +21,6 @@ func (c contextKey) String() string {
 var (
 	contextKeyOrigin = contextKey("origin")
 )
-
-func makeLocalAddress(pubKey []byte) loom.LocalAddress {
-	hasher := ripemd160.New()
-	hasher.Write(pubKey[:]) // does not error
-
-	var addr loom.LocalAddress
-	copy(addr, hasher.Sum(nil))
-	return addr
-}
 
 func Origin(ctx context.Context) loom.Address {
 	return ctx.Value(contextKeyOrigin).(loom.Address)


### PR DESCRIPTION
Kyle's objection has been dully noted, this is a hack to get the Unity SDK working, and we should provide a better way of accessing app state that doesn't require creating an RPC endpoint for each little piece of state.

Kyle's suggestion:
>The best way would be to query the app state via rpc and then provide nonce wrapping code
>Because there are a lot of pieces of state we might want to pull out besides nonce.
>
>We do this in loom JS