### PR TITLE
Disable windows build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ void setBuildStatus(String message, String state, String context) {
 }
 
 def builders = [:]
+def disabled = [:]
 
 builders['linux'] = {
   node('linux') {
@@ -53,7 +54,7 @@ builders['linux'] = {
   }
 }
 
-builders['windows'] = {
+disabled['windows'] = {
   node('windows') {
     def thisBuild = null
 

--- a/Jenkinsfile-PR.groovy
+++ b/Jenkinsfile-PR.groovy
@@ -9,6 +9,7 @@ void setBuildStatus(String message, String state, String context) {
 }
 
 def builders = [:]
+def disabled = [:]
 
 builders['linux'] = {
   node('linux') {
@@ -60,7 +61,7 @@ builders['linux'] = {
   }
 }
 
-builders['windows'] = {
+disabled['windows'] = {
   node('windows') {
     def thisBuild = null
 


### PR DESCRIPTION
Move Windows to the disabled variable for now until we figure out how we can fix it.

This is for both:

* https://ci.kanwisher.com/job/loom-sdk-pipeline3/
* https://ci.kanwisher.com/job/loom-sdk-pipeline-prbuilder/

A ticket has been created for fixing it https://github.com/loomnetwork/ops/issues/120