### PR TITLE
migration testing & improvements

### DIFF
--- a/builtin/plugins/dposv2/dpos.go
+++ b/builtin/plugins/dposv2/dpos.go
@@ -2210,7 +2210,7 @@ func Dump(ctx contract.Context, dposv3Address loom.Address) (*dposv3.Initializat
 		amount := adjustDoubledDelegationAmount(*delegation)
 
 		v3Delegation := &dposv3.Delegation{
-			Validator:    validator,
+			Validator:    adjustValidatorIfLimboValidator(ctx, validator),
 			Delegator:    delegation.Delegator,
 			Index:        dposv3.DELEGATION_START_INDEX + indices[delegationKey],
 			Amount:       amount,

--- a/builtin/plugins/dposv2/util.go
+++ b/builtin/plugins/dposv2/util.go
@@ -7,6 +7,8 @@ import (
 	"github.com/loomnetwork/go-loom/common"
 	contract "github.com/loomnetwork/go-loom/plugin/contractpb"
 	types "github.com/loomnetwork/go-loom/types"
+
+	"github.com/loomnetwork/loomchain/builtin/plugins/dposv3"
 )
 
 const billionthsBasisPointRatio = 100000
@@ -54,6 +56,13 @@ func adjustValidatorIfInPlasmaValidators(delegation Delegation) *types.Address {
 		if validator.Local.Compare(plasmaValidator.Local) == 0 {
 			return plasmaValidators[0].MarshalPB()
 		}
+	}
+	return validator
+}
+
+func adjustValidatorIfLimboValidator(ctx contract.Context, validator *types.Address) *types.Address {
+	if validator.Local.Compare(limboValidatorAddress.Local) == 0 {
+		return dposv3.LimboValidatorAddress(ctx).MarshalPB()
 	}
 	return validator
 }

--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -291,7 +291,7 @@ func (c *DPOS) Redelegate(ctx contract.Context, req *RedelegateRequest) error {
 
 	// Unless redelegation is to the limbo validator check that the new
 	// validator address corresponds to one of the registered candidates
-	if loom.UnmarshalAddressPB(req.ValidatorAddress).Compare(limboValidatorAddress(ctx)) != 0 {
+	if loom.UnmarshalAddressPB(req.ValidatorAddress).Compare(LimboValidatorAddress(ctx)) != 0 {
 		candidate := GetCandidate(ctx, loom.UnmarshalAddressPB(req.ValidatorAddress))
 		// Delegations can only be made to existing candidates
 		if candidate == nil {
@@ -385,7 +385,7 @@ func (c *DPOS) ConsolidateDelegations(ctx contract.Context, req *ConsolidateDele
 
 	// Unless considation is for the limbo validator, check that the new
 	// validator address corresponds to one of the registered candidates
-	if loom.UnmarshalAddressPB(req.ValidatorAddress).Compare(limboValidatorAddress(ctx)) != 0 {
+	if loom.UnmarshalAddressPB(req.ValidatorAddress).Compare(LimboValidatorAddress(ctx)) != 0 {
 		candidate := GetCandidate(ctx, loom.UnmarshalAddressPB(req.ValidatorAddress))
 		// Delegations can only be made to existing candidates
 		if candidate == nil {
@@ -1312,7 +1312,7 @@ func rewardAndSlash(ctx contract.Context, state *State) ([]*DelegationResult, er
 						referrerReward = CalculateFraction(defaultReferrerFee, referrerReward)
 
 						// referrer fees are delegater to limbo validator
-						IncreaseRewardDelegation(ctx, limboValidatorAddress(ctx).MarshalPB(), referrerAddress, referrerReward)
+						IncreaseRewardDelegation(ctx, LimboValidatorAddress(ctx).MarshalPB(), referrerAddress, referrerReward)
 
 						// any referrer bonus amount is subtracted from the validatorShare
 						validatorShare.Sub(&validatorShare, &referrerReward)
@@ -1471,7 +1471,7 @@ func distributeDelegatorRewards(ctx contract.Context, formerValidatorTotals map[
 		validatorKey := loom.UnmarshalAddressPB(delegation.Validator).String()
 
 		// Do not distribute rewards to delegators of the Limbo validator
-		if loom.UnmarshalAddressPB(delegation.Validator).Compare(limboValidatorAddress(ctx)) != 0 {
+		if loom.UnmarshalAddressPB(delegation.Validator).Compare(LimboValidatorAddress(ctx)) != 0 {
 			// allocating validator distributions to delegators
 			// based on former validator delegation totals
 			delegationTotal := formerValidatorTotals[validatorKey]
@@ -1527,7 +1527,7 @@ func distributeDelegatorRewards(ctx contract.Context, formerValidatorTotals map[
 
 		// Calculate delegation totals for all validators except the Limbo
 		// validator
-		if loom.UnmarshalAddressPB(delegation.Validator).Compare(limboValidatorAddress(ctx)) != 0 {
+		if loom.UnmarshalAddressPB(delegation.Validator).Compare(LimboValidatorAddress(ctx)) != 0 {
 			newTotal := common.BigZero()
 			weightedDelegation := calculateWeightedDelegationAmount(*delegation)
 			newTotal.Add(newTotal, &weightedDelegation)

--- a/builtin/plugins/dposv3/dpos_test.go
+++ b/builtin/plugins/dposv3/dpos_test.go
@@ -323,7 +323,7 @@ func TestChangeFee(t *testing.T) {
 
 func TestDelegate(t *testing.T) {
 	pctx := createCtx()
-	limboValidatorAddress := limboValidatorAddress(contractpb.WrapPluginStaticContext(pctx))
+	limboValidatorAddress := LimboValidatorAddress(contractpb.WrapPluginStaticContext(pctx))
 
 	oraclePubKey, _ := hex.DecodeString(validatorPubKeyHex2)
 	oracleAddr := loom.Address{
@@ -481,7 +481,7 @@ func TestDelegate(t *testing.T) {
 
 func TestRedelegate(t *testing.T) {
 	pctx := createCtx()
-	limboValidatorAddress := limboValidatorAddress(contractpb.WrapPluginStaticContext(pctx))
+	limboValidatorAddress := LimboValidatorAddress(contractpb.WrapPluginStaticContext(pctx))
 
 	// Deploy the coin contract (DPOS Init() will attempt to resolve it)
 	coinContract := &coin.Coin{}
@@ -1076,7 +1076,7 @@ func TestValidatorRewards(t *testing.T) {
 func TestReferrerRewards(t *testing.T) {
 	// Init the coin balances
 	pctx := createCtx()
-	limboValidatorAddress := limboValidatorAddress(contractpb.WrapPluginStaticContext(pctx))
+	limboValidatorAddress := LimboValidatorAddress(contractpb.WrapPluginStaticContext(pctx))
 	coinAddr := pctx.CreateContract(coin.Contract)
 
 	coinContract := &coin.Coin{}

--- a/builtin/plugins/dposv3/util.go
+++ b/builtin/plugins/dposv3/util.go
@@ -107,6 +107,6 @@ func logStaticDposError(ctx contract.StaticContext, err error, req string) error
 
 // LIMBO VALIDATOR
 
-func limboValidatorAddress(ctx contract.StaticContext) loom.Address {
+func LimboValidatorAddress(ctx contract.StaticContext) loom.Address {
 	return loom.RootAddress(ctx.Block().ChainID)
 }


### PR DESCRIPTION
- limbo delegation migration uses new dposv3 limbo validator address format