### PR TITLE
Vendor bigcache package && unvendor levigo package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,16 @@
   version = "v0.3.1"
 
 [[projects]]
+  digest = "1:f96ba6ecca7ba87b1dddd70ae38cfc4ce5ea844f58d1f728e121d2e29cdfb8a2"
+  name = "github.com/allegro/bigcache"
+  packages = [
+    ".",
+    "queue",
+  ]
+  pruneopts = "UT"
+  revision = "84a0ff3f153cbd7e280a19029a864bb04b504e62"
+
+[[projects]]
   branch = "master"
   digest = "1:093bf93a65962e8191e3e8cd8fc6c363f83d43caca9739c906531ba7210a9904"
   name = "github.com/btcsuite/btcd"
@@ -105,14 +115,6 @@
   pruneopts = "UT"
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:39b27d1381a30421f9813967a5866fba35dc1d4df43a6eefe3b7a5444cb07214"
-  name = "github.com/jmhodges/levigo"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "c42d9e0ca023e2198120196f842701bb4c55d7b9"
 
 [[projects]]
   branch = "master"
@@ -410,6 +412,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/BurntSushi/toml",
+    "github.com/allegro/bigcache",
     "github.com/gomodule/redigo/redis",
     "github.com/loomnetwork/mamamerkle",
     "github.com/miguelmota/go-solidity-sha3",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@ ignored = [
   "github.com/prometheus/client_golang/prometheus*",
   "github.com/loomnetwork/yubihsm-go*",
   "github.com/certusone/yubihsm-go*",
-  "github.com/allegro/bigcache*"
+  "github.com/jmhodges/levigo*" # can only build it with the right c packages
 ]
 
 [[constraint]]
@@ -84,6 +84,10 @@ ignored = [
 [[override]]
   name = "github.com/tendermint/go-amino"
   version = "=0.14.0"
+
+[[constraint]]
+  name = "github.com/allegro/bigcache"
+  revision = "84a0ff3f153cbd7e280a19029a864bb04b504e62"
 
 [prune]
   go-tests = true

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOLANG_PROTOBUF_DIR = $(GOPATH)/src/github.com/golang/protobuf
 GOGO_PROTOBUF_DIR = $(GOPATH)/src/github.com/gogo/protobuf
 GO_ETHEREUM_DIR = $(GOPATH)/src/github.com/ethereum/go-ethereum
 HASHICORP_DIR = $(GOPATH)/src/github.com/hashicorp/go-plugin
+LEVIGO_DIR = $(GOPATH)/src/github.com/jmhodges/levigo
 
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
@@ -16,6 +17,7 @@ GO_LOOM_GIT_REV = HEAD
 ETHEREUM_GIT_REV = c4f3537b02811a7487655c02e6685195dff46b0a
 # use go-plugin we get 'timeout waiting for connection info' error
 HASHICORP_GIT_REV = f4c3476bd38585f9ec669d10ed1686abd52b9961
+LEVIGO_GIT_REV = c42d9e0ca023e2198120196f842701bb4c55d7b9
 
 GIT_SHA = `git rev-parse --verify HEAD`
 GO_LOOM_GIT_SHA = `cd ${PLUGIN_DIR} && git rev-parse --verify ${GO_LOOM_GIT_REV}`
@@ -64,15 +66,13 @@ dposv2_oracle:
 loom: proto
 	go build $(GOFLAGS) $(PKG)/cmd/$@
 
-loom-cleveldb: proto
-	go get github.com/jmhodges/levigo
+loom-cleveldb: proto c-leveldb
 	go build $(GOFLAGS_CLEVELDB) -o $@ $(PKG)/cmd/loom
 
 plasmachain: proto
 	go build $(GOFLAGS_PLASMACHAIN) -o $@ $(PKG)/cmd/loom
 
-plasmachain-cleveldb: proto
-	go get github.com/jmhodges/levigo
+plasmachain-cleveldb: proto c-leveldb
 	go build $(GOFLAGS_PLASMACHAIN_CLEVELDB) -o $@ $(PKG)/cmd/loom
 
 loom-race: proto
@@ -89,6 +89,10 @@ protoc-gen-gogo:
 	$(PROTOC) --gogo_out=$(GOPATH)/src $(PKG)/$<
 
 proto: registry/registry.pb.go
+
+c-leveldb:
+	go get github.com/jmhodges/levigo
+	cd $(LEVIGO_DIR) && git checkout master && git pull && git checkout $(LEVIGO_GIT_REV)
 
 $(PLUGIN_DIR):
 	git clone -q git@github.com:loomnetwork/go-loom.git $@
@@ -118,7 +122,6 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR)
 		github.com/miguelmota/go-solidity-sha3 \
 		golang.org/x/sys/cpu \
 		github.com/loomnetwork/yubihsm-go \
-		github.com/allegro/bigcache \
 		github.com/gorilla/websocket \
 		github.com/phonkee/go-pubsub
 	# for when you want to reference a different branch of go-loom


### PR DESCRIPTION
levigo only needs to be installed for c-leveldb builds, so I've locked
it down in the makefile and removed it from the Gopkg.lock.