### PR TITLE
Disable dupl linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
     - gochecknoinits
     - scopelint
     - stylecheck
-
+    - dupl
 # linters-settings:
 #   govet:
 #     check-shadowing: true


### PR DESCRIPTION
disable dupl linter in golangci-lint, it will suppress lines are duplicate of bugs spotted by dupl linter