### PR TITLE
Handle nil value in Context.Set() consistently in internal/external plugins

### DIFF
--- a/plugin/external.go
+++ b/plugin/external.go
@@ -252,7 +252,11 @@ func (s *GRPCAPIServer) Set(ctx context.Context, req *types.SetRequest) (*types.
 	if s.ctx == nil {
 		return nil, errVolatileCall
 	}
-	s.ctx.Set(req.Key, req.Value)
+	if req.Value == nil {
+		s.ctx.Set(req.Key, []byte{})
+	} else {
+		s.ctx.Set(req.Key, req.Value)
+	}
 	return &types.SetResponse{}, nil
 }
 


### PR DESCRIPTION
The `IAVLStore` doesn't allow `nil` values, in internal/builtin plugins (see `wrappedPluginContext.Set()`) no attempt will be made to store `nil` values in the `IAVLStore` because because `proto.Marshal()` will return an empty byte array instead of `nil` if a protobuf message is encoded to `nil` (because all its members are set to default values).

In the case of external plugins the relevant code is in `GRPCAPIServer.Set()`, here the value encoded in the request message may be `nil`, and the code will attempt to insert it into the `IAVLStore` cause
the `IAVL` tree to panic with `Attempt to store nil value at key whaaaatever`.