### PR TITLE
e2e test add freeport

### DIFF
--- a/e2e/node/cluster.go
+++ b/e2e/node/cluster.go
@@ -21,29 +21,11 @@ import (
 
 // global port generators
 var (
-	rpcPortGenerator   *portGenerator
-	p2pPortGenerator   *portGenerator
-	proxyPortGenerator *portGenerator
-	queryPortGenerator *portGenerator
+	portGen *portGenerator
 )
 
 func init() {
-	rpcPortGenerator = &portGenerator{
-		start:   57000,
-		current: 57000,
-	}
-	p2pPortGenerator = &portGenerator{
-		start:   56000,
-		current: 56000,
-	}
-	proxyPortGenerator = &portGenerator{
-		start:   58000,
-		current: 58000,
-	}
-	queryPortGenerator = &portGenerator{
-		start:   59000,
-		current: 59000,
-	}
+	portGen = &portGenerator{}
 }
 
 func CreateCluster(nodes []*Node, account []*Account) error {
@@ -84,9 +66,9 @@ func CreateCluster(nodes []*Node, account []*Account) error {
 			return err
 		}
 		str := string(data)
-		rpcPort := rpcPortGenerator.Next()
-		p2pPort := p2pPortGenerator.Next()
-		proxyAppPort := proxyPortGenerator.Next()
+		rpcPort := portGen.Next()
+		p2pPort := portGen.Next()
+		proxyAppPort := portGen.Next()
 		rpcLaddr := fmt.Sprintf("tcp://127.0.0.1:%d", rpcPort)
 		p2pLaddr := fmt.Sprintf("127.0.0.1:%d", p2pPort)
 		proxyAppPortAddr := fmt.Sprintf("tcp://127.0.0.1:%d", proxyAppPort)
@@ -131,7 +113,7 @@ func CreateCluster(nodes []*Node, account []*Account) error {
 			LogAppDb           bool
 			LogDestination     string
 		}{
-			QueryServerHost:    fmt.Sprintf("tcp://127.0.0.1:%d", queryPortGenerator.Next()),
+			QueryServerHost:    fmt.Sprintf("tcp://127.0.0.1:%d", portGen.Next()),
 			Peers:              strings.Join(peers, ","),
 			PersistentPeers:    strings.Join(persistentPeers, ","),
 			RPCProxyPort:       int32(rpcProxyPort),

--- a/e2e/node/node.go
+++ b/e2e/node/node.go
@@ -43,7 +43,7 @@ func NewNode(ID int64, baseDir, loomPath, contractDir, genesisFile string) *Node
 		ContractDir:     contractDir,
 		LoomPath:        loomPath,
 		Dir:             path.Join(baseDir, fmt.Sprintf("%d", ID)),
-		QueryServerHost: fmt.Sprintf("tcp://127.0.0.1:%d", queryPortGenerator.Next()),
+		QueryServerHost: fmt.Sprintf("tcp://127.0.0.1:%d", portGen.Next()),
 		BaseGenesis:     genesisFile,
 	}
 }

--- a/e2e/node/port.go
+++ b/e2e/node/port.go
@@ -6,13 +6,21 @@ import (
 )
 
 type portGenerator struct {
-	lock    sync.Mutex
-	start   int
-	current int
+	smap sync.Map
 }
 
 func (p *portGenerator) Next() int {
-	return GetPort()
+	// make sure that we don't reuse the port
+	var port int
+	for {
+		port = GetPort()
+		_, ok := p.smap.Load(&port)
+		if !ok {
+			p.smap.Store(&port, &port)
+			break
+		}
+	}
+	return port
 }
 
 // GetFreePort asks the kernel for a free open port that is ready to use.


### PR DESCRIPTION
- change fixed set of port in e2e test to use freeport.
- use global port generator instead of separated one for each category.