### PR TITLE
fix ChainId typo

### DIFF
--- a/vm/evm.go
+++ b/vm/evm.go
@@ -118,7 +118,7 @@ func defaultChainConfig() params.ChainConfig {
 		Epoch:  1000, // Epoch length to reset votes and checkpoint
 	}
 	return params.ChainConfig{
-		ChainID:        big.NewInt(0), // Chain id identifies the current chain and is used for replay protection
+		ChainId:        big.NewInt(0), // Chain id identifies the current chain and is used for replay protection
 		HomesteadBlock: nil,           // Homestead switch block (nil = no fork, 0 = already homestead)
 		DAOForkBlock:   nil,           // TheDAO hard-fork switch block (nil = no fork)
 		DAOForkSupport: true,          // Whether the nodes supports or opposes the DAO hard-fork


### PR DESCRIPTION
I failed to build the latest master running `make` with: 

```
go build -tags "evm" -ldflags "-X github.com/loomnetwork/loomchain.Build= -X github.com/loomnetwork/loomchain.GitSHA=`git rev-parse --verify HEAD`" github.com/loomnetwork/loomchain/cmd/loom
# github.com/loomnetwork/loomchain/vm
vm/evm.go:121:10: unknown field 'ChainID' in struct literal of type params.ChainConfig (but does have ChainId)
make: *** [loom] Error 2
```
This should fix it.