### PR TITLE
add pubkey cmd to validators-tool

### DIFF
--- a/e2e/cmd/main.go
+++ b/e2e/cmd/main.go
@@ -17,6 +17,7 @@ func main() {
 	rootCmd.AddCommand(newRunCommand())
 	rootCmd.AddCommand(newTestCommand())
 	rootCmd.AddCommand(newGenerateCommand())
+	rootCmd.AddCommand(newPubKeyCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/e2e/cmd/pubkey.go
+++ b/e2e/cmd/pubkey.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+
+	loom "github.com/loomnetwork/go-loom"
+	"github.com/spf13/cobra"
+)
+
+func newPubKeyCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:           "pubkey",
+		Short:         "Convert public key to loom's address hex format",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(ccmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return fmt.Errorf("at least one argument required")
+			}
+			for _, pubkey := range args {
+				address := loom.LocalAddressFromPublicKey([]byte(pubkey))
+				fmt.Printf("loom address: %s\n", address)
+			}
+			return nil
+		},
+	}
+	return command
+}


### PR DESCRIPTION
- add pubkey command to help convert pubkey to loom's address.