### PR TITLE
Add `gateway unclaimed-tokens` cmd & extend `gateway account` cmd

### DIFF
--- a/cmd/loom/gateway/gateway_cmd.go
+++ b/cmd/loom/gateway/gateway_cmd.go
@@ -12,6 +12,7 @@ func NewGatewayCommand() *cobra.Command {
 		newMapContractsCommand(),
 		newMapAccountsCommand(),
 		newQueryAccountCommand(),
+		newQueryUnclaimedTokensCommand(),
 		newReplaceOwnerCommand(),
 		newGetStateCommand(),
 		newAddOracleCommand(),

--- a/cmd/loom/gateway/general_cmds.go
+++ b/cmd/loom/gateway/general_cmds.go
@@ -65,7 +65,7 @@ func newReplaceOwnerCommand() *cobra.Command {
 			} else if strings.Compare(args[1], LoomGatewayName) == 0 {
 				name = LoomGatewayName
 			} else {
-				errors.New("Invalid gateway name")
+				return errors.New("Invalid gateway name")
 			}
 
 			rpcClient := getDAppChainClient()
@@ -113,7 +113,7 @@ func newRemoveOracleCommand() *cobra.Command {
 			} else if strings.Compare(args[1], LoomGatewayName) == 0 {
 				name = LoomGatewayName
 			} else {
-				errors.New("Invalid gateway name")
+				return errors.New("Invalid gateway name")
 			}
 
 			rpcClient := getDAppChainClient()
@@ -161,7 +161,7 @@ func newAddOracleCommand() *cobra.Command {
 			} else if strings.Compare(args[1], LoomGatewayName) == 0 {
 				name = LoomGatewayName
 			} else {
-				errors.New("Invalid gateway name")
+				return errors.New("Invalid gateway name")
 			}
 
 			rpcClient := getDAppChainClient()
@@ -199,7 +199,7 @@ func newGetStateCommand() *cobra.Command {
 			} else if strings.Compare(args[0], LoomGatewayName) == 0 {
 				name = LoomGatewayName
 			} else {
-				errors.New("Invalid gateway name")
+				return errors.New("Invalid gateway name")
 			}
 
 			rpcClient := getDAppChainClient()
@@ -236,7 +236,7 @@ func newGetOraclesCommand() *cobra.Command {
 			} else if strings.Compare(args[0], LoomGatewayName) == 0 {
 				name = LoomGatewayName
 			} else {
-				errors.New("Invalid gateway name")
+				return errors.New("Invalid gateway name")
 			}
 
 			rpcClient := getDAppChainClient()

--- a/cmd/loom/gateway/query_cmds.go
+++ b/cmd/loom/gateway/query_cmds.go
@@ -5,11 +5,13 @@ package gateway
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/loomnetwork/go-loom"
-
+	ctypes "github.com/loomnetwork/go-loom/builtin/types/coin"
+	tgtypes "github.com/loomnetwork/go-loom/builtin/types/transfer_gateway"
 	"github.com/loomnetwork/go-loom/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -18,6 +20,8 @@ import (
 type accountInfo struct {
 	DAppChainAddress string
 	EthereumAddress  string
+	LOOM             string
+	ETH              string
 }
 
 const queryAccountCmdExample = `
@@ -60,14 +64,63 @@ func newQueryAccountCommand() *cobra.Command {
 			if err != nil {
 				fmt.Printf("No account information found for %v", addr)
 			}
-			info := &accountInfo{}
+
+			var localAddr, foreignAddr loom.Address
 			if addr.ChainID == "eth" {
-				info.DAppChainAddress = mappedAccount.String()
-				info.EthereumAddress = common.BytesToAddress(addr.Local).Hex()
+				localAddr = mappedAccount
+				foreignAddr = addr
 			} else {
-				info.DAppChainAddress = addr.String()
-				info.EthereumAddress = common.BytesToAddress(mappedAccount.Local).Hex()
+				localAddr = addr
+				foreignAddr = mappedAccount
 			}
+
+			info := &accountInfo{
+				DAppChainAddress: localAddr.Local.String(),
+				EthereumAddress:  common.BytesToAddress(foreignAddr.Local).Hex(),
+			}
+
+			coinAddr, err := rpcClient.Resolve("coin")
+			if err == nil {
+				coinContract := client.NewContract(rpcClient, coinAddr.Local)
+				req := &ctypes.BalanceOfRequest{
+					Owner: localAddr.MarshalPB(),
+				}
+				var resp ctypes.BalanceOfResponse
+				_, err = coinContract.StaticCall("BalanceOf", req, localAddr, &resp)
+				if err != nil {
+					return errors.Wrap(err, "failed to call coin.BalanceOf")
+				}
+				balance := new(big.Int)
+				if resp.Balance != nil {
+					balance = resp.Balance.Value.Int
+				}
+				info.LOOM = fmt.Sprintf(
+					"%s (%s)",
+					formatTokenAmount(balance), balance.String(),
+				)
+			}
+
+			ethCoinAddr, err := rpcClient.Resolve("ethcoin")
+			if err == nil {
+				coinContract := client.NewContract(rpcClient, ethCoinAddr.Local)
+				req := &ctypes.BalanceOfRequest{
+					Owner: localAddr.MarshalPB(),
+				}
+				var resp ctypes.BalanceOfResponse
+				_, err = coinContract.StaticCall("BalanceOf", req, localAddr, &resp)
+				if err != nil {
+					return errors.Wrap(err, "failed to call ethcoin.BalanceOf")
+				}
+				balance := new(big.Int)
+				if resp.Balance != nil {
+					balance = resp.Balance.Value.Int
+				}
+				info.ETH = fmt.Sprintf(
+					"%s (%s)",
+					formatTokenAmount(balance), balance.String(),
+				)
+			}
+
 			output, err := json.MarshalIndent(info, "", "  ")
 			if err != nil {
 				return err
@@ -76,5 +129,86 @@ func newQueryAccountCommand() *cobra.Command {
 			return nil
 		},
 	}
+	return cmd
+}
+
+// Converts the given amount to a human readable string by stripping off 18 decimal places.
+func formatTokenAmount(amount *big.Int) string {
+	divisor := big.NewInt(10)
+	divisor.Exp(divisor, big.NewInt(18), nil)
+	return new(big.Int).Div(amount, divisor).String()
+}
+
+const queryUnclaimedTokensCmdExample = `
+# Show unclaimed LOOM in the DAppChain Gateway deposited by an Ethereum account
+./loom gateway unclaimed-tokens loomcoin-gateway 0x2a6b071aD396cEFdd16c731454af0d8c95ECD4B2
+
+# Show unclaimed tokens in the DAppChain Gateway deposited by an Ethereum account
+./loom gateway unclaimed-tokens eth:0x5d1ddf5223a412d24901c32d14ef56cb706c0f64
+`
+
+func newQueryUnclaimedTokensCommand() *cobra.Command {
+	var gatewayName string
+	cmd := &cobra.Command{
+		Use:     "unclaimed-tokens <account-addr> [gateway-name]",
+		Short:   "Shows unclaimed tokens in the Transfer Gateway deposited by an Ethereum account",
+		Example: queryUnclaimedTokensCmdExample,
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var addr loom.Address
+			var err error
+			if strings.HasPrefix(args[0], "eth:") {
+				addr, err = loom.ParseAddress(args[0])
+			} else {
+				if strings.HasPrefix(args[0], gatewayCmdFlags.ChainID+":") {
+					return errors.Wrap(err, "account address is not an Ethereum address")
+				} else {
+					local, err := loom.LocalAddressFromHexString(args[0])
+					if err != nil {
+						return errors.Wrap(err, "failed to parse account address")
+					}
+					addr = loom.Address{ChainID: "eth", Local: local}
+				}
+			}
+			if err != nil {
+				return errors.Wrap(err, "invalid account address")
+			}
+
+			gatewayName := GatewayName
+			if len(args) > 1 {
+				if strings.EqualFold(args[1], LoomGatewayName) {
+					gatewayName = LoomGatewayName
+				} else if !strings.EqualFold(args[1], GatewayName) {
+					return errors.New("Invalid gateway name")
+				}
+			}
+
+			rpcClient := getDAppChainClient()
+			gatewayAddr, err := rpcClient.Resolve(gatewayName)
+			if err != nil {
+				return errors.Wrap(err, "failed to resolve DAppChain Gateway address")
+			}
+			gateway := client.NewContract(rpcClient, gatewayAddr.Local)
+
+			req := &tgtypes.TransferGatewayGetUnclaimedTokensRequest{
+				Owner: addr.MarshalPB(),
+			}
+			resp := &tgtypes.TransferGatewayGetUnclaimedTokensResponse{}
+			_, err = gateway.StaticCall("GetUnclaimedTokens", req, addr, resp)
+			if err != nil {
+				return errors.Wrap(err, "failed to call GetUnclaimedTokens on Gateway contract")
+			}
+			output, err := json.MarshalIndent(resp.UnclaimedTokens, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(output))
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(
+		&gatewayName, "gateway", "g", GatewayName,
+		"Which Gateway contract to query, gateway or loomcoin-gateway",
+	)
 	return cmd
 }


### PR DESCRIPTION
The gateway account cmd now displays the ETH & LOOM balances for the
DAppChain account if an account mapping exists.

The gateway unclaimed-tokens` cmd displays the unclaimed tokens held
by the DAppChain Gateway.

Output from the commands is rather crude.