### PR TITLE
adding e2e `excludes` condition & abstracting e2e code

### DIFF
--- a/e2e/dpos-4-validators.toml
+++ b/e2e/dpos-4-validators.toml
@@ -35,22 +35,34 @@
   Expected = ["{{index $.NodePubKeyList 0}}", "{{index $.NodePubKeyList 1}}", "{{index $.NodePubKeyList 2}}"]
 
 [[TestCases]]
+  RunCmd = "example-cli call approve dposV2 100000000000000000000000 -k {{index $.NodePrivKeyPathList 0}}"
+  Condition = "contains"
+  Expected = ["Error"]
+
+[[TestCases]]
   RunCmd = "example-cli call approve dposV2 21 -k {{index $.NodePrivKeyPathList 0}}"
-  Condition = ""
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call approve dposV2 21 -k {{index $.NodePrivKeyPathList 1}}"
-  Condition = ""
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call approve dposV2 21 -k {{index $.NodePrivKeyPathList 2}}"
-  Condition = ""
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call delegateV2 {{index $.NodeAddressList 0}} 10 -k {{index $.NodePrivKeyPathList 0}}"
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call delegateV2 {{index $.NodeAddressList 0}} 10 -k {{index $.NodePrivKeyPathList 0}}"
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call delegateV2 {{index $.NodeAddressList 1}} 20 -k {{index $.NodePrivKeyPathList 1}}"

--- a/e2e/dpos-delegation.toml
+++ b/e2e/dpos-delegation.toml
@@ -5,7 +5,8 @@
 
 [[TestCases]]
   RunCmd = "example-cli call list_validatorsV2"
-  Condition = ""
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call approve dposV2 1250000 -k {{index $.NodePrivKeyPathList 1}}"
@@ -18,7 +19,8 @@
 
 [[TestCases]]
   RunCmd = "example-cli call approve dposV2 1250000 -k {{index $.NodePrivKeyPathList 2}}"
-  Condition = ""
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call register_candidateV2 {{index $.NodePubKeyList 2}} 100 --name numero_dos -k {{index $.NodePrivKeyPathList 2}}"
@@ -30,19 +32,23 @@
 
 [[TestCases]]
   RunCmd = "example-cli call approve dposV2 10 -k {{index $.NodePrivKeyPathList 1}}"
-  Condition = ""
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call approve dposV2 20 -k {{index $.NodePrivKeyPathList 2}}"
-  Condition = ""
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call delegateV2 {{index $.NodeAddressList 1}} 20 -k {{index $.NodePrivKeyPathList 2}}"
-  Condition = ""
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call approve dposV2 1250000 -k {{index $.NodePrivKeyPathList 3}}"
-  Condition = ""
+  Condition = "excludes"
+  Excluded = ["Error"]
 
 [[TestCases]]
   RunCmd = "example-cli call approve dposV2 200000 -k {{index $.AccountPrivKeyPathList 0}}"

--- a/e2e/lib/test.go
+++ b/e2e/lib/test.go
@@ -18,6 +18,7 @@ type TestCase struct {
 	RunCmd     string     `toml:"RunCmd"`
 	Condition  string     `toml:"Condition"`
 	Expected   []string   `toml:"Expected"`
+	Excluded   []string   `toml:"Excluded"`
 	Iterations int        `toml:"Iterations"`
 	Delay      int64      `toml:"Delay"` // in millisecond
 	All        bool       `toml:"All"`


### PR DESCRIPTION
fixes #658

- adding e2e `excludes` condition & abstracting e2e code
- demonstrating use of `excludes` in certain e2e tests