### PR TITLE
Add CachingStoreConfig.DebugForceEnable setting to loom.yml

### DIFF
--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -560,12 +560,15 @@ func loadAppStore(cfg *config.Config, logger *loom.Logger, targetVersion int64) 
 		}
 	}
 
-	// NOTE: Can't wrap the MultiReaderIAVLStore in a CachingStore yet.
-	if cfg.CachingStoreConfig.CachingEnabled && cfg.AppStore.Version == 1 {
+	// NOTE: Shouldn't wrap the MultiReaderIAVLStore in a CachingStore yet, otherwise the
+	//       MultiReaderIAVLStore loses its advantages.
+	if cfg.CachingStoreConfig.CachingEnabled &&
+		((cfg.AppStore.Version == 1) || cfg.CachingStoreConfig.DebugForceEnable) {
 		appStore, err = store.NewCachingStore(appStore, cfg.CachingStoreConfig)
 		if err != nil {
 			return nil, err
 		}
+		logger.Info("CachingStore enabled")
 	}
 
 	return appStore, nil

--- a/store/cachingstore.go
+++ b/store/cachingstore.go
@@ -37,6 +37,10 @@ func (c CachingStoreLogger) Printf(format string, v ...interface{}) {
 
 type CachingStoreConfig struct {
 	CachingEnabled bool
+	// CachingEnabled may be ignored in some configurations, this will force enable the caching
+	// store in those cases.
+	// WARNING: This should only used for debugging.
+	DebugForceEnable bool
 	// Number of cache shards, value must be a power of two
 	Shards int
 	// Time after we need to evict the key

--- a/store/multi_reader_iavl_store.go
+++ b/store/multi_reader_iavl_store.go
@@ -20,7 +20,7 @@ import (
 // - Only the values from the leaf nodes of the latest saved IAVL tree are stored in valueDB,
 //   which means MultiReaderIAVLStore can only load the latest IAVL tree. Rollback to an earlier
 //   version is currently impossible.
-// - Set/Delete/SaveVersion must be called from a single thread, i.e. that can only be one writer.
+// - Set/Delete/SaveVersion must be called from a single thread, i.e. there can only be one writer.
 type MultiReaderIAVLStore struct {
 	IAVLStore
 	valueDB    db.DBWrapper


### PR DESCRIPTION
This can be used to force enable usage of the `CachingStore` with the
`MultiReaderIAVLStore`, in doing so the `MultiReaderIAVLStore` loses its
ability to use real snapshots so all queries will either hit the
cache or the IAVL tree.