### PR TITLE
Remove special casing of current chain ID in ChainConfigMiddleware

### DIFF
--- a/auth/chainconfig_middleware.go
+++ b/auth/chainconfig_middleware.go
@@ -35,13 +35,10 @@ func NewChainConfigMiddleware(
 	})
 }
 
+// Filters out any auth.ChainConfig(s) that haven't been enabled by the majority of validators.
 func getEnabledChains(chains map[string]ChainConfig, state loomchain.State) map[string]ChainConfig {
 	enabledChains := map[string]ChainConfig{}
 	for chainID, config := range chains {
-		if chainID == state.Block().ChainID {
-			enabledChains[chainID] = config
-			continue
-		}
 		if state.FeatureEnabled(chainFeaturePrefix+chainID, false) {
 			enabledChains[chainID] = config
 		}
@@ -57,7 +54,7 @@ func ResolveAccountAddress(
 ) (loom.Address, error) {
 	chains := getEnabledChains(authCfg.Chains, state)
 	if len(chains) > 0 {
-		chain, found := authCfg.Chains[account.ChainID]
+		chain, found := chains[account.ChainID]
 		if !found {
 			return loom.Address{}, fmt.Errorf("unknown chain ID %s", account.ChainID)
 		}

--- a/e2e/loom-3-test.toml
+++ b/e2e/loom-3-test.toml
@@ -4,12 +4,22 @@
   Expected = [ "" ]
 
 [[TestCases]]
+  RunCmd = "loom chain-cfg add-feature auth:sigtx:default -k {{index $.NodePrivKeyPathList 0}}"
+  Condition = "contains"
+  Expected = [ "" ]
+
+[[TestCases]]
   RunCmd = "loom chain-cfg add-feature auth:sigtx:eth -k {{index $.NodePrivKeyPathList 0}}"
   Condition = "contains"
   Expected = [ "" ]
 
 [[TestCases]]
   RunCmd = "loom chain-cfg add-feature auth:sigtx:tron -k {{index $.NodePrivKeyPathList 0}}"
+  Condition = "contains"
+  Expected = [ "" ]
+
+[[TestCases]]
+  RunCmd = "loom chain-cfg enable-feature auth:sigtx:default -k {{index $.NodePrivKeyPathList 0}}"
   Condition = "contains"
   Expected = [ "" ]
 
@@ -29,19 +39,9 @@
   Expected = [ "auth:sigtx:tron","auth:sigtx:eth" ]
 
 [[TestCases]]
-  RunCmd = "loom chain-cfg list-features -k {{index $.NodePrivKeyPathList 0}}"
+  RunCmd = "loom chain-cfg get-feature auth:sigtx:default -k {{index $.NodePrivKeyPathList 0}}"
   Condition = "contains"
-  Expected = [ "auth:sigtx:tron","auth:sigtx:eth" ]
-
-[[TestCases]]
-  RunCmd = "loom chain-cfg list-features -k {{index $.NodePrivKeyPathList 0}}"
-  Condition = "contains"
-  Expected = [ "auth:sigtx:tron","auth:sigtx:eth" ]
-
-[[TestCases]]
-  RunCmd = "loom chain-cfg list-features -k {{index $.NodePrivKeyPathList 0}}"
-  Condition = "contains"
-  Expected = [ "auth:sigtx:tron","auth:sigtx:eth" ]
+  Expected = [ "auth:sigtx:default","ENABLED" ]
 
 [[TestCases]]
   RunCmd = "loom chain-cfg get-feature auth:sigtx:tron -k {{index $.NodePrivKeyPathList 0}}"

--- a/e2e/loom-4-test.toml
+++ b/e2e/loom-4-test.toml
@@ -4,12 +4,22 @@
   Expected = [ "" ]
 
 [[TestCases]]
+  RunCmd = "loom chain-cfg add-feature auth:sigtx:default -k {{index $.NodePrivKeyPathList 0}}"
+  Condition = "contains"
+  Expected = [ "" ]
+
+[[TestCases]]
   RunCmd = "loom chain-cfg add-feature auth:sigtx:eth -k {{index $.NodePrivKeyPathList 0}}"
   Condition = "contains"
   Expected = [ "" ]
 
 [[TestCases]]
   RunCmd = "loom chain-cfg add-feature auth:sigtx:tron -k {{index $.NodePrivKeyPathList 0}}"
+  Condition = "contains"
+  Expected = [ "" ]
+
+[[TestCases]]
+  RunCmd = "loom chain-cfg enable-feature auth:sigtx:default -k {{index $.NodePrivKeyPathList 0}}"
   Condition = "contains"
   Expected = [ "" ]
 
@@ -26,22 +36,12 @@
 [[TestCases]]
   RunCmd = "loom chain-cfg list-features -k {{index $.NodePrivKeyPathList 0}}"
   Condition = "contains"
-  Expected = [ "auth:sigtx:tron","auth:sigtx:eth" ]
+  Expected = [ "auth:sigtx:default", "auth:sigtx:tron","auth:sigtx:eth" ]
 
 [[TestCases]]
-  RunCmd = "loom chain-cfg list-features -k {{index $.NodePrivKeyPathList 0}}"
+  RunCmd = "loom chain-cfg get-feature auth:sigtx:default -k {{index $.NodePrivKeyPathList 0}}"
   Condition = "contains"
-  Expected = [ "auth:sigtx:tron","auth:sigtx:eth" ]
-
-[[TestCases]]
-  RunCmd = "loom chain-cfg list-features -k {{index $.NodePrivKeyPathList 0}}"
-  Condition = "contains"
-  Expected = [ "auth:sigtx:tron","auth:sigtx:eth" ]
-
-[[TestCases]]
-  RunCmd = "loom chain-cfg list-features -k {{index $.NodePrivKeyPathList 0}}"
-  Condition = "contains"
-  Expected = [ "auth:sigtx:tron","auth:sigtx:eth" ]
+  Expected = [ "auth:sigtx:default","ENABLED" ]
 
 [[TestCases]]
   RunCmd = "loom chain-cfg get-feature auth:sigtx:tron -k {{index $.NodePrivKeyPathList 0}}"


### PR DESCRIPTION
Previously if the current chain ID was found in the `Auth.Chains` config setting the `MultiChainSignatureTxMiddleware` was activated right away. Running `MultiChainSignatureTxMiddleware` with a single chain should be equivalent to running `SignatureTxMiddleware`, unless there's a config
error, but I'd rather not rely on assumptions.