### PR TITLE
Make MultiWriterAppStore read evm.db for prefix "vm" by default

### DIFF
--- a/features.go
+++ b/features.go
@@ -37,7 +37,8 @@ const (
 	// Enables usage of ctx.Validators() in ChainConfig contract.
 	ChainCfgVersion1_1 = "chaincfg:v1.1"
 
-	// Enables application to persist and retrieve EVM state in/from evm.db
+	// Forces the MultiWriterAppStore to write EVM state only to evm.db, otherwise it'll write EVM
+	// state to both evm.db & app.db.
 	EvmDBFeature = "db:evm"
 
 	// Enables Coin v1.1 contract (also applies to ETHCoin)


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request