### PR TITLE
Fix TestChainConfigMiddlewareMultipleChain

### DIFF
--- a/auth/chainconfig_middleware_test.go
+++ b/auth/chainconfig_middleware_test.go
@@ -47,13 +47,11 @@ func TestChainConfigMiddlewareSingleChain(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TODO: This test doesn't really test multiple chains at the moment, chains have to be enabled via
-//       feature flags.
 func TestChainConfigMiddlewareMultipleChain(t *testing.T) {
 	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil)
-	state.SetFeature(featurePrefix+"default", true)
-	state.SetFeature(featurePrefix+"tron", true)
-	state.SetFeature(featurePrefix+"eth", true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"default", true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"tron", true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"eth", true)
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
 	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
 	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))


### PR DESCRIPTION
Multi Chains feature is now enabled by feature flag. Need to make a change on unit test.