### PR TITLE
make oracles only load secp256k1 keys if batch signing is not enabled

### DIFF
--- a/gateway/oracle.go
+++ b/gateway/oracle.go
@@ -173,9 +173,16 @@ func createOracle(cfg *TransferGatewayConfig, chainID string, metricSubsystem st
 	}
 	signer := auth.NewSigner(signerType, privKey)
 
-	mainnetPrivateKey, err := LoadMainnetPrivateKey(cfg.MainnetPrivateKeyHsmEnabled, cfg.MainnetPrivateKeyPath)
-	if err != nil {
-		return nil, err
+	receiptSigningEnabled := !cfg.BatchSignFnConfig.Enabled
+
+	// only load the mainnet private key if receipt signing is needed
+	var mainnetPrivateKey lcrypto.PrivateKey
+	if receiptSigningEnabled {
+		mainnetPrivateKey, err = LoadMainnetPrivateKey(cfg.MainnetPrivateKeyHsmEnabled, cfg.MainnetPrivateKeyPath)
+		if err != nil {
+			return nil, err
+
+		}
 	}
 
 	address := loom.Address{
@@ -223,7 +230,7 @@ func createOracle(cfg *TransferGatewayConfig, chainID string, metricSubsystem st
 		withdrawalSig:       cfg.WithdrawalSig,
 		withdrawerBlacklist: withdrawerBlacklist,
 		// Oracle will do receipt signing when BatchSignFnConfig is disabled
-		receiptSigningEnabled: !cfg.BatchSignFnConfig.Enabled,
+		receiptSigningEnabled: receiptSigningEnabled,
 	}, nil
 }
 


### PR DESCRIPTION
Previously, the oracle setup would require a secp256k1 key, even though it wouldn’t sign, since there is a check that prevents signing in https://github.com/loomnetwork/loomchain/blob/master/gateway/oracle.go#L400