### PR TITLE
(dposv3) ValidatorStatistics Storage Refactor

### DIFF
--- a/builtin/plugins/dposv3/storage.go
+++ b/builtin/plugins/dposv3/storage.go
@@ -36,11 +36,6 @@ func sortDelegations(delegations []*Delegation) []*Delegation {
 	return delegations
 }
 
-func sortStatistics(statistics ValidatorStatisticList) ValidatorStatisticList {
-	sort.Sort(byValidatorAddress(statistics))
-	return statistics
-}
-
 type byPubkey []*Validator
 
 func (s byPubkey) Len() int {
@@ -123,40 +118,6 @@ func SetStatistic(ctx contract.Context, statistic *ValidatorStatistic) error {
 	}
 
 	return ctx.Set(append(statisticsKey, addressBytes...), statistic)
-}
-
-func saveValidatorStatisticList(ctx contract.Context, sl ValidatorStatisticList) error {
-	sorted := sortStatistics(sl)
-	return ctx.Set(statisticsKey, &dtypes.ValidatorStatisticListV2{Statistics: sorted})
-}
-
-func loadValidatorStatisticList(ctx contract.StaticContext) (ValidatorStatisticList, error) {
-	var pbcl dtypes.ValidatorStatisticListV2
-	err := ctx.Get(statisticsKey, &pbcl)
-	if err == contract.ErrNotFound {
-		return ValidatorStatisticList{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return pbcl.Statistics, nil
-}
-
-type byValidatorAddress ValidatorStatisticList
-
-func (s byValidatorAddress) Len() int {
-	return len(s)
-}
-
-func (s byValidatorAddress) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s byValidatorAddress) Less(i, j int) bool {
-	vaddr1 := loom.UnmarshalAddressPB(s[i].Address)
-	vaddr2 := loom.UnmarshalAddressPB(s[j].Address)
-	diff := vaddr1.Local.Compare(vaddr2.Local)
-	return diff < 0
 }
 
 func GetDistribution(ctx contract.StaticContext, delegator types.Address) (*Distribution, error) {

--- a/builtin/plugins/dposv3/storage_test.go
+++ b/builtin/plugins/dposv3/storage_test.go
@@ -319,3 +319,55 @@ func TestGetSetDistributions(t *testing.T) {
 	assert.Equal(t, 0, d.Address.Local.Compare(address1.Local))
 	assert.Equal(t, 0, d.Amount.Value.Cmp(loom.NewBigUIntFromInt(5)))
 }
+
+func TestGetSetStatistics(t *testing.T) {
+	address1 := delegatorAddress1
+	address2 := delegatorAddress2
+
+	pctx := plugin.CreateFakeContext(address1, address1)
+	ctx := contractpb.WrapPluginContext(pctx)
+
+	statistic := ValidatorStatistic{
+		Address: address1.MarshalPB(),
+		WhitelistAmount: &types.BigUInt{Value: *loom.NewBigUIntFromInt(1)},
+	}
+
+	err := SetStatistic(ctx, &statistic)
+	assert.Nil(t, err)
+
+	s, err := GetStatistic(ctx, address1)
+	assert.NotNil(t, s)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 0, s.Address.Local.Compare(address1.Local))
+	assert.Equal(t, 0, s.WhitelistAmount.Value.Cmp(loom.NewBigUIntFromInt(1)))
+
+	statistic2 := ValidatorStatistic{
+		Address: address2.MarshalPB(),
+		WhitelistAmount: &types.BigUInt{Value: *loom.NewBigUIntFromInt(10)},
+	}
+
+	// Creating new distribution for address2
+	err = SetStatistic(ctx, &statistic2)
+	assert.Nil(t, err)
+
+	// Updating address1's distribution
+	statistic.WhitelistAmount = &types.BigUInt{Value: *loom.NewBigUIntFromInt(5)}
+	err = SetStatistic(ctx, &statistic)
+	assert.Nil(t, err)
+
+	s, err = GetStatistic(ctx, address2)
+	assert.NotNil(t, s)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 0, s.Address.Local.Compare(address2.Local))
+	assert.Equal(t, 0, s.WhitelistAmount.Value.Cmp(loom.NewBigUIntFromInt(10)))
+
+	// Checking that address1's distribution was properly updated
+	s, err = GetStatistic(ctx, address1)
+	assert.NotNil(t, s)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 0, s.Address.Local.Compare(address1.Local))
+	assert.Equal(t, 0, s.WhitelistAmount.Value.Cmp(loom.NewBigUIntFromInt(5)))
+}


### PR DESCRIPTION
- removing array-based statistics storage
- adding storage unit tests
- improving `UnregisterCandidate` function to handle 0-value delegations