### PR TITLE
Fix yubikey load commands

### DIFF
--- a/gateway/oracle.go
+++ b/gateway/oracle.go
@@ -947,9 +947,9 @@ func LoadMainnetPrivateKey(hsmEnabled bool, path string) (lcrypto.PrivateKey, er
 	var err error
 
 	if hsmEnabled {
-		privKey, err = lcrypto.LoadSecp256k1PrivKey(path)
+		privKey, err = lcrypto.LoadYubiHsmPrivKey(path)
 	} else {
-		privKey, err = lcrypto.LoadYubiHsmPrivKey(lcrypto.YubiHsmPrivKeyTypeSecp256k1, path)
+		privKey, err = lcrypto.LoadSecp256k1PrivKey(path)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Fix changes matching https://github.com/loomnetwork/go-loom/pull/224, also fix order of commands (previously if hsm enabled loaded non-hsm key)