### PR TITLE
Only allow oracles to sumbit events

### DIFF
--- a/builtin/plugins/gateway/gateway_test.go
+++ b/builtin/plugins/gateway/gateway_test.go
@@ -59,6 +59,20 @@ func TestEmptyEventBatchProcessing(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+func TestPermissions(t *testing.T) {
+	fakeCtx := plugin.CreateFakeContext(addr1 /*caller*/, addr1 /*contract*/)
+
+	gwContract := &Gateway{}
+	err := gwContract.Init(contract.WrapPluginContext(fakeCtx), &GatewayInitRequest{})
+	require.Nil(t, err)
+
+	err = gwContract.ProcessEventBatch(
+		contract.WrapPluginContext(fakeCtx.WithSender(addr2)),
+		&ProcessEventBatchRequest{FtDeposits: genTokenDeposits([]uint64{5})},
+	)
+	require.Equal(t, ErrNotAuthorized, err, "Should fail because caller is not authorized to call ProcessEventBatchRequest")
+}
+
 func TestOldEventBatchProcessing(t *testing.T) {
 	fakeCtx := plugin.CreateFakeContext(addr1 /*caller*/, loom.Address{} /*contract*/)
 	gw := &Gateway{}


### PR DESCRIPTION
Currently the set of oracles has to be specified in the Gateway contract genesis, in the future the contract will allow the set of oracles to be modified at runtime.