### PR TITLE
dposv2 testing & cleanup

### DIFF
--- a/builtin/plugins/dposv2/dpos.go
+++ b/builtin/plugins/dposv2/dpos.go
@@ -1131,6 +1131,7 @@ func distributeDelegatorRewards(ctx contract.Context, state State, formerValidat
 			}
 		} else if delegation.State == REDELEGATING {
 			delegation.Validator = delegation.UpdateValidator
+			validatorKey = loom.UnmarshalAddressPB(delegation.Validator).String()
 		}
 
 		// After a delegation update, zero out UpdateAmount

--- a/builtin/plugins/dposv2/dpos_test.go
+++ b/builtin/plugins/dposv2/dpos_test.go
@@ -708,16 +708,7 @@ func TestRedelegate(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	// Two election periods pass before redelegation takes effect
-	err = Elect(contractpb.WrapPluginContext(dposCtx))
-	require.Nil(t, err)
-
-	// Verifying that addr1 is still validator in between 1st and 2nd elections
-	listValidatorsResponse, err = dposContract.ListValidators(contractpb.WrapPluginContext(dposCtx), &ListValidatorsRequest{})
-	require.Nil(t, err)
-	assert.Equal(t, len(listValidatorsResponse.Statistics), 1)
-	assert.True(t, listValidatorsResponse.Statistics[0].Address.Local.Compare(addr1.Local) == 0)
-
+	// Redelegation takes effect within a single election period
 	err = Elect(contractpb.WrapPluginContext(dposCtx))
 	require.Nil(t, err)
 
@@ -735,10 +726,7 @@ func TestRedelegate(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	// Two election periods pass before redelegation takes effect
-	err = Elect(contractpb.WrapPluginContext(dposCtx))
-	require.Nil(t, err)
-
+	// Redelegation takes effect within a single election period
 	err = Elect(contractpb.WrapPluginContext(dposCtx))
 	require.Nil(t, err)
 

--- a/builtin/plugins/dposv2/overview.md
+++ b/builtin/plugins/dposv2/overview.md
@@ -64,6 +64,10 @@ the tokens have not yet been released. The tokens continue to earn rewards for
 the delegator and are liable to be slashed until the next valdiator election
 when they are automatically transfered to an address which the delegator specifies.
 
+`REDELEGATING`: A redelegation request has been made within the last election
+period. During the next election, the `delegation.Validator` value will be set
+to the `delegation.UpdateValidator`.
+
 ## Election
 
 Loom's dPoS implementation relies on a dynamic set of Validators which


### PR DESCRIPTION
- added negative redelegation test
- removed redundant checks in `Redelegate`
- checking all save errors
- fixing redelegation behavior