### PR TITLE
Add test for ethcoin contract

### DIFF
--- a/builtin/plugins/ethcoin/eth_coin_test.go
+++ b/builtin/plugins/ethcoin/eth_coin_test.go
@@ -1,0 +1,152 @@
+package ethcoin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	loom "github.com/loomnetwork/go-loom"
+	"github.com/loomnetwork/go-loom/plugin"
+	"github.com/loomnetwork/go-loom/plugin/contractpb"
+	"github.com/loomnetwork/go-loom/types"
+)
+
+var (
+	addr1 = loom.MustParseAddress("chain:0xb16a379ec18d4093666f8f38b11a3071c920207d")
+	addr2 = loom.MustParseAddress("chain:0xfa4c7920accfd66b86f5fd0e69682a79f762d49e")
+	addr3 = loom.MustParseAddress("chain:0x5cecd1f7261e1f4c684e297be3edf03b825e01c4")
+)
+
+func TestTransfer(t *testing.T) {
+	ctx := contractpb.WrapPluginContext(
+		plugin.CreateFakeContext(addr1, addr1),
+	)
+
+	amount := loom.NewBigUIntFromInt(100)
+	contract := &ETHCoin{}
+	err := contract.Transfer(ctx, &TransferRequest{
+		To:     addr2.MarshalPB(),
+		Amount: &types.BigUInt{Value: *amount},
+	})
+	assert.NotNil(t, err)
+
+	acct := &Account{
+		Owner: addr1.MarshalPB(),
+		Balance: &types.BigUInt{
+			Value: *loom.NewBigUIntFromInt(100),
+		},
+	}
+	err = saveAccount(ctx, acct)
+	require.Nil(t, err)
+
+	err = contract.Transfer(ctx, &TransferRequest{
+		To:     addr2.MarshalPB(),
+		Amount: &types.BigUInt{Value: *amount},
+	})
+	assert.Nil(t, err)
+
+	resp, err := contract.BalanceOf(ctx, &BalanceOfRequest{
+		Owner: addr1.MarshalPB(),
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 0, int(resp.Balance.Value.Int64()))
+
+	resp, err = contract.BalanceOf(ctx, &BalanceOfRequest{
+		Owner: addr2.MarshalPB(),
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 100, int(resp.Balance.Value.Int64()))
+}
+
+func TestApprove(t *testing.T) {
+	contract := &ETHCoin{}
+
+	ctx := contractpb.WrapPluginContext(
+		plugin.CreateFakeContext(addr1, addr1),
+	)
+	acct := &Account{
+		Owner: addr1.MarshalPB(),
+		Balance: &types.BigUInt{
+			Value: *loom.NewBigUIntFromInt(100),
+		},
+	}
+	err := saveAccount(ctx, acct)
+	require.Nil(t, err)
+
+	err = contract.Approve(ctx, &ApproveRequest{
+		Spender: addr3.MarshalPB(),
+		Amount: &types.BigUInt{
+			Value: *loom.NewBigUIntFromInt(40),
+		},
+	})
+	assert.Nil(t, err)
+
+	allowResp, err := contract.Allowance(ctx, &AllowanceRequest{
+		Owner:   addr1.MarshalPB(),
+		Spender: addr3.MarshalPB(),
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 40, int(allowResp.Amount.Value.Int64()))
+}
+
+func TestTransferFrom(t *testing.T) {
+	contract := &ETHCoin{}
+
+	pctx := plugin.CreateFakeContext(addr1, addr1)
+	ctx := contractpb.WrapPluginContext(pctx)
+	acct := &Account{
+		Owner: addr1.MarshalPB(),
+		Balance: &types.BigUInt{
+			Value: *loom.NewBigUIntFromInt(100),
+		},
+	}
+	err := saveAccount(ctx, acct)
+	require.Nil(t, err)
+
+	err = contract.Approve(ctx, &ApproveRequest{
+		Spender: addr3.MarshalPB(),
+		Amount: &types.BigUInt{
+			Value: *loom.NewBigUIntFromInt(40),
+		},
+	})
+	assert.Nil(t, err)
+
+	ctx = contractpb.WrapPluginContext(pctx.WithSender(addr3))
+	err = contract.TransferFrom(ctx, &TransferFromRequest{
+		From: addr1.MarshalPB(),
+		To:   addr2.MarshalPB(),
+		Amount: &types.BigUInt{
+			Value: *loom.NewBigUIntFromInt(50),
+		},
+	})
+	assert.NotNil(t, err)
+
+	err = contract.TransferFrom(ctx, &TransferFromRequest{
+		From: addr1.MarshalPB(),
+		To:   addr2.MarshalPB(),
+		Amount: &types.BigUInt{
+			Value: *loom.NewBigUIntFromInt(30),
+		},
+	})
+	assert.Nil(t, err)
+
+	allowResp, err := contract.Allowance(ctx, &AllowanceRequest{
+		Owner:   addr1.MarshalPB(),
+		Spender: addr3.MarshalPB(),
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 10, int(allowResp.Amount.Value.Int64()))
+
+	balResp, err := contract.BalanceOf(ctx, &BalanceOfRequest{
+		Owner: addr1.MarshalPB(),
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 70, int(balResp.Balance.Value.Int64()))
+
+	balResp, err = contract.BalanceOf(ctx, &BalanceOfRequest{
+		Owner: addr2.MarshalPB(),
+	})
+	require.Nil(t, err)
+	assert.Equal(t, 30, int(balResp.Balance.Value.Int64()))
+}

--- a/plugin/fake_context.go
+++ b/plugin/fake_context.go
@@ -1,0 +1,71 @@
+// +build evm
+
+package plugin
+
+import (
+	"context"
+
+	loom "github.com/loomnetwork/go-loom"
+	"github.com/loomnetwork/go-loom/plugin"
+	"github.com/loomnetwork/go-loom/types"
+	"github.com/loomnetwork/loomchain"
+	levm "github.com/loomnetwork/loomchain/evm"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// Contract context for tests that need both Go & EVM contracts.
+type FakeContextWithEVM struct {
+	*plugin.FakeContext
+	State loomchain.State
+}
+
+func CreateFakeContextWithEVM(caller, address loom.Address) *FakeContextWithEVM {
+	block := abci.Header{
+		ChainID: "chain",
+		Height:  int64(34),
+		Time:    int64(123456789),
+	}
+	ctx := plugin.CreateFakeContext(caller, address).WithBlock(
+		types.BlockHeader{
+			ChainID: block.ChainID,
+			Height:  block.Height,
+			Time:    block.Time,
+		},
+	)
+	state := loomchain.NewStoreState(context.Background(), ctx, block)
+	return &FakeContextWithEVM{
+		FakeContext: ctx,
+		State:       state,
+	}
+}
+
+func (c *FakeContextWithEVM) WithBlock(header loom.BlockHeader) *FakeContextWithEVM {
+	return &FakeContextWithEVM{
+		FakeContext: c.FakeContext.WithBlock(header),
+		State:       c.State,
+	}
+}
+
+func (c *FakeContextWithEVM) WithSender(caller loom.Address) *FakeContextWithEVM {
+	return &FakeContextWithEVM{
+		FakeContext: c.FakeContext.WithSender(caller),
+		State:       c.State,
+	}
+}
+
+func (c *FakeContextWithEVM) WithAddress(addr loom.Address) *FakeContextWithEVM {
+	return &FakeContextWithEVM{
+		FakeContext: c.FakeContext.WithAddress(addr),
+		State:       c.State,
+	}
+}
+
+func (c *FakeContextWithEVM) CallEVM(addr loom.Address, input []byte) ([]byte, error) {
+	vm := levm.NewLoomVm(c.State, nil)
+	return vm.Call(c.ContractAddress(), addr, input)
+}
+
+func (c *FakeContextWithEVM) StaticCallEVM(addr loom.Address, input []byte) ([]byte, error) {
+	vm := levm.NewLoomVm(c.State, nil)
+	return vm.StaticCall(c.ContractAddress(), addr, input)
+}


### PR DESCRIPTION
And move the fake context used in the Gateway test to a separate file so it can be used in other tests.