### PR TITLE
Minor cleanup of EventHandler & DefaultEventHandler

### DIFF
--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -403,7 +403,7 @@ func loadApp(chainID string, cfg *Config, loader plugin.Loader, b backend.Backen
 		logger.Info("Using simple log event dispatcher")
 		eventDispatcher = events.NewLogEventDispatcher()
 	}
-	eventHandler := loomchain.NewDefaultEventHandler(eventDispatcher, b)
+	eventHandler := loomchain.NewDefaultEventHandler(eventDispatcher)
 
 	// TODO: It shouldn't be possible to change the registry version via config after the first run,
 	//       changing it from that point on should require a special upgrade tx that stores the

--- a/eth/subs/subs.go
+++ b/eth/subs/subs.go
@@ -30,8 +30,10 @@ type EthSubscriptionSet struct {
 func NewEthSubscriptionSet() *EthSubscriptionSet {
 	s := &EthSubscriptionSet{
 		ResetHub: NewEthResetHub(),
-		clients:  make(map[string]pubsub.Subscriber),
-		callers:  make(map[string][]string),
+		// maps ID to subscriber
+		clients: make(map[string]pubsub.Subscriber),
+		// maps remote socket address to list of subscriber IDs
+		callers: make(map[string][]string),
 	}
 	return s
 }

--- a/evm/loomevm.go
+++ b/evm/loomevm.go
@@ -200,9 +200,10 @@ func (lvm LoomVm) saveEventsAndHashReceipt(caller, addr loom.Address, events []*
 	txHash := h.Sum(nil)
 
 	txReceipt.TxHash = txHash
+	blockHeight := uint64(txReceipt.BlockNumber)
 	for _, event := range events {
 		event.TxHash = txHash
-		_ = lvm.eventHandler.Post(lvm.state, event)
+		_ = lvm.eventHandler.Post(blockHeight, event)
 		pEvent := ptypes.EventData(*event)
 		txReceipt.Logs = append(txReceipt.Logs, &pEvent)
 	}
@@ -219,7 +220,7 @@ func (lvm LoomVm) saveEventsAndHashReceipt(caller, addr loom.Address, events []*
 	receiptState := store.PrefixKVStore(utils.ReceiptPrefix, lvm.state)
 	receiptState.Set(txHash, postTxReceipt)
 
-	height := utils.BlockHeightToBytes(uint64(sState.Block().Height))
+	height := utils.BlockHeightToBytes(blockHeight)
 	bloomState := store.PrefixKVStore(utils.BloomPrefix, lvm.state)
 	bloomState.Set(height, txReceipt.LogsBloom)
 	txHashState := store.PrefixKVStore(utils.TxHashPrefix, lvm.state)

--- a/middleware.go
+++ b/middleware.go
@@ -202,14 +202,14 @@ func NewInstrumentingEventHandler(next EventHandler) EventHandler {
 }
 
 // Post captures the metrics
-func (m InstrumentingEventHandler) Post(state State, e *EventData) (err error) {
+func (m InstrumentingEventHandler) Post(height uint64, e *EventData) (err error) {
 	defer func(begin time.Time) {
 		lvs := []string{"method", "Post", "error", fmt.Sprint(err != nil)}
 		m.requestCount.With(lvs...).Add(1)
 		m.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	err = m.next.Post(state, e)
+	err = m.next.Post(height, e)
 	return
 }
 

--- a/plugin/vm.go
+++ b/plugin/vm.go
@@ -289,7 +289,8 @@ func (c *contractContext) EmitTopics(event []byte, topics ...string) {
 		EncodedBody:     event,
 		OriginalRequest: c.req.Body,
 	}
-	c.eventHandler.Post(c.State, &data)
+	height := uint64(c.State.Block().Height)
+	c.eventHandler.Post(height, &data)
 }
 
 func (c *contractContext) ContractRecord(contractAddr loom.Address) (*lp.ContractRecord, error) {

--- a/plugin/vm_test.go
+++ b/plugin/vm_test.go
@@ -35,7 +35,7 @@ var (
 type fakeEventHandler struct {
 }
 
-func (eh *fakeEventHandler) Post(state loomchain.State, e *loomchain.EventData) error {
+func (eh *fakeEventHandler) Post(height uint64, e *loomchain.EventData) error {
 	return nil
 }
 


### PR DESCRIPTION
- `EventHandler.Post()` doesn't need `loomchain.State`, just the block height.
- `DefaultEvenHandler` doesn't need a `Backend`.

And added some comments for future me.