### PR TITLE
EthGetBlockByNumber, zero block valid input

### DIFF
--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -657,6 +657,9 @@ func (s *QueryServer) EthGetBlockByNumber(block eth.BlockHeight, full bool) (res
 
 	height, err := eth.DecBlockHeight(snapshot.Block().Height, block)
 	if err != nil {
+		if err.Error() == "zero block height is not valid" {
+			return eth.JsonBlockObject{}, nil
+		}
 		return resp, err
 	}
 	r, err := s.ReceiptHandlerProvider.ReaderAt(snapshot.Block().Height)


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request

EthGetBlockByNumber allow zero as valid input, returning empty object.