### PR TITLE
Build on any available node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,155 +12,161 @@ def builders = [:]
 def disabled = [:]
 
 builders['linux'] = {
-  node('linux') {
-    def thisBuild = null
+  node('linux-any') {
+    timestamps {
+      def thisBuild = null
 
-    try {
-      stage ('Checkout - Linux') {
-        checkout changelog: true, poll: true, scm:
-        [
-          $class: 'GitSCM',
-          branches: [[name: 'refs/heads/master']],
-          doGenerateSubmoduleConfigurations: false,
-          submoduleCfg: [],
-          userRemoteConfigs:
-          [[
-            credentialsId: 'loom-sdk',
-            url: 'git@github.com:loomnetwork/loomchain.git'
-          ]]
-        ]
-      }
+      try {
+        stage ('Checkout - Linux') {
+          checkout changelog: true, poll: true, scm:
+          [
+            $class: 'GitSCM',
+            branches: [[name: 'refs/heads/master']],
+            doGenerateSubmoduleConfigurations: false,
+            submoduleCfg: [],
+            userRemoteConfigs:
+            [[
+              credentialsId: 'loom-sdk',
+              url: 'git@github.com:loomnetwork/loomchain.git'
+            ]]
+          ]
+        }
 
-      setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "Linux");
+        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "Linux");
 
-      stage ('Build - Linux') {
-        sh '''
-          ./jenkins.sh
-          cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
-          gsutil cp loom gs://private.delegatecall.com/loom/linux/build-$BUILD_NUMBER/loom
-          gsutil cp e2e/validators-tool gs://private.delegatecall.com/loom/linux/build-$BUILD_NUMBER/validators-tool
-          gsutil cp tgoracle gs://private.delegatecall.com/loom/linux/build-$BUILD_NUMBER/tgoracle
-          gsutil cp loom gs://private.delegatecall.com/loom/linux/latest/loom
-          gsutil cp e2e/validators-tool gs://private.delegatecall.com/loom/linux/latest/validators-tool
-          gsutil cp tgoracle gs://private.delegatecall.com/loom/linux/latest/tgoracle
-          gsutil cp install.sh gs://private.delegatecall.com/install.sh
-          docker build --build-arg BUILD_NUMBER=${BUILD_NUMBER} -t loomnetwork/loom:latest .
-          docker tag loomnetwork/loom:latest loomnetwork/loom:${BUILD_NUMBER}
-          docker push loomnetwork/loom:latest
-          docker push loomnetwork/loom:${BUILD_NUMBER}
-        '''
-      }
-    } catch (e) {
-      thisBuild = 'FAILURE'
-      throw e
-    } finally {
-      if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "Linux");
-        slackSend channel: '#blockchain-engineers', color: '#FF0000', message: "${env.JOB_NAME} (LINUX) - #${env.BUILD_NUMBER} Failure after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
-      }
-      else if (currentBuild.currentResult == 'SUCCESS') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "Linux");
-        slackSend channel: '#blockchain-engineers', color: '#006400', message: "${env.JOB_NAME} (LINUX) - #${env.BUILD_NUMBER} Success after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
+        stage ('Build - Linux') {
+          sh '''
+            ./jenkins.sh
+            cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
+            gsutil cp loom gs://private.delegatecall.com/loom/linux/build-$BUILD_NUMBER/loom
+            gsutil cp e2e/validators-tool gs://private.delegatecall.com/loom/linux/build-$BUILD_NUMBER/validators-tool
+            gsutil cp tgoracle gs://private.delegatecall.com/loom/linux/build-$BUILD_NUMBER/tgoracle
+            gsutil cp loom gs://private.delegatecall.com/loom/linux/latest/loom
+            gsutil cp e2e/validators-tool gs://private.delegatecall.com/loom/linux/latest/validators-tool
+            gsutil cp tgoracle gs://private.delegatecall.com/loom/linux/latest/tgoracle
+            gsutil cp install.sh gs://private.delegatecall.com/install.sh
+            docker build --build-arg BUILD_NUMBER=${BUILD_NUMBER} -t loomnetwork/loom:latest .
+            docker tag loomnetwork/loom:latest loomnetwork/loom:${BUILD_NUMBER}
+            docker push loomnetwork/loom:latest
+            docker push loomnetwork/loom:${BUILD_NUMBER}
+          '''
+        }
+      } catch (e) {
+        thisBuild = 'FAILURE'
+        throw e
+      } finally {
+        if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "Linux");
+          slackSend channel: '#blockchain-engineers', color: '#FF0000', message: "${env.JOB_NAME} (LINUX) - #${env.BUILD_NUMBER} Failure after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
+        }
+        else if (currentBuild.currentResult == 'SUCCESS') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "Linux");
+          slackSend channel: '#blockchain-engineers', color: '#006400', message: "${env.JOB_NAME} (LINUX) - #${env.BUILD_NUMBER} Success after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
+        }
       }
     }
   }
 }
 
 disabled['windows'] = {
-  node('windows') {
-    def thisBuild = null
+  node('windows-any') {
+    timestamps {
+      def thisBuild = null
 
-    try {
-      stage ('Checkout - Windows') {
-        checkout changelog: true, poll: true, scm:
-        [
-          $class: 'GitSCM',
-          branches: [[name: 'refs/heads/master']],
-          doGenerateSubmoduleConfigurations: false,
-          submoduleCfg: [],
-          userRemoteConfigs:
-          [[
-            credentialsId: 'loom-sdk',
-            url: 'git@github.com:loomnetwork/loomchain.git'
-          ]]
-        ]
-      }
+      try {
+        stage ('Checkout - Windows') {
+          checkout changelog: true, poll: true, scm:
+          [
+            $class: 'GitSCM',
+            branches: [[name: 'refs/heads/master']],
+            doGenerateSubmoduleConfigurations: false,
+            submoduleCfg: [],
+            userRemoteConfigs:
+            [[
+              credentialsId: 'loom-sdk',
+              url: 'git@github.com:loomnetwork/loomchain.git'
+            ]]
+          ]
+        }
 
-      setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "Windows");
+        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "Windows");
 
-      stage ('Build - Windows') {
-        bat '''
-          jenkins.cmd
-          SET PATH=C:\\Program Files (x86)\\Google\\Cloud SDK\\google-cloud-sdk\\bin;%PATH%;
-          cd \\msys64\\tmp\\gopath-${BUILD_TAG}\\src\\github.com\\loomnetwork\\loomchain
-          gsutil cp loom.exe gs://private.delegatecall.com/loom/windows/build-$BUILD_NUMBER/loom.exe
-          gsutil cp loom.exe gs://private.delegatecall.com/loom/windows/latest/loom.exe
-        '''
-      }
-    } catch (e) {
-      thisBuild = 'FAILURE'
-      throw e
-    } finally {
-      if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "Windows");
-        slackSend channel: '#blockchain-engineers', color: '#FF0000', message: "${env.JOB_NAME} (WINDOWS) - #${env.BUILD_NUMBER} Failure after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
-      }
-      else if (currentBuild.currentResult == 'SUCCESS') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "Windows");
-        slackSend channel: '#blockchain-engineers', color: '#006400', message: "${env.JOB_NAME} (WINDOWS) - #${env.BUILD_NUMBER} Success after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
+        stage ('Build - Windows') {
+          bat '''
+            jenkins.cmd
+            SET PATH=C:\\Program Files (x86)\\Google\\Cloud SDK\\google-cloud-sdk\\bin;%PATH%;
+            cd \\msys64\\tmp\\gopath-${BUILD_TAG}\\src\\github.com\\loomnetwork\\loomchain
+            gsutil cp loom.exe gs://private.delegatecall.com/loom/windows/build-$BUILD_NUMBER/loom.exe
+            gsutil cp loom.exe gs://private.delegatecall.com/loom/windows/latest/loom.exe
+          '''
+        }
+      } catch (e) {
+        thisBuild = 'FAILURE'
+        throw e
+      } finally {
+        if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "Windows");
+          slackSend channel: '#blockchain-engineers', color: '#FF0000', message: "${env.JOB_NAME} (WINDOWS) - #${env.BUILD_NUMBER} Failure after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
+        }
+        else if (currentBuild.currentResult == 'SUCCESS') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "Windows");
+          slackSend channel: '#blockchain-engineers', color: '#006400', message: "${env.JOB_NAME} (WINDOWS) - #${env.BUILD_NUMBER} Success after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
+        }
       }
     }
   }
 }
 
 builders['osx'] = {
-  node('osx') {
-    def thisBuild = null
+  node('osx-any') {
+    timestamps {
+      def thisBuild = null
 
-    try {
-      stage ('Checkout - OSX') {
-        checkout changelog: true, poll: true, scm:
-        [
-          $class: 'GitSCM',
-          branches: [[name: 'refs/heads/master']],
-          doGenerateSubmoduleConfigurations: false,
-          submoduleCfg: [],
-          userRemoteConfigs:
-          [[
-            credentialsId: 'loom-sdk',
-            url: 'git@github.com:loomnetwork/loomchain.git'
-          ]]
-        ]
-      }
+      try {
+        stage ('Checkout - OSX') {
+          checkout changelog: true, poll: true, scm:
+          [
+            $class: 'GitSCM',
+            branches: [[name: 'refs/heads/master']],
+            doGenerateSubmoduleConfigurations: false,
+            submoduleCfg: [],
+            userRemoteConfigs:
+            [[
+              credentialsId: 'loom-sdk',
+              url: 'git@github.com:loomnetwork/loomchain.git'
+            ]]
+          ]
+        }
 
-      setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "OSX");
+        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "OSX");
 
-      stage ('Build - OSX') {
-        sh '''
-          ./jenkins.sh
-          cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
-          gsutil cp loom gs://private.delegatecall.com/loom/osx/build-$BUILD_NUMBER/loom
-          gsutil cp e2e/validators-tool gs://private.delegatecall.com/loom/osx/build-$BUILD_NUMBER/validators-tool
-          gsutil cp tgoracle gs://private.delegatecall.com/loom/osx/build-$BUILD_NUMBER/tgoracle
-          gsutil cp loom gs://private.delegatecall.com/loom/osx/latest/loom
-          gsutil cp e2e/validators-tool gs://private.delegatecall.com/loom/osx/latest/validators-tool
-          gsutil cp tgoracle gs://private.delegatecall.com/loom/osx/latest/tgoracle
-        '''
+        stage ('Build - OSX') {
+          sh '''
+            ./jenkins.sh
+            cd /tmp/gopath-${BUILD_TAG}/src/github.com/loomnetwork/loomchain/
+            gsutil cp loom gs://private.delegatecall.com/loom/osx/build-$BUILD_NUMBER/loom
+            gsutil cp e2e/validators-tool gs://private.delegatecall.com/loom/osx/build-$BUILD_NUMBER/validators-tool
+            gsutil cp tgoracle gs://private.delegatecall.com/loom/osx/build-$BUILD_NUMBER/tgoracle
+            gsutil cp loom gs://private.delegatecall.com/loom/osx/latest/loom
+            gsutil cp e2e/validators-tool gs://private.delegatecall.com/loom/osx/latest/validators-tool
+            gsutil cp tgoracle gs://private.delegatecall.com/loom/osx/latest/tgoracle
+          '''
+        }
+      } catch (e) {
+        thisBuild = 'FAILURE'
+        throw e
+      } finally {
+        if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "OSX");
+          slackSend channel: '#blockchain-engineers', color: '#FF0000', message: "${env.JOB_NAME} (OSX) - #${env.BUILD_NUMBER} Failure after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
+        }
+        else if (currentBuild.currentResult == 'SUCCESS') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "OSX");
+          slackSend channel: '#blockchain-engineers', color: '#006400', message: "${env.JOB_NAME} (OSX) - #${env.BUILD_NUMBER} Success after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
+        }
       }
-    } catch (e) {
-      thisBuild = 'FAILURE'
-      throw e
-    } finally {
-      if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "OSX");
-        slackSend channel: '#blockchain-engineers', color: '#FF0000', message: "${env.JOB_NAME} (OSX) - #${env.BUILD_NUMBER} Failure after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
-      }
-      else if (currentBuild.currentResult == 'SUCCESS') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "OSX");
-        slackSend channel: '#blockchain-engineers', color: '#006400', message: "${env.JOB_NAME} (OSX) - #${env.BUILD_NUMBER} Success after ${currentBuild.durationString.replace(' and counting', '')} (<${env.BUILD_URL}|Open>)"
-      }
+      build job: 'homebrew-client', parameters: [[$class: 'StringParameterValue', name: 'LOOM_BUILD', value: "$BUILD_NUMBER"]]
     }
-    build job: 'homebrew-client', parameters: [[$class: 'StringParameterValue', name: 'LOOM_BUILD', value: "$BUILD_NUMBER"]]
   }
 }
 

--- a/Jenkinsfile-PR.groovy
+++ b/Jenkinsfile-PR.groovy
@@ -12,150 +12,156 @@ def builders = [:]
 def disabled = [:]
 
 builders['linux'] = {
-  node('linux') {
-    def thisBuild = null
+  node('linux-any') {
+    timestamps {
+      def thisBuild = null
 
-    try {
-      stage ('Checkout - Linux') {
-        checkout changelog: true, poll: true, scm:
-        [
-          $class: 'GitSCM',
-          branches: [[name: 'origin/pull/*/head']],
-          doGenerateSubmoduleConfigurations: false,
-          extensions: [
-            [$class: 'PreBuildMerge',
-            options: [
-              fastForwardMode: 'FF',
-              mergeRemote: 'origin',
-              mergeTarget: 'master'
-              ]
-            ]],
-          submoduleCfg: [],
-          userRemoteConfigs:
-          [[
-            credentialsId: 'loom-sdk',
-            url: 'git@github.com:loomnetwork/loomchain.git',
-            refspec: '+refs/pull/*/head:refs/remotes/origin/pull/*/head'
-          ]]
-        ]
-      }
+      try {
+        stage ('Checkout - Linux') {
+          checkout changelog: true, poll: true, scm:
+          [
+            $class: 'GitSCM',
+            branches: [[name: 'origin/pull/*/head']],
+            doGenerateSubmoduleConfigurations: false,
+            extensions: [
+              [$class: 'PreBuildMerge',
+              options: [
+                fastForwardMode: 'FF',
+                mergeRemote: 'origin',
+                mergeTarget: 'master'
+                ]
+              ]],
+            submoduleCfg: [],
+            userRemoteConfigs:
+            [[
+              credentialsId: 'loom-sdk',
+              url: 'git@github.com:loomnetwork/loomchain.git',
+              refspec: '+refs/pull/*/head:refs/remotes/origin/pull/*/head'
+            ]]
+          ]
+        }
 
-      setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "Linux");
+        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "Linux");
 
-      stage ('Build - Linux') {
-        sh '''
-          ./jenkins.sh
-        '''
-      }
-    } catch (e) {
-      thisBuild = 'FAILURE'
-      throw e
-    } finally {
-      if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "Linux");
-      }
-      else if (currentBuild.currentResult == 'SUCCESS') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "Linux");
+        stage ('Build - Linux') {
+          sh '''
+            ./jenkins.sh
+          '''
+        }
+      } catch (e) {
+        thisBuild = 'FAILURE'
+        throw e
+      } finally {
+        if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "Linux");
+        }
+        else if (currentBuild.currentResult == 'SUCCESS') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "Linux");
+        }
       }
     }
   }
 }
 
 disabled['windows'] = {
-  node('windows') {
-    def thisBuild = null
+  node('windows-any') {
+      timestamps {
+      def thisBuild = null
 
-    try {
-      stage ('Checkout - Windows') {
-        checkout changelog: true, poll: true, scm:
-        [
-          $class: 'GitSCM',
-          branches: [[name: 'origin/pull/*/head']],
-          doGenerateSubmoduleConfigurations: false,
-          extensions: [
-            [$class: 'PreBuildMerge',
-            options: [
-              fastForwardMode: 'FF',
-              mergeRemote: 'origin',
-              mergeTarget: 'master'
-              ]
-            ]],
-          submoduleCfg: [],
-          userRemoteConfigs:
-          [[
-            credentialsId: 'loom-sdk',
-            url: 'git@github.com:loomnetwork/loomchain.git',
-            refspec: '+refs/pull/*/head:refs/remotes/origin/pull/*/head'
-          ]]
-        ]
-      }
+      try {
+        stage ('Checkout - Windows') {
+          checkout changelog: true, poll: true, scm:
+          [
+            $class: 'GitSCM',
+            branches: [[name: 'origin/pull/*/head']],
+            doGenerateSubmoduleConfigurations: false,
+            extensions: [
+              [$class: 'PreBuildMerge',
+              options: [
+                fastForwardMode: 'FF',
+                mergeRemote: 'origin',
+                mergeTarget: 'master'
+                ]
+              ]],
+            submoduleCfg: [],
+            userRemoteConfigs:
+            [[
+              credentialsId: 'loom-sdk',
+              url: 'git@github.com:loomnetwork/loomchain.git',
+              refspec: '+refs/pull/*/head:refs/remotes/origin/pull/*/head'
+            ]]
+          ]
+        }
 
-      setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "Windows");
+        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "Windows");
 
-      stage ('Build - Windows') {
-        bat '''
-          jenkins.cmd
-        '''
-      }
-    } catch (e) {
-      thisBuild = 'FAILURE'
-      throw e
-    } finally {
-      if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "Windows");
-      }
-      else if (currentBuild.currentResult == 'SUCCESS') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "Windows");
+        stage ('Build - Windows') {
+          bat '''
+            jenkins.cmd
+          '''
+        }
+      } catch (e) {
+        thisBuild = 'FAILURE'
+        throw e
+      } finally {
+        if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "Windows");
+        }
+        else if (currentBuild.currentResult == 'SUCCESS') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "Windows");
+        }
       }
     }
   }
 }
 
 builders['osx'] = {
-  node('osx') {
-    def thisBuild = null
+  node('osx-any') {
+    timestamps {
+      def thisBuild = null
 
-    try {
-      stage ('Checkout - OSX') {
-        checkout changelog: true, poll: true, scm:
-        [
-          $class: 'GitSCM',
-          branches: [[name: 'origin/pull/*/head']],
-          doGenerateSubmoduleConfigurations: false,
-          extensions: [
-            [$class: 'PreBuildMerge',
-            options: [
-              fastForwardMode: 'FF',
-              mergeRemote: 'origin',
-              mergeTarget: 'master'
-              ]
-            ]],
-          submoduleCfg: [],
-          userRemoteConfigs:
-          [[
-            credentialsId: 'loom-sdk',
-            url: 'git@github.com:loomnetwork/loomchain.git',
-            refspec: '+refs/pull/*/head:refs/remotes/origin/pull/*/head'
-          ]]
-        ]
-      }
+      try {
+        stage ('Checkout - OSX') {
+          checkout changelog: true, poll: true, scm:
+          [
+            $class: 'GitSCM',
+            branches: [[name: 'origin/pull/*/head']],
+            doGenerateSubmoduleConfigurations: false,
+            extensions: [
+              [$class: 'PreBuildMerge',
+              options: [
+                fastForwardMode: 'FF',
+                mergeRemote: 'origin',
+                mergeTarget: 'master'
+                ]
+              ]],
+            submoduleCfg: [],
+            userRemoteConfigs:
+            [[
+              credentialsId: 'loom-sdk',
+              url: 'git@github.com:loomnetwork/loomchain.git',
+              refspec: '+refs/pull/*/head:refs/remotes/origin/pull/*/head'
+            ]]
+          ]
+        }
 
-      setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "OSX");
+        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} is in progress", "PENDING", "OSX");
 
-      stage ('Build - OSX') {
-        sh '''
-          ./jenkins.sh
-        '''
-      }
-    } catch (e) {
-      thisBuild = 'FAILURE'
-      throw e
-    } finally {
-      if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "OSX");
-      }
-      else if (currentBuild.currentResult == 'SUCCESS') {
-        setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "OSX");
+        stage ('Build - OSX') {
+          sh '''
+            ./jenkins.sh
+          '''
+        }
+      } catch (e) {
+        thisBuild = 'FAILURE'
+        throw e
+      } finally {
+        if (currentBuild.currentResult == 'FAILURE' || thisBuild == 'FAILURE') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} failed", "FAILURE", "OSX");
+        }
+        else if (currentBuild.currentResult == 'SUCCESS') {
+          setBuildStatus("Build ${env.BUILD_DISPLAY_NAME} succeeded in ${currentBuild.durationString.replace(' and counting', '')}", "SUCCESS", "OSX");
+        }
       }
     }
   }


### PR DESCRIPTION
Related to https://github.com/loomnetwork/ops/issues/371

Changes:

1. Add timestamps
1. Allow to build on any available nodes (`linux-any`, `osx-any`, `windows-any`). Only Linux has multiple slaves right now, the others are provided for future consideration, so that we don't have to edit this file again.

Linux builds will build on either master, slave on AWS, or slave on GCP - reducing wait time for the build.

However the other platforms will cause the main build to be waiting as it waits for completion.