### PR TITLE
Fix: delegator gets extra funds when redelegating

### DIFF
--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -349,8 +349,10 @@ func (c *DPOS) Redelegate(ctx contract.Context, req *RedelegateRequest) error {
 	} else {
 		// if less than the full amount is being redelegated, create a new
 		// delegation for new validator and unbond from former validator
-		priorDelegation.State = UNBONDING
-		priorDelegation.UpdateAmount = req.Amount
+		priorDelegation.State = REDELEGATING
+		priorDelegation.UpdateAmount.Value.Add(&priorDelegation.UpdateAmount.Value, &req.Amount.Value)
+		priorDelegation.UpdateValidator = priorDelegation.Validator
+
 		index, err := GetNextDelegationIndex(ctx, *req.ValidatorAddress, *priorDelegation.Delegator)
 		if err != nil {
 			return err

--- a/builtin/plugins/dposv3/dpos_test.go
+++ b/builtin/plugins/dposv3/dpos_test.go
@@ -625,9 +625,23 @@ func TestRedelegate(t *testing.T) {
 
 	require.NoError(t, elect(pctx, dpos.Address))
 
-	delegations, _, _, err := dpos.CheckDelegation(pctx, &addr3, &delegatorAddress2)
+	balanceBefore, err := coinContract.BalanceOf(contractpb.WrapPluginContext(coinCtx), &coin.BalanceOfRequest{
+		Owner: addr1.MarshalPB(),
+	})
 	require.Nil(t, err)
-	// assert.True(t, delegationResponse.Amount.Value.Cmp(smallDelegationAmount) == 0)
+
+	require.NoError(t, elect(pctx, dpos.Address))
+
+	balanceAfter, err := coinContract.BalanceOf(contractpb.WrapPluginContext(coinCtx), &coin.BalanceOfRequest{
+		Owner: addr1.MarshalPB(),
+	})
+	require.Nil(t, err)
+
+	require.True(t, balanceBefore.Balance.Value.Cmp(&balanceAfter.Balance.Value) == 0)
+
+	require.NoError(t, elect(pctx, dpos.Address))
+
+	delegations, _, _, err := dpos.CheckDelegation(pctx, &addr3, &delegatorAddress2)
 	assert.Equal(t, delegations[len(delegations)-1].LocktimeTier, TIER_THREE)
 
 	// checking that all 3 candidates have been elected validators


### PR DESCRIPTION
When delegations that are getting redelegated get processed in distributeDelegatorRewards during the next election, the original delegation is essentially refunded to the delegator, and a new delegation with req.Amount goes into effect.  So the net effect is that the delegator receives req.Amount in new money.

Fixed by setting the state during redelegation to REDELEGATING, and updating the updateValidator to be the same as before