### PR TITLE
Add withdrawer blacklist to TG Oracle

### DIFF
--- a/gateway/config.go
+++ b/gateway/config.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"fmt"
 
+	loom "github.com/loomnetwork/go-loom"
 	"github.com/pkg/errors"
 )
 
@@ -54,6 +55,8 @@ type TransferGatewayConfig struct {
 	OracleReconnectInterval int32
 	// Address on from which the out-of-process Oracle should expose the status & metrics endpoints.
 	OracleQueryAddress string
+	// List of DAppChain addresses that aren't allowed to withdraw to the Mainnet Gateway
+	WithdrawerAddressBlacklist []string
 }
 
 func DefaultConfig(rpcProxyPort int32) *TransferGatewayConfig {
@@ -121,4 +124,16 @@ func (c *TransferGatewayConfig) Validate() error {
 		return errors.New("NumMainnetBlockConfirmations can't be negative")
 	}
 	return nil
+}
+
+func (c *TransferGatewayConfig) GetWithdrawerAddressBlacklist() ([]loom.Address, error) {
+	var addrList []loom.Address
+	for _, addrStr := range c.WithdrawerAddressBlacklist {
+		addr, err := loom.ParseAddress(addrStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse address in WithdrawerAddressBlacklist")
+		}
+		addrList = append(addrList, addr)
+	}
+	return addrList, nil
 }

--- a/gateway/oracle_test.go
+++ b/gateway/oracle_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	loom "github.com/loomnetwork/go-loom"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,4 +52,19 @@ func TestTransferGatewayOracleMainnetEventSort(t *testing.T) {
 	}
 	sortMainnetEvents(events)
 	require.EqualValues(t, sortedEvents, events, "wrong sort order")
+}
+
+func TestTransferGatewayOracleConfigWithdrawerAddressBlacklist(t *testing.T) {
+	cfg := DefaultConfig(8888)
+	addr1 := loom.MustParseAddress("chain:0xb16a379ec18d4093666f8f38b11a3071c920207d")
+	addr2 := loom.MustParseAddress("chain:0x5cecd1f7261e1f4c684e297be3edf03b825e01c5")
+	cfg.WithdrawerAddressBlacklist = []string{
+		addr1.String(),
+		addr2.String(),
+	}
+	blacklist, err := cfg.GetWithdrawerAddressBlacklist()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(blacklist))
+	require.Equal(t, 0, addr1.Compare(blacklist[0]))
+	require.Equal(t, 0, addr2.Compare(blacklist[1]))
 }


### PR DESCRIPTION
The blacklist can be specified using the WithdrawerAddressBlacklist
setting in the Oracle config, which should contain a list of DAppChain
addresses the TG Oracle shouldn't sign withdrawals for.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request