### PR TITLE
Remove unnecessary labels from recently added metrics

### DIFF
--- a/store/evmstore.go
+++ b/store/evmstore.go
@@ -3,7 +3,6 @@ package store
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"sort"
 	"time"
 
@@ -30,7 +29,7 @@ func init() {
 			Subsystem: "evmstore",
 			Name:      "commit",
 			Help:      "How long EvmStore.Commit() took to execute (in seconds)",
-		}, []string{"version"},
+		}, []string{},
 	)
 }
 
@@ -177,8 +176,7 @@ func (s *EvmStore) Set(key, val []byte) {
 
 func (s *EvmStore) Commit(version int64) []byte {
 	defer func(begin time.Time) {
-		lvs := []string{"version", fmt.Sprintf("%d", version)}
-		commitDuration.With(lvs...).Observe(time.Since(begin).Seconds())
+		commitDuration.Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
 	currentRoot := make([]byte, len(s.rootHash))

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -38,7 +38,7 @@ func init() {
 			Subsystem: subsystem,
 			Name:      "save_version",
 			Help:      "How long IAVLStore.SaveVersion() took to execute (in seconds)",
-		}, []string{"error"},
+		}, []string{},
 	)
 }
 
@@ -129,8 +129,7 @@ func (s *IAVLStore) Version() int64 {
 func (s *IAVLStore) SaveVersion() ([]byte, int64, error) {
 	var err error
 	defer func(begin time.Time) {
-		lvs := []string{"error", fmt.Sprint(err != nil)}
-		iavlSaveVersionDuration.With(lvs...).Observe(time.Since(begin).Seconds())
+		iavlSaveVersionDuration.Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
 	oldVersion := s.Version()

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -41,7 +41,7 @@ func init() {
 			Subsystem: "multi_writer_appstore",
 			Name:      "save_version",
 			Help:      "How long MultiWriterAppStore.SaveVersion() took to execute (in seconds)",
-		}, []string{"error"},
+		}, []string{},
 	)
 }
 
@@ -134,8 +134,7 @@ func (s *MultiWriterAppStore) Version() int64 {
 func (s *MultiWriterAppStore) SaveVersion() ([]byte, int64, error) {
 	var err error
 	defer func(begin time.Time) {
-		lvs := []string{"error", fmt.Sprint(err != nil)}
-		saveVersionDuration.With(lvs...).Observe(time.Since(begin).Seconds())
+		saveVersionDuration.Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
 	currentRoot := s.evmStore.Commit(s.Version() + 1)


### PR DESCRIPTION
Main problem was with the EvmStore commit metric, the version label had
a unique value for each entry which made plotting this metric on
a graph rather challenging (killed the Prometheus/Grafana rendering
basically).