### PR TITLE
Fix PluginVM initialization in QueryServer.QueryPlugin()

### DIFF
--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -129,10 +129,13 @@ func (s *QueryServer) Query(caller, contract string, query []byte, vmType vm.VMT
 }
 
 func (s *QueryServer) QueryPlugin(caller, contract loom.Address, query []byte) ([]byte, error) {
-	vm := &lcp.PluginVM{
-		Loader: s.Loader,
-		State:  s.StateProvider.ReadOnlyState(),
-	}
+	vm := lcp.NewPluginVM(
+		s.Loader,
+		s.StateProvider.ReadOnlyState(),
+		s.CreateRegistry(s.StateProvider.ReadOnlyState()),
+		nil,
+		log.Default,
+	)
 	req := &plugin.Request{
 		ContentType: plugin.EncodingType_PROTOBUF3,
 		Accept:      plugin.EncodingType_PROTOBUF3,

--- a/rpc/query_server_test.go
+++ b/rpc/query_server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/loomnetwork/loomchain/eth/subs"
 	llog "github.com/loomnetwork/loomchain/log"
 	"github.com/loomnetwork/loomchain/plugin"
+	registry "github.com/loomnetwork/loomchain/registry/factory"
 	"github.com/loomnetwork/loomchain/store"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -105,9 +106,12 @@ func TestQueryServer(t *testing.T) {
 
 func testQueryServerContractQuery(t *testing.T) {
 	loader := &queryableContractLoader{TMLogger: llog.Root.With("module", "contract")}
+	createRegistry, err := registry.NewRegistryFactory(registry.LatestRegistryVersion)
+	require.NoError(t, err)
 	var qs QueryService = &QueryServer{
-		StateProvider: &stateProvider{},
-		Loader:        loader,
+		StateProvider:  &stateProvider{},
+		Loader:         loader,
+		CreateRegistry: createRegistry,
 	}
 	bus := &QueryEventBus{
 		Subs:    *loomchain.NewSubscriptionSet(),
@@ -201,10 +205,13 @@ func testQueryMetric(t *testing.T) {
 	}, fieldKeys)
 
 	loader := &queryableContractLoader{TMLogger: llog.Root.With("module", "contract")}
+	createRegistry, err := registry.NewRegistryFactory(registry.LatestRegistryVersion)
+	require.NoError(t, err)
 	// create query service
 	var qs QueryService = &QueryServer{
-		StateProvider: &stateProvider{},
-		Loader:        loader,
+		StateProvider:  &stateProvider{},
+		Loader:         loader,
+		CreateRegistry: createRegistry,
 	}
 	qs = InstrumentingMiddleware{requestCount, requestLatency, qs}
 	bus := &QueryEventBus{
@@ -219,7 +226,7 @@ func testQueryMetric(t *testing.T) {
 
 	// HTTP
 	pubKey := "441B9DCC47A734695A508EDF174F7AAF76DD7209DEA2D51D3582DA77CE2756BE"
-	_, err := http.Get(fmt.Sprintf("%s/nonce?key=\"%s\"", ts.URL, pubKey))
+	_, err = http.Get(fmt.Sprintf("%s/nonce?key=\"%s\"", ts.URL, pubKey))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
PluginVM was being created without a registry, nor a logger. Tests also needed a fixup.