### PR TITLE
Use loomnetwork/go-ethereum/tree/deterministic-stateobject-updateTrie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GOFLAGS_NOEVM = -ldflags "-X $(PKG).Build=$(BUILD_NUMBER) -X $(PKG).GitSHA=$(GIT
 PROTOC = protoc --plugin=./protoc-gen-gogo -Ivendor -I$(GOPATH)/src -I/usr/local/include
 PLUGIN_DIR = $(GOPATH)/src/github.com/loomnetwork/go-loom
 GOGO_PROTOBUF_DIR = $(GOPATH)/src/github.com/gogo/protobuf
+GO_ETHEREUM_DIR = $(GOPATH)/src/github.com/ethereum/go-ethereum
 
 .PHONY: all clean test install deps proto builtin oracles tgoracle plasmacash-oracle
 
@@ -71,6 +72,12 @@ deps: $(PLUGIN_DIR)
 		github.com/miguelmota/go-solidity-sha3
 	# checkout the last commit before the dev branch was merged into master (and screwed everything up)
 	cd $(GOGO_PROTOBUF_DIR) && git checkout 1ef32a8b9fc3f8ec940126907cedb5998f6318e4
+	# use our go-ethereum fork
+	cd $(GO_ETHEREUM_DIR) && \
+	git remote add loom-go-ethereum https://github.com/loomnetwork/go-ethereum.git && \
+	git fetch loom-go-ethereum --depth=10 && \
+	git checkout bab696378c359c56640fae48dfd3132763dbc64b
+	# fetch vendored packages
 	dep ensure -vendor-only
 
 test: proto


### PR DESCRIPTION
This seems to fix consensus failure stemming from ERC721 transfers in the Loom EVM.