### PR TITLE
Cleanup EVM integration

### DIFF
--- a/evm/test_cryptozombies.go
+++ b/evm/test_cryptozombies.go
@@ -148,7 +148,8 @@ func deployContract(t *testing.T, vm lvm.VM, caller loom.Address, code string, r
 }
 
 func testGetCode(t *testing.T, vm lvm.VM, addr loom.Address, expectedCode string) {
-	actualCode := vm.GetCode(addr)
+	actualCode, err := vm.GetCode(addr)
+	require.NoError(t, err)
 	if !checkEqual(actualCode, common.Hex2Bytes(expectedCode)) {
 		t.Error("wrong runcode returned by GetCode")
 	}

--- a/plugin/vm.go
+++ b/plugin/vm.go
@@ -184,8 +184,8 @@ func (vm *PluginVM) StaticCallEVM(caller, addr loom.Address, input []byte) ([]by
 	return evm.StaticCall(caller, addr, input)
 }
 
-func (vm *PluginVM) GetCode(addr loom.Address) []byte {
-	return []byte{}
+func (vm *PluginVM) GetCode(addr loom.Address) ([]byte, error) {
+	return []byte{}, nil
 }
 
 // Implements plugin.Context interface (go-loom/plugin/contract.go)

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -171,7 +171,7 @@ func (s *QueryServer) GetEvmCode(contract string) ([]byte, error) {
 		return nil, err
 	}
 	vm := levm.NewLoomVm(s.StateProvider.ReadOnlyState(), nil)
-	return vm.GetCode(contractAddr), nil
+	return vm.GetCode(contractAddr)
 }
 
 // Nonce returns of nonce from the application states

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -11,7 +11,7 @@ type VM interface {
 	Create(caller loom.Address, code []byte) ([]byte, loom.Address, error)
 	Call(caller, addr loom.Address, input []byte) ([]byte, error)
 	StaticCall(caller, addr loom.Address, input []byte) ([]byte, error)
-	GetCode(addr loom.Address) []byte
+	GetCode(addr loom.Address) ([]byte, error)
 }
 
 type Factory func(loomchain.State) VM


### PR DESCRIPTION
- Propagate errors from `NewLoomEvm()` instead of silently ignoring them.
- Change Evm struct to use `vm.StateDB` (an interface) instead of the `state.StateDB` struct.
- Move `Evm.Commit()` code into `LoomEvm.Commit()` because the former no longer has access to `state.StateDB`, and I don't like to use type assertions unless absolutely necessary.
- As a side effect, these changes also clear up a bunch of vet warnings about copying locks in `state.StateDB`.

The point of this is to be able to swap out `state.StateDB` for something else, which is I need for integrating the `ethcoin` with the `EVM`.