### PR TITLE
Add timing metrics to IAVLStore, MultiWriterAppStore, and EvmStore

### DIFF
--- a/store/evmstore.go
+++ b/store/evmstore.go
@@ -24,16 +24,14 @@ var (
 )
 
 func init() {
-	const namespace = "loomchain"
-	const subsystem = "evmstore"
-
 	commitDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
+			Namespace: "loomchain",
+			Subsystem: "evmstore",
 			Name:      "commit",
 			Help:      "How long EvmStore.Commit() took to execute (in seconds)",
-		}, []string{"version"})
+		}, []string{"version"},
+	)
 }
 
 func evmRootKey(blockHeight int64) []byte {

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -30,15 +30,16 @@ func init() {
 			Subsystem: subsystem,
 			Name:      "prune_duration",
 			Help:      "How long IAVLStore.Prune() took to execute (in seconds)",
-		}, []string{"error"})
+		}, []string{"error"},
+	)
 	iavlSaveVersionDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "save_version",
 			Help:      "How long IAVLStore.SaveVersion() took to execute (in seconds)",
-		}, []string{"error"})
-
+		}, []string{"error"},
+	)
 }
 
 type IAVLStore struct {

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -35,16 +35,14 @@ var (
 )
 
 func init() {
-	const namespace = "loomchain"
-	const subsystem = "multi_writer_appstore"
-
 	saveVersionDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
+			Namespace: "loomchain",
+			Subsystem: "multi_writer_appstore",
 			Name:      "save_version",
 			Help:      "How long MultiWriterAppStore.SaveVersion() took to execute (in seconds)",
-		}, []string{"error"})
+		}, []string{"error"},
+	)
 }
 
 // MultiWriterAppStore reads & writes keys that have the "vm" prefix via both the IAVLStore and the EvmStore,


### PR DESCRIPTION
We need to measure the execution time of `IAVLStore.SaveVersion()`, `MultiWriterAppStore.SaveVersion()` and `EvmStore.Commit()` in order to see how much our chain performance improve with `evm.db`  

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request