### PR TITLE
Fix LogEventDispatcher.Send

### DIFF
--- a/events/log.go
+++ b/events/log.go
@@ -18,7 +18,7 @@ func NewLogEventDispatcher() *LogEventDispatcher {
 
 // Send sends the event
 func (ed *LogEventDispatcher) Send(index uint64, eventIdex int, msg []byte) error {
-	log.Info("Event emitted: index: %d, length: %d, msg: %s\n", index, len(msg), msg)
+	log.Info("Event emitted", "index", index, "length", len(msg), "msg", string(msg))
 	return nil
 }
 


### PR DESCRIPTION
`log.Info` doesn't expect a format string, so it just prints it out
verbatim without replacing the format specifiers so all log entries just
end up as `Event emitted: index: %d, length: %d, msg: %s`