### PR TITLE
Read In Config File

### DIFF
--- a/abci/backend/tendermint.go
+++ b/abci/backend/tendermint.go
@@ -42,10 +42,11 @@ func resetPrivValidator(privVal *pv.FilePV, height int64) {
 func (b *TendermintBackend) parseConfig() (*cfg.Config, error) {
 	v := viper.New()
 	v.AutomaticEnv()
-	v.SetEnvPrefix("TM")
-	v.SetConfigName("config")   // name of config file (without extension)
-	v.AddConfigPath(b.RootPath) // search root directory
 
+	v.SetEnvPrefix("TM")
+	v.SetConfigName("config")               // name of config file (without extension)
+	v.AddConfigPath(b.RootPath + "/config") // search root directory
+	v.ReadInConfig()
 	conf := cfg.DefaultConfig()
 	err := v.Unmarshal(conf)
 	if err != nil {


### PR DESCRIPTION
During init. it generates a tendermint config in chaindata/config/config.toml
but any changes to that are never read in since the path really is `RootPath + /config`