### PR TITLE
Lock hashicorp go-plugin version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR)
 	# use a modified stateObject for EVM calls
 	cd $(GO_ETHEREUM_DIR) && git checkout bab696378c359c56640fae48dfd3132763dbc64b
 	# use go-plugin we get 'timeout waiting for connection info' error
-	cd $(HASHICORP_DIR) && git checkout ff43c1c7ba0a8b5638e7c2b9dd7a53b14b3e0101
+	cd $(HASHICORP_DIR) && git checkout f4c3476bd38585f9ec669d10ed1686abd52b9961
 	# fetch vendored packages
 	dep ensure -vendor-only
 


### PR DESCRIPTION
Lock harshicorp go-plugin to `f4c3476bd38585f9ec669d10ed1686abd52b9961` before the chain starts getting `timeout waiting for connection info` error when running a cluster