### PR TITLE
Fix bug where fee was being reset to 0 after registering

### DIFF
--- a/builtin/plugins/dposv2/dpos.go
+++ b/builtin/plugins/dposv2/dpos.go
@@ -1052,7 +1052,7 @@ func slash(ctx contract.Context, validatorAddr []byte, slashPercentage loom.BigU
 
 	// If slashing percentage is less than current total slash percentage, do
 	// not further increase total slash percentage during this election period
-	if (slashPercentage.Cmp(&stat.SlashPercentage.Value) < 0) {
+	if slashPercentage.Cmp(&stat.SlashPercentage.Value) < 0 {
 		return nil
 	}
 

--- a/builtin/plugins/dposv2/dpos_test.go
+++ b/builtin/plugins/dposv2/dpos_test.go
@@ -315,7 +315,7 @@ func TestLockTimes(t *testing.T) {
 	d2LockTime := delegation2Response.Delegation.LockTime
 	d2LockTimeTier := delegation2Response.Delegation.LocktimeTier
 	// New locktime should be the `now` value extended by the previous locktime
-	assert.Equal(t, d2LockTime, now + d1LockTime)
+	assert.Equal(t, d2LockTime, now+d1LockTime)
 	assert.Equal(t, true, d2LockTimeTier == 2)
 
 	// Elections must happen so that we delegate again
@@ -340,7 +340,7 @@ func TestLockTimes(t *testing.T) {
 	d3LockTimeTier := delegation3Response.Delegation.LocktimeTier
 
 	// New locktime should be the `now` value extended by the new locktime
-	assert.Equal(t, d3LockTime, now + d3LockTime)
+	assert.Equal(t, d3LockTime, now+d3LockTime)
 	assert.Equal(t, true, d3LockTimeTier == 3)
 
 	err = Elect(contractpb.WrapPluginContext(dposCtx))

--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -829,7 +829,7 @@ func Elect(ctx contract.Context) error {
 	totalValidatorDelegations := common.BigZero()
 	for _, res := range delegationResults[:validatorCount] {
 		candidate := candidates.Get(res.ValidatorAddress)
-		if candidate != nil  && common.IsPositive(res.DelegationTotal) {
+		if candidate != nil && common.IsPositive(res.DelegationTotal) {
 			// checking that DelegationTotal is positive ensures ensures that if
 			// by accident a negative delegation total is calculated, the chain
 			// does not halt due to the error. 0-value delegations are best to
@@ -964,7 +964,7 @@ func slash(ctx contract.Context, validatorAddr []byte, slashPercentage loom.BigU
 
 	// If slashing percentage is less than current total slash percentage, do
 	// not further increase total slash percentage during this election period
-	if (slashPercentage.Cmp(&statistic.SlashPercentage.Value) < 0) {
+	if slashPercentage.Cmp(&statistic.SlashPercentage.Value) < 0 {
 		return nil
 	}
 

--- a/builtin/plugins/dposv3/dpos_test.go
+++ b/builtin/plugins/dposv3/dpos_test.go
@@ -192,7 +192,7 @@ func TestChangeFee(t *testing.T) {
 	err = Elect(contractpb.WrapPluginContext(pctx.WithSender(addr)))
 	require.Nil(t, err)
 
-    // Fee should not reset
+	// Fee should not reset
 	listResponse, err = dposContract.ListCandidates(contractpb.WrapPluginContext(pctx.WithSender(addr)), &ListCandidateRequest{})
 	require.Nil(t, err)
 	assert.Equal(t, oldFee, listResponse.Candidates[0].Fee)
@@ -280,7 +280,7 @@ func TestLockTimes(t *testing.T) {
 	})
 	selfDelegationLockTime := checkSelfDelegation.Delegation.LockTime
 
-	assert.Equal(t, now + TierLocktimeMap[1], selfDelegationLockTime)
+	assert.Equal(t, now+TierLocktimeMap[1], selfDelegationLockTime)
 	assert.Equal(t, true, checkSelfDelegation.Delegation.LocktimeTier == 1)
 
 	// make a delegation to candidate registered above
@@ -329,7 +329,7 @@ func TestLockTimes(t *testing.T) {
 	require.Nil(t, err)
 	d2LockTime := delegation2Response.Delegation.LockTime
 	// New locktime should be the `now` value extended by the previous locktime
-	assert.Equal(t, d2LockTime, now + d1LockTime)
+	assert.Equal(t, d2LockTime, now+d1LockTime)
 
 	// Elections must happen so that we delegate again
 	err = Elect(contractpb.WrapPluginContext(dposCtx))
@@ -352,7 +352,7 @@ func TestLockTimes(t *testing.T) {
 	d3LockTime := delegation3Response.Delegation.LockTime
 
 	// New locktime should be the `now` value extended by the new locktime
-	assert.Equal(t, d3LockTime, now + d3LockTime)
+	assert.Equal(t, d3LockTime, now+d3LockTime)
 
 	err = Elect(contractpb.WrapPluginContext(dposCtx))
 	require.Nil(t, err)
@@ -365,7 +365,7 @@ func TestLockTimes(t *testing.T) {
 	require.NotNil(t, err)
 
 	// advancing contract time beyond the delegator1-addr1 lock period
-	dposCtx.SetTime(dposCtx.Now().Add(time.Duration(now + d3LockTime + 1) * time.Second))
+	dposCtx.SetTime(dposCtx.Now().Add(time.Duration(now+d3LockTime+1) * time.Second))
 
 	// Checking that delegator1 can unbond after lock period elapses
 	err = dposContract.Unbond(contractpb.WrapPluginContext(dposCtx.WithSender(delegatorAddress1)), &UnbondRequest{

--- a/builtin/plugins/dposv3/storage_test.go
+++ b/builtin/plugins/dposv3/storage_test.go
@@ -277,7 +277,7 @@ func TestGetSetDistributions(t *testing.T) {
 
 	distribution := Distribution{
 		Address: address1.MarshalPB(),
-		Amount: &types.BigUInt{Value: *loom.NewBigUIntFromInt(1)},
+		Amount:  &types.BigUInt{Value: *loom.NewBigUIntFromInt(1)},
 	}
 
 	err := SetDistribution(ctx, &distribution)
@@ -292,7 +292,7 @@ func TestGetSetDistributions(t *testing.T) {
 
 	distribution2 := Distribution{
 		Address: address2.MarshalPB(),
-		Amount: &types.BigUInt{Value: *loom.NewBigUIntFromInt(10)},
+		Amount:  &types.BigUInt{Value: *loom.NewBigUIntFromInt(10)},
 	}
 
 	// Creating new distribution for address2
@@ -328,7 +328,7 @@ func TestGetSetStatistics(t *testing.T) {
 	ctx := contractpb.WrapPluginContext(pctx)
 
 	statistic := ValidatorStatistic{
-		Address: address1.MarshalPB(),
+		Address:         address1.MarshalPB(),
 		WhitelistAmount: &types.BigUInt{Value: *loom.NewBigUIntFromInt(1)},
 	}
 
@@ -343,7 +343,7 @@ func TestGetSetStatistics(t *testing.T) {
 	assert.Equal(t, 0, s.WhitelistAmount.Value.Cmp(loom.NewBigUIntFromInt(1)))
 
 	statistic2 := ValidatorStatistic{
-		Address: address2.MarshalPB(),
+		Address:         address2.MarshalPB(),
 		WhitelistAmount: &types.BigUInt{Value: *loom.NewBigUIntFromInt(10)},
 	}
 


### PR DESCRIPTION
This was not a security issue, as Validators who got their fee reset to 0 could call ChangeFee, after which their value wouldn't get reset