### PR TITLE
Add metrics endpoint to out-of-process Transfer Gateway Oracle

### DIFF
--- a/cmd/tgoracle/main.go
+++ b/cmd/tgoracle/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/loomnetwork/loomchain/gateway"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/viper"
 )
 
@@ -37,7 +38,8 @@ func main() {
 		json.NewEncoder(w).Encode(orc.Status())
 	})
 
-	// TODO: http.Handle("/metrics", promhttp.Handler())
+	http.Handle("/metrics", promhttp.Handler())
+
 	log.Fatal(http.ListenAndServe(cfg.TransferGateway.OracleQueryAddress, nil))
 }
 

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -1,0 +1,91 @@
+package gateway
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-kit/kit/metrics"
+	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+)
+
+type Metrics struct {
+	methodCallCount              metrics.Counter
+	methodDuration               metrics.Histogram
+	fetchedMainnetEventCount     metrics.Counter
+	submittedMainnetEventCount   metrics.Counter
+	signedWithdrawalCount        metrics.Counter
+	verifiedContractCreatorCount metrics.Counter
+}
+
+func NewMetrics() *Metrics {
+	const namespace = "loomchain"
+	const subsystem = "tg_oracle"
+
+	return &Metrics{
+		methodCallCount: kitprometheus.NewCounterFrom(
+			stdprometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "method_call_count",
+				Help:      "Number of times a method has been invoked.",
+			}, []string{"method", "error"}),
+		methodDuration: kitprometheus.NewSummaryFrom(
+			stdprometheus.SummaryOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "method_duration",
+				Help:      "How long a method took to execute (in seconds).",
+			}, []string{"method", "error"}),
+		fetchedMainnetEventCount: kitprometheus.NewCounterFrom(
+			stdprometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "fetched_mainnet_event_count",
+				Help:      "Number of Mainnet events fetched from the Mainnet Gateway.",
+			}, []string{"kind"}),
+		submittedMainnetEventCount: kitprometheus.NewCounterFrom(
+			stdprometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "submitted_mainnet_event_count",
+				Help:      "Number of Mainnet events successfully submitted to the DAppChain Gateway.",
+			}, nil),
+		signedWithdrawalCount: kitprometheus.NewCounterFrom(
+			stdprometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "signed_withdrawal_count",
+				Help:      "Number of withdrawals signed.",
+			}, nil),
+		verifiedContractCreatorCount: kitprometheus.NewCounterFrom(
+			stdprometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      "verified_contract_creator_count",
+				Help:      "Number of contract creator verifications performed.",
+			}, nil),
+	}
+}
+
+func (m *Metrics) MethodCalled(begin time.Time, method string, err error) {
+	lvs := []string{"method", method, "error", fmt.Sprint(err != nil)}
+	m.methodDuration.With(lvs...).Observe(time.Since(begin).Seconds())
+	m.methodCallCount.With(lvs...).Add(1)
+}
+
+func (m *Metrics) FetchedMainnetEvents(numEvents int, kind string) {
+	m.fetchedMainnetEventCount.With("kind", kind).Add(float64(numEvents))
+}
+
+func (m *Metrics) SubmittedMainnetEvents(numEvents int) {
+	m.submittedMainnetEventCount.Add(float64(numEvents))
+}
+
+func (m *Metrics) WithdrawalsSigned(numWithdrawals int) {
+	m.signedWithdrawalCount.Add(float64(numWithdrawals))
+}
+
+func (m *Metrics) ContractCreatorsVerified(numCreators int) {
+	m.verifiedContractCreatorCount.Add(float64(numCreators))
+}


### PR DESCRIPTION
The address the `/metrics` endpoint is served on can be set via the `OracleQueryAddress` setting in the `TransferGateway` section of `loom.yml`. If not set in the config it defaults to `127.0.0.1:9998`