### PR TITLE
Add /status endpoint to out-of-process Transfer Gateway Oracle

### DIFF
--- a/cmd/tgoracle/main.go
+++ b/cmd/tgoracle/main.go
@@ -3,11 +3,10 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"os/signal"
+	"encoding/json"
+	"log"
+	"net/http"
 	"path/filepath"
-	"syscall"
 
 	"github.com/loomnetwork/loomchain/gateway"
 	"github.com/spf13/viper"
@@ -32,13 +31,14 @@ func main() {
 
 	go orc.RunWithRecovery()
 
-	// Run forever until interrupted by SIGTERM
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	for sig := range c {
-		fmt.Printf("captured %v, exiting...\n", sig)
-		os.Exit(1)
-	}
+	http.HandleFunc("/status", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(orc.Status())
+	})
+
+	// TODO: http.Handle("/metrics", promhttp.Handler())
+	log.Fatal(http.ListenAndServe(cfg.TransferGateway.OracleQueryAddress, nil))
 }
 
 // Loads loom.yml or equivalent from one of the usual location, or if overrideCfgDirs is provided

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -34,6 +34,8 @@ type TransferGatewayConfig struct {
 	OracleStartupDelay int32
 	// Number of seconds to wait between reconnection attempts.
 	OracleReconnectInterval int32
+	// Address on from which the out-of-process Oracle should expose the status & metrics endpoints.
+	OracleQueryAddress string
 }
 
 func DefaultConfig(rpcProxyPort int32) *TransferGatewayConfig {
@@ -52,5 +54,6 @@ func DefaultConfig(rpcProxyPort int32) *TransferGatewayConfig {
 		OracleLogLevel:            "info",
 		OracleLogDestination:      "file://tgoracle.log",
 		OracleStartupDelay:        5,
+		OracleQueryAddress:        "127.0.0.1:9998",
 	}
 }

--- a/gateway/dappchain_gateway.go
+++ b/gateway/dappchain_gateway.go
@@ -1,0 +1,135 @@
+package gateway
+
+import (
+	"time"
+
+	loom "github.com/loomnetwork/go-loom"
+	"github.com/loomnetwork/go-loom/auth"
+	tgtypes "github.com/loomnetwork/go-loom/builtin/types/transfer_gateway"
+	"github.com/loomnetwork/go-loom/client"
+	"github.com/pkg/errors"
+)
+
+type (
+	ProcessEventBatchRequest           = tgtypes.TransferGatewayProcessEventBatchRequest
+	GatewayStateRequest                = tgtypes.TransferGatewayStateRequest
+	GatewayStateResponse               = tgtypes.TransferGatewayStateResponse
+	ConfirmWithdrawalReceiptRequest    = tgtypes.TransferGatewayConfirmWithdrawalReceiptRequest
+	PendingWithdrawalsRequest          = tgtypes.TransferGatewayPendingWithdrawalsRequest
+	PendingWithdrawalsResponse         = tgtypes.TransferGatewayPendingWithdrawalsResponse
+	MainnetEvent                       = tgtypes.TransferGatewayMainnetEvent
+	MainnetDepositEvent                = tgtypes.TransferGatewayMainnetEvent_Deposit
+	MainnetWithdrawalEvent             = tgtypes.TransferGatewayMainnetEvent_Withdrawal
+	MainnetTokenDeposited              = tgtypes.TransferGatewayTokenDeposited
+	MainnetTokenWithdrawn              = tgtypes.TransferGatewayTokenWithdrawn
+	TokenKind                          = tgtypes.TransferGatewayTokenKind
+	PendingWithdrawalSummary           = tgtypes.TransferGatewayPendingWithdrawalSummary
+	UnverifiedContractCreatorsRequest  = tgtypes.TransferGatewayUnverifiedContractCreatorsRequest
+	UnverifiedContractCreatorsResponse = tgtypes.TransferGatewayUnverifiedContractCreatorsResponse
+	VerifyContractCreatorsRequest      = tgtypes.TransferGatewayVerifyContractCreatorsRequest
+	UnverifiedContractCreator          = tgtypes.TransferGatewayUnverifiedContractCreator
+	VerifiedContractCreator            = tgtypes.TransferGatewayVerifiedContractCreator
+)
+
+const (
+	TokenKind_ERC721 = tgtypes.TransferGatewayTokenKind_ERC721
+	TokenKind_ERC20  = tgtypes.TransferGatewayTokenKind_ERC20
+	TokenKind_ETH    = tgtypes.TransferGatewayTokenKind_ETH
+)
+
+// DAppChainGateway is a partial client-side binding of the Gateway Go contract
+type DAppChainGateway struct {
+	Address loom.Address
+	// Timestamp of the last successful response from the DAppChain
+	LastResponseTime time.Time
+
+	contract *client.Contract
+	caller   loom.Address
+	logger   *loom.Logger
+	signer   auth.Signer
+}
+
+func ConnectToDAppChainGateway(
+	loomClient *client.DAppChainRPCClient, caller loom.Address, signer auth.Signer,
+	logger *loom.Logger,
+) (*DAppChainGateway, error) {
+	gatewayAddr, err := loomClient.Resolve("gateway")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to resolve Gateway Go contract address")
+	}
+
+	return &DAppChainGateway{
+		Address:          gatewayAddr,
+		LastResponseTime: time.Now(),
+		contract:         client.NewContract(loomClient, gatewayAddr.Local),
+		caller:           caller,
+		signer:           signer,
+		logger:           logger,
+	}, nil
+}
+
+func (gw *DAppChainGateway) LastMainnetBlockNum() (uint64, error) {
+	var resp GatewayStateResponse
+	if _, err := gw.contract.StaticCall("GetState", &GatewayStateRequest{}, gw.caller, &resp); err != nil {
+		gw.logger.Error("failed to retrieve state from Gateway contract on DAppChain", "err", err)
+		return 0, err
+	}
+	gw.LastResponseTime = time.Now()
+	return resp.State.LastMainnetBlockNum, nil
+}
+
+func (gw *DAppChainGateway) ProcessEventBatch(events []*MainnetEvent) error {
+	// TODO: limit max message size to under 1MB
+	req := &ProcessEventBatchRequest{
+		Events: events,
+	}
+	if _, err := gw.contract.Call("ProcessEventBatch", req, gw.signer, nil); err != nil {
+		gw.logger.Error("failed to commit ProcessEventBatch tx", "err", err)
+		return err
+	}
+	gw.LastResponseTime = time.Now()
+	return nil
+}
+
+func (gw *DAppChainGateway) PendingWithdrawals() ([]*PendingWithdrawalSummary, error) {
+	req := &PendingWithdrawalsRequest{}
+	resp := PendingWithdrawalsResponse{}
+	if _, err := gw.contract.StaticCall("PendingWithdrawals", req, gw.caller, &resp); err != nil {
+		gw.logger.Error("failed to fetch pending withdrawals from DAppChain", "err", err)
+		return nil, err
+	}
+	gw.LastResponseTime = time.Now()
+	return resp.Withdrawals, nil
+}
+
+func (gw *DAppChainGateway) ConfirmWithdrawalReceipt(req *ConfirmWithdrawalReceiptRequest) error {
+	_, err := gw.contract.Call("ConfirmWithdrawalReceipt", req, gw.signer, nil)
+	if err != nil {
+		return err
+	}
+	gw.LastResponseTime = time.Now()
+	return nil
+}
+
+func (gw *DAppChainGateway) UnverifiedContractCreators() ([]*UnverifiedContractCreator, error) {
+	req := &UnverifiedContractCreatorsRequest{}
+	resp := UnverifiedContractCreatorsResponse{}
+	if _, err := gw.contract.StaticCall("UnverifiedContractCreators", req, gw.caller, &resp); err != nil {
+		gw.logger.Error("failed to fetch pending contract mappings from DAppChain", "err", err)
+		return nil, err
+	}
+	gw.LastResponseTime = time.Now()
+	return resp.Creators, nil
+}
+
+func (gw *DAppChainGateway) VerifyContractCreators(verifiedCreators []*VerifiedContractCreator) error {
+	req := &VerifyContractCreatorsRequest{
+		Creators: verifiedCreators,
+	}
+	_, err := gw.contract.Call("VerifyContractCreators", req, gw.signer, nil)
+	if err != nil {
+		return err
+	}
+	gw.LastResponseTime = time.Now()
+	return nil
+}


### PR DESCRIPTION
The address the /status endpoint is served on can be set via the `OracleQueryAddress` setting in the `TransferGateway` section of `loom.yml`. If not set in the config it defaults to `127.0.0.1:9998`