### PR TITLE
Fix QueryServer.QueryPlugin PluginVM creation

### DIFF
--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -128,10 +128,13 @@ func (s *QueryServer) Query(caller, contract string, query []byte, vmType vm.VMT
 }
 
 func (s *QueryServer) QueryPlugin(caller, contract loom.Address, query []byte) ([]byte, error) {
-	vm := &lcp.PluginVM{
-		Loader: s.Loader,
-		State:  s.StateProvider.ReadOnlyState(),
-	}
+	vm := lcp.NewPluginVM(
+		s.Loader,
+		s.StateProvider.ReadOnlyState(),
+		s.CreateRegistry(s.StateProvider.ReadOnlyState()),
+		nil,
+		log.Default,
+	)
 	req := &plugin.Request{
 		ContentType: plugin.EncodingType_PROTOBUF3,
 		Accept:      plugin.EncodingType_PROTOBUF3,


### PR DESCRIPTION
It was creating a PluginVM without a registry, nor a logger.