### PR TITLE
Fix loading of EVM root in MultiWriterAppStore

### DIFF
--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -45,10 +45,10 @@ func NewMultiWriterAppStore(appStore *IAVLStore, evmStore *EvmStore, evmStoreEna
 		evmStore:        evmStore,
 	}
 	appStoreEvmRoot := store.appStore.Get(rootKey)
-	evmStoreEvmRoot := store.evmStore.Get(rootHashKey)
+	evmStoreEvmRoot, version := store.evmStore.getLastSavedRoot(store.appStore.Version())
 	if !bytes.Equal(appStoreEvmRoot, evmStoreEvmRoot) {
-		return nil, fmt.Errorf("EVM roots mismatch, version:%d, evm.db:%X, app.db:%X",
-			appStore.Version(), evmStoreEvmRoot, appStoreEvmRoot)
+		return nil, fmt.Errorf("EVM roots mismatch, evm.db(%d): %X, app.db(%d): %X",
+			version, evmStoreEvmRoot, appStore.Version(), appStoreEvmRoot)
 	}
 	store.setLastSavedTreeToVersion(appStore.Version())
 	return store, nil


### PR DESCRIPTION
Since we cache EVM root in EvmStore, we have to get saved EVM root from disk using `getLastSavedRoot`.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request