### PR TITLE
Load dposv3 when set in the loom.yml

### DIFF
--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -979,7 +979,7 @@ func loadApp(chainID string, cfg *config.Config, loader plugin.Loader, b backend
 		if err != nil {
 			return nil, err
 		}
-		// DPOSv3 can only be enabled via feature flag
+		// DPOSv3 can only be enabled via feature flag or if it's enabled via the loom.yml
 		if cfg.DPOSVersion == 3 || state.FeatureEnabled(loomchain.DPOSVersion3Feature, false) {
 			return plugin.NewValidatorsManagerV3(pvm.(*plugin.PluginVM))
 		} else if cfg.DPOSVersion == 2 {


### PR DESCRIPTION
Loads DPOSv3 via the loom.yml when it's set as `DPOSVersion: 3`