### PR TITLE
Passing block height from block store

### DIFF
--- a/store/block_store.go
+++ b/store/block_store.go
@@ -285,7 +285,8 @@ func (s *TendermintBlockStore) GetTxResult(txHash []byte) (*ctypes.ResultTx, err
 		return nil, err
 	}
 	return &ctypes.ResultTx{
-		Index: txResult.Index,
+		Index:  txResult.Index,
+		Height: txResult.Height,
 		TxResult: abci.ResponseDeliverTx{
 			Data: txResult.TxResult.Data,
 			Info: txResult.TxResult.Info,


### PR DESCRIPTION
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request

This PR addresses an issue regarding the block store didn't receive the BlockHeight data from Tendermint so before the `ctypes.ResultTx` was using the default value for Height which was `0` and causing issues to retrieve the receipt for go plugins transactions