### PR TITLE
Fix ChainConfig contract deployment

### DIFF
--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -901,7 +901,16 @@ func loadApp(chainID string, cfg *config.Config, loader plugin.Loader, b backend
 		if err != nil {
 			return nil, err
 		}
-		return plugin.NewChainConfigManager(pvm.(*plugin.PluginVM), state)
+
+		m, err := plugin.NewChainConfigManager(pvm.(*plugin.PluginVM), state)
+		if err != nil {
+			// This feature will remain disabled until the ChainConfig contract is deployed
+			if err == plugin.ErrChainConfigContractNotFound {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return m, nil
 	}
 
 	postCommitMiddlewares := []loomchain.PostCommitMiddleware{

--- a/plugin/chain_config_manager.go
+++ b/plugin/chain_config_manager.go
@@ -5,6 +5,13 @@ import (
 	contract "github.com/loomnetwork/go-loom/plugin/contractpb"
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/builtin/plugins/chainconfig"
+	regcommon "github.com/loomnetwork/loomchain/registry"
+	"github.com/pkg/errors"
+)
+
+var (
+	// ErrChainConfigContractNotFound indicates that the ChainConfig contract hasn't been deployed yet.
+	ErrChainConfigContractNotFound = errors.New("[ChainConfigManager] ChainContract contract not found")
 )
 
 // ChainConfigManager implements loomchain.ChainConfigManager interface
@@ -13,10 +20,14 @@ type ChainConfigManager struct {
 	state loomchain.State
 }
 
+// NewChainConfigManager attempts to create an instance of ChainConfigManager.
 func NewChainConfigManager(pvm *PluginVM, state loomchain.State) (*ChainConfigManager, error) {
 	caller := loom.RootAddress(pvm.State.Block().ChainID)
 	contractAddr, err := pvm.Registry.Resolve("chainconfig")
 	if err != nil {
+		if err == regcommon.ErrNotFound {
+			return nil, ErrChainConfigContractNotFound
+		}
 		return nil, err
 	}
 	readOnly := false


### PR DESCRIPTION
The contract needs to be deployed before the `ChainConfigManager` can access it, so don't panic if the contract is missing.