### PR TITLE
DPOSv2.1: use 2-week locktime for tier0

### DIFF
--- a/builtin/plugins/dposv2/dpos.go
+++ b/builtin/plugins/dposv2/dpos.go
@@ -250,17 +250,17 @@ func (c *DPOS) Delegate(ctx contract.Context, req *DelegateRequest) error {
 	var tierTime uint64
 	// If there was no prior delegation, or if the user is supplying a bigger locktime
 	if priorDelegation == nil || locktimeTier >= priorDelegation.LocktimeTier {
-        if !v2_1 {
-		    tierTime = calculateTierLocktime(locktimeTier, uint64(state.Params.ElectionCycleLength))
-        } else {
-		    tierTime = TierLocktimeMap[locktimeTier]
-        }
+		if !v2_1 {
+			tierTime = calculateTierLocktime(locktimeTier, uint64(state.Params.ElectionCycleLength))
+		} else {
+			tierTime = TierLocktimeMap[locktimeTier]
+		}
 	} else {
-        if !v2_1 {
-            tierTime = calculateTierLocktime(priorDelegation.LocktimeTier, uint64(state.Params.ElectionCycleLength))
-        } else {
-		    tierTime = TierLocktimeMap[priorDelegation.LocktimeTier]
-        }
+		if !v2_1 {
+			tierTime = calculateTierLocktime(priorDelegation.LocktimeTier, uint64(state.Params.ElectionCycleLength))
+		} else {
+			tierTime = TierLocktimeMap[priorDelegation.LocktimeTier]
+		}
 	}
 	lockTime := now + tierTime
 
@@ -415,12 +415,12 @@ func (c *DPOS) Delegate2(ctx contract.Context, req *DelegateRequest) error {
 		locktimeTier = priorDelegation.LocktimeTier
 	}
 
-    var tierTime uint64
-    if !v2_1 {
-        tierTime = calculateTierLocktime(locktimeTier, uint64(state.Params.ElectionCycleLength))
-    } else {
-        tierTime = TierLocktimeMap[locktimeTier]
-    }
+	var tierTime uint64
+	if !v2_1 {
+		tierTime = calculateTierLocktime(locktimeTier, uint64(state.Params.ElectionCycleLength))
+	} else {
+		tierTime = TierLocktimeMap[locktimeTier]
+	}
 	now := uint64(ctx.Now().Unix())
 	lockTime := now + tierTime
 
@@ -754,12 +754,12 @@ func (c *DPOS) RegisterCandidate2(ctx contract.Context, req *RegisterCandidateRe
 
 		locktimeTier := TierMap[tier]
 		now := uint64(ctx.Now().Unix())
-        var tierTime uint64
-        if !v2_1 {
-            tierTime = calculateTierLocktime(locktimeTier, uint64(state.Params.ElectionCycleLength))
-        } else {
-            tierTime = TierLocktimeMap[locktimeTier]
-        }
+		var tierTime uint64
+		if !v2_1 {
+			tierTime = calculateTierLocktime(locktimeTier, uint64(state.Params.ElectionCycleLength))
+		} else {
+			tierTime = TierLocktimeMap[locktimeTier]
+		}
 		lockTime := now + tierTime
 
 		delegation := &Delegation{
@@ -854,12 +854,12 @@ func (c *DPOS) RegisterCandidate(ctx contract.Context, req *RegisterCandidateReq
 
 		locktimeTier := TierMap[tier]
 		now := uint64(ctx.Now().Unix())
-        var tierTime uint64
-        if !v2_1 {
-            tierTime = calculateTierLocktime(locktimeTier, uint64(state.Params.ElectionCycleLength))
-        } else {
-            tierTime = TierLocktimeMap[locktimeTier]
-        }
+		var tierTime uint64
+		if !v2_1 {
+			tierTime = calculateTierLocktime(locktimeTier, uint64(state.Params.ElectionCycleLength))
+		} else {
+			tierTime = TierLocktimeMap[locktimeTier]
+		}
 		lockTime := now + tierTime
 
 		delegation := &Delegation{

--- a/builtin/plugins/gateway/gateway.go
+++ b/builtin/plugins/gateway/gateway.go
@@ -214,7 +214,7 @@ func (gw *Gateway) Init(ctx contract.Context, req *InitRequest) error {
 	}
 
 	return saveState(ctx, &GatewayState{
-		Owner: req.Owner,
+		Owner:                 req.Owner,
 		NextContractMappingID: 1,
 		LastMainnetBlockNum:   req.FirstMainnetBlockNum,
 	})


### PR DESCRIPTION
So far if the election cycles were set to be less than 2 weeks and somebody delegated with Tier0, the unbonding period was set to the `ElectionCycleLength`. V2_1 removes that and sets it back to 2-weeks, as was done in DPOSv3. This PR also utilizes the feature flag and is a noop if it's not enabled.