### PR TITLE
Improve EvmStore.getLastSavedRoot performance

### DIFF
--- a/store/evmstore_test.go
+++ b/store/evmstore_test.go
@@ -132,3 +132,35 @@ func (t *EvmStoreTestSuite) TestEvmStoreRangePrefix() {
 	dataRange = evmStore.Range([]byte("vv"))
 	require.Equal(100, len(dataRange))
 }
+
+func (t *EvmStoreTestSuite) TestLoadVersionEvmStore() {
+	require := t.Require()
+	evmDb, err := db.LoadMemDB()
+	evmDb.Set(evmRootKey(1), []byte{1})
+	evmDb.Set(evmRootKey(2), []byte{2})
+	evmDb.Set(evmRootKey(3), []byte{3})
+	evmDb.Set(evmRootKey(100), []byte{100})
+	evmDb.Set(evmRootKey(200), []byte{200})
+
+	evmStore := NewEvmStore(evmDb, 100)
+	err = evmStore.LoadVersion(500)
+	require.NoError(err)
+	root, version := evmStore.Version()
+	require.Equal(true, bytes.Equal(root, []byte{200}))
+	require.Equal(int64(200), version)
+
+	err = evmStore.LoadVersion(2)
+	root, version = evmStore.Version()
+	require.Equal(true, bytes.Equal(root, []byte{2}))
+	require.Equal(int64(2), version)
+
+	err = evmStore.LoadVersion(99)
+	root, version = evmStore.Version()
+	require.Equal(true, bytes.Equal(root, []byte{3}))
+	require.Equal(int64(3), version)
+
+	err = evmStore.LoadVersion(100)
+	root, version = evmStore.Version()
+	require.Equal(true, bytes.Equal(root, []byte{100}))
+	require.Equal(int64(100), version)
+}


### PR DESCRIPTION
The way we call `ReverseIterator` was not quite right. `ReverseIterator` takes two arguments `start` and `end`. TM ReverseIterator uses `seek(end)` to go to the latest prefix key and then iterate back to `start`. Previously, we only specify `start` which makes it iterates through the database from the last index. Fix this now by specifying `end`.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request