### PR TITLE
Fix vmroot not found in app.db

### DIFF
--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -62,6 +62,10 @@ func NewMultiWriterAppStore(appStore *IAVLStore, evmStore *EvmStore, evmStoreEna
 		evmStore:        evmStore,
 	}
 	appStoreEvmRoot := store.appStore.Get(rootKey)
+	// if root is nil, this is the first run after migration, so get evmroot from vmvmroot
+	if appStoreEvmRoot == nil {
+		appStoreEvmRoot = store.appStore.Get(util.PrefixKey(vmPrefix, rootKey))
+	}
 	evmStoreEvmRoot, version := store.evmStore.getLastSavedRoot(store.appStore.Version())
 	if !bytes.Equal(appStoreEvmRoot, evmStoreEvmRoot) {
 		return nil, fmt.Errorf("EVM roots mismatch, evm.db(%d): %X, app.db(%d): %X",


### PR DESCRIPTION
After the migration, evm root hash in `vmroot` in `app.db` is empty, so we need to read it from its previous location which is `vmvmroot`. 

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request