### PR TITLE
Throttle using category "loom-sdk"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,4 +148,6 @@ builders['osx'] = {
   }
 }
 
-parallel builders
+throttle(['loom-sdk') {
+  parallel builders
+}

--- a/Jenkinsfile-PR.groovy
+++ b/Jenkinsfile-PR.groovy
@@ -161,4 +161,6 @@ builders['osx'] = {
   }
 }
 
-parallel builders
+throttle(['loom-sdk') {
+  parallel builders
+}


### PR DESCRIPTION
Throttle builds for loom-sdk. One build for each node to avoid collision during test.

For: https://github.com/loomnetwork/ops/issues/180

Reference: https://github.com/jenkinsci/throttle-concurrent-builds-plugin