### PR TITLE
MultiWriterAppStore supports MultiReaderIAVLStore

### DIFF
--- a/store/multi_writer_app_store_test.go
+++ b/store/multi_writer_app_store_test.go
@@ -222,7 +222,7 @@ func mockMultiWriterStore() (*MultiWriterAppStore, error) {
 	}
 	memDb, _ = db.LoadMemDB()
 	evmStore := NewEvmStore(memDb, 100)
-	multiWriterStore, err := NewMultiWriterAppStore(iavlStore, evmStore, false, false)
+	multiWriterStore, err := NewMultiWriterAppStore(iavlStore, evmStore, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, `MultiWriterAppStore` (AppStore version 3) only works with `IAVLStore` (AppStore version 1). Since we need to test `MultiWriterAppStore` on Asia1 and Us1 clusters which are running `MultiReaderIAVLStore` (AppStore version 2), we need to make `MultiWriterAppStore` support `MultiReaderIAVLStore`. Theoretically, `MultiWriterAppStore` should work with `MultiReaderIAVLStore` with minor tweaks

Note: this PR deprecates `CachingStore`. After this PR is merged, AppStore version 1 is only compatible with `VersionedCachingStore`

TODO: make ./loom db evm-state-dump-2 works with AppStore 2

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request