### PR TITLE
Automation: Move push to a new stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,81 +3,87 @@
 pipeline {
   agent none
 
-  stage ('Checkout') {
-    parallel {
-      stage ('Checkout - Linux') {
-        agent { label 'linux' }
-        steps {
-          checkout scm
+  stages {
+    stage ('Checkout') {
+      parallel {
+        stage ('Checkout - Linux') {
+          agent { label 'linux' }
+          steps {
+            checkout scm
+          }
         }
-      }
-      stage ('Checkout - Windows') {
-        agent { label 'windows' }
-        steps {
-          checkout scm
+        stage ('Checkout - Windows') {
+          agent { label 'windows' }
+          steps {
+            checkout scm
+          }
         }
-      }
-      stage ('Checkout - OSX') {
-        agent { label 'osx' }
-        steps {
-          checkout scm
-        }
-      }
-    }
-
-    parallel {
-      stage ('Build - Linux') {
-        agent { label 'linux' }
-        steps {
-          sh '''
-            ./jenkins.sh
-          '''
-        }
-      }
-      stage ('Build - Windows') {
-        agent { label 'windows' }
-        steps {
-          bat '''
-            jenkins.cmd
-          '''
-        }
-      }
-      stage ('Build - OSX') {
-        agent { label 'osx' }
-        steps {
-          sh '''
-            ./jenkins.sh
-          '''
+        stage ('Checkout - OSX') {
+          agent { label 'osx' }
+          steps {
+            checkout scm
+          }
         }
       }
     }
 
-    parallel {
-      stage ('Push - Linux') {
-        agent { label 'linux' }
-        steps {
-          sh '''
-            cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
-            gsutil cp loom gs://private.delegatecall.com/loom/linux/build-$BUILD_NUMBER/loom
-          '''
+    stage ('Build') {
+      parallel {
+        stage ('Build - Linux') {
+          agent { label 'linux' }
+          steps {
+            sh '''
+              ./jenkins.sh
+            '''
+          }
+        }
+        stage ('Build - Windows') {
+          agent { label 'windows' }
+          steps {
+            bat '''
+              jenkins.cmd
+            '''
+          }
+        }
+        stage ('Build - OSX') {
+          agent { label 'osx' }
+          steps {
+            sh '''
+              ./jenkins.sh
+            '''
+          }
         }
       }
-      stage ('Push - Windows') {
-        agent { label 'windows' }
-        steps {
-          bat '''
-            cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
-            gsutil cp loom gs://private.delegatecall.com/loom/windows/build-$BUILD_NUMBER/loom
-          '''
+    }
+
+    stage ('Push') {
+      parallel {
+        stage ('Push - Linux') {
+          agent { label 'linux' }
+          steps {
+            sh '''
+              cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
+              gsutil cp loom gs://private.delegatecall.com/loom/linux/build-$BUILD_NUMBER/loom
+            '''
+          }
         }
-      }
-      stage ('Push - OSX') {
-        agent { label 'osx' }
-        steps {
-          sh '''
-            cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
-            gsutil cp loom gs://private.delegatecall.com/loom/osx/build-$BUILD_NUMBER/loom
-          '''
+        stage ('Push - Windows') {
+          agent { label 'windows' }
+          steps {
+            bat '''
+              cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
+              gsutil cp loom gs://private.delegatecall.com/loom/windows/build-$BUILD_NUMBER/loom
+            '''
+          }
+        }
+        stage ('Push - OSX') {
+          agent { label 'osx' }
+          steps {
+            sh '''
+              cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
+              gsutil cp loom gs://private.delegatecall.com/loom/osx/build-$BUILD_NUMBER/loom
+            '''
+          }
         }
       }
     }


### PR DESCRIPTION
* Moves the push commands to a separate push stage.
* Makes the stage naming more clear what it's for.

On quick glance it doesn't appear to be possible to remove the parent stages, but I'm happy to be wrong on that.

*NOTE* This means that no pushes will happen if any of the builds fail.