### PR TITLE
Only make registry key as true if matched and published.

### DIFF
--- a/eth/subs/reset-hub.go
+++ b/eth/subs/reset-hub.go
@@ -42,8 +42,8 @@ func (h *EthResetHub) Publish(message pubsub.Message) int {
 		if unsent {
 			if sub.Match(message.Topic()) {
 				count += sub.Publish(message)
+				h.registry[sub] = false
 			}
-			h.registry[sub] = false
 		}
 	}
 


### PR DESCRIPTION
Should fix https://github.com/loomnetwork/loom-js/issues/82

EthResetHub is an implementation of the [pubsub.Hub interface](https://github.com/phonkee/go-pubsub/blob/master/interfaces.go)
It adds the extra functionality to remember if a subscription has already been replied to in response to an event, and only reply once to each event. The `Reset()` method forgets this memory.
The `registry: map[pubsub.Subscriber]bool{}` holds this memory, whether it has been replied to or not, for each subscription. 
```go
    for sub, unsent := range h.registry {
        if unsent {
            if sub.Match(message.Topic()) {
                count += sub.Publish(message)
		h.registry[sub] = false
            }
        }
    }
```
The above code checks each subscription. If it has not been replied to yet, it checks to see if the active event matches the subscription and if so publishes it. 
If we publish the event to a subscription, then we want to mark it as published, so we do not send it again to the same subscription. Hence the ` h.registry[sub] = false` line should only be run if the message gets published, so is repositioned immediately after ` count += sub.Publish(message)`.