### PR TITLE
Change microseconds to seconds

### DIFF
--- a/app.go
+++ b/app.go
@@ -176,21 +176,21 @@ func init() {
 	deliverTxLatency = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "loomchain",
 		Subsystem: "application",
-		Name:      "delivertx_latency_microseconds",
-		Help:      "Total duration of delivertx in microseconds.",
+		Name:      "delivertx_latency_seconds",
+		Help:      "Total duration of delivertx in seconds.",
 	}, fieldKeys)
 
 	checkTxLatency = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "loomchain",
 		Subsystem: "application",
-		Name:      "checktx_latency_microseconds",
-		Help:      "Total duration of checktx in microseconds.",
+		Name:      "checktx_latency_seconds",
+		Help:      "Total duration of checktx in seconds.",
 	}, fieldKeys)
 	commitBlockLatency = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "loomchain",
 		Subsystem: "application",
-		Name:      "commit_block_latency_microseconds",
-		Help:      "Total duration of commit block in microseconds.",
+		Name:      "commit_block_latency_seconds",
+		Help:      "Total duration of commit block in seconds.",
 	}, fieldKeys)
 
 	committedBlockCount = kitprometheus.NewCounterFrom(stdprometheus.CounterOpts{

--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -572,8 +572,8 @@ func initQueryService(app *loomchain.Application, chainID string, cfg *Config, l
 	requestLatency := kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "loomchain",
 		Subsystem: "query_service",
-		Name:      "request_latency_microseconds",
-		Help:      "Total duration of requests in microseconds.",
+		Name:      "request_latency_seconds",
+		Help:      "Total duration of requests in seconds.",
 	}, fieldKeys)
 
 	regVer, err := registry.RegistryVersionFromInt(cfg.RegistryVersion)

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -45,8 +45,8 @@ func init() {
 	txLatency = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "loomchain",
 		Subsystem: "application",
-		Name:      "evmtx_latency_microseconds",
-		Help:      "Total duration of go-ethereum EVM tx in microseconds.",
+		Name:      "evmtx_latency_seconds",
+		Help:      "Total duration of go-ethereum EVM tx in seconds.",
 	}, fieldKeys)
 	txGas = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "loomchain",

--- a/middleware.go
+++ b/middleware.go
@@ -146,8 +146,8 @@ func NewInstrumentingTxMiddleware() TxMiddleware {
 	requestLatency := kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "loomchain",
 		Subsystem: "tx_service",
-		Name:      "request_latency_microseconds",
-		Help:      "Total duration of requests in microseconds.",
+		Name:      "request_latency_seconds",
+		Help:      "Total duration of requests in seconds.",
 	}, fieldKeys)
 
 	return &InstrumentingTxMiddleware{
@@ -190,8 +190,8 @@ func NewInstrumentingEventHandler(next EventHandler) EventHandler {
 	requestLatency := kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "loomchain",
 		Subsystem: "event_service",
-		Name:      "request_latency_microseconds",
-		Help:      "Total duration of requests in microseconds.",
+		Name:      "request_latency_seconds",
+		Help:      "Total duration of requests in seconds.",
 	}, fieldKeys)
 
 	return &InstrumentingEventHandler{

--- a/rpc/query_server_test.go
+++ b/rpc/query_server_test.go
@@ -200,8 +200,8 @@ func testQueryMetric(t *testing.T) {
 	requestLatency := kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
 		Namespace: "loomchain",
 		Subsystem: "query_service",
-		Name:      "request_latency_microseconds",
-		Help:      "Total duration of requests in microseconds.",
+		Name:      "request_latency_seconds",
+		Help:      "Total duration of requests in seconds.",
 	}, fieldKeys)
 
 	loader := &queryableContractLoader{TMLogger: llog.Root.With("module", "contract")}


### PR DESCRIPTION
Latency metrics are measured in seconds not microseconds.
For example `deliverTxLatency.With(lvs...).Observe(time.Since(begin).Seconds())`