### PR TITLE
Disable saving of failed EVM tx receipts & hashes

### DIFF
--- a/app.go
+++ b/app.go
@@ -337,16 +337,12 @@ func (a *Application) processTx(txBytes []byte, fake bool) (TxHandlerResult, err
 	r, err := a.TxHandler.ProcessTx(state, txBytes)
 	if err != nil {
 		storeTx.Rollback()
-		if r.Info == utils.CallEVM || r.Info == utils.DeployEvm {
-			//panic("not implemented")
-			a.ReceiptHandler.SetFailStatusCurrentReceipt()
-			a.ReceiptHandler.CommitCurrentReceipt()
-		}
+		// TODO: save receipt & hash of failed EVM tx to node-local persistent cache (not app state)
+		a.ReceiptHandler.DiscardCurrentReceipt()
 		return r, err
 	}
 	if !fake {
 		if r.Info == utils.CallEVM || r.Info == utils.DeployEvm {
-			//panic("not implemented")
 			a.EventHandler.EthSubscriptionSet().EmitTxEvent(r.Data, r.Info)
 			a.ReceiptHandler.CommitCurrentReceipt()
 		}

--- a/receipts.go
+++ b/receipts.go
@@ -30,6 +30,7 @@ type ReceiptHandler interface {
 	SetFailStatusCurrentReceipt()
 	CommitBlock(state State, height int64) error
 	CommitCurrentReceipt()
+	DiscardCurrentReceipt()
 	ClearData() error
 	ReadOnlyHandler() ReadReceiptHandler
 	Close() error

--- a/receipts/common/common.go
+++ b/receipts/common/common.go
@@ -7,10 +7,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/plugin/types"
+	loom_types "github.com/loomnetwork/go-loom/types"
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/eth/bloom"
-
-	//"github.com/loomnetwork/loomchain/eth/bloom"
 	"github.com/loomnetwork/loomchain/store"
 	"github.com/pkg/errors"
 )
@@ -50,17 +49,16 @@ func SetBloomFilter(state loomchain.State, filter []byte, height uint64) {
 }
 
 func WriteReceipt(
-	state loomchain.State,
+	block loom_types.BlockHeader,
 	caller, addr loom.Address,
 	events []*loomchain.EventData,
 	status int32,
 	eventHadler loomchain.EventHandler,
 ) (types.EvmTxReceipt, error) {
-	block := state.Block()
 	txReceipt := types.EvmTxReceipt{
-		TransactionIndex:  state.Block().NumTxs,
+		TransactionIndex:  block.NumTxs,
 		BlockHash:         block.GetLastBlockID().Hash,
-		BlockNumber:       state.Block().Height,
+		BlockNumber:       block.Height,
 		CumulativeGasUsed: 0,
 		GasUsed:           0,
 		ContractAddress:   addr.Local,

--- a/receipts/handler/handler.go
+++ b/receipts/handler/handler.go
@@ -147,6 +147,10 @@ func (r *ReceiptHandler) CommitCurrentReceipt() {
 	}
 }
 
+func (r *ReceiptHandler) DiscardCurrentReceipt() {
+	r.currentReceipt = nil
+}
+
 func (r *ReceiptHandler) CommitBlock(state loomchain.State, height int64) error {
 	var err error
 
@@ -171,6 +175,7 @@ func (r *ReceiptHandler) CommitBlock(state loomchain.State, height int64) error 
 	return err
 }
 
+// TODO: this doesn't need the entire state passed in, just the block header
 func (r *ReceiptHandler) CacheReceipt(state loomchain.State, caller, addr loom.Address, events []*loomchain.EventData, txErr error) ([]byte, error) {
 	var status int32
 	if txErr == nil {
@@ -178,7 +183,7 @@ func (r *ReceiptHandler) CacheReceipt(state loomchain.State, caller, addr loom.A
 	} else {
 		status = loomchain.StatusTxFail
 	}
-	receipt, err := common.WriteReceipt(state, caller, addr, events, status, r.eventHandler)
+	receipt, err := common.WriteReceipt(state.Block(), caller, addr, events, status, r.eventHandler)
 	if err != nil {
 		errors.Wrap(err, "receipt not written, returning empty hash")
 		return []byte{}, err


### PR DESCRIPTION
Previously if an EVM tx failed within `Application.CheckTx()` a tx receipt would be retained, and saved to the app store in `Application.EndBlock()`. A tx that errors out in `Application.CheckTx()` will not be transmitted by the node to its peers, therefore the app hash obtained by the node in `Application.Commit()` upon saving the current block will not match the one obtained by its peers. At least in theory, it's unclear whether we've seen this happen in practice, but I'm erring on the side of caution here.

In the case of an EVM tx failing within `Application.DeliverTx()` the tx receipt could be stored in the app state, as all nodes will do the same. However, it doesn't seem like a good idea to modify app state if a tx fails, even if it is technically possible at the moment, so I've removed that code for the time being.

I think a better idea would be store tx receipts for failed txs in a local cache that doesn't have to match across all validators, this cache would store receipts for any EVM tx that failed, be it in `CheckTx`, or `DeliverTx`.