### PR TITLE
[DO-NOT-MERGE] Commit failed receipts

### DIFF
--- a/app.go
+++ b/app.go
@@ -586,6 +586,7 @@ func (a *Application) processTx(txBytes []byte, isCheckTx bool) (TxHandlerResult
 
 	// Failed transactions should have a receipt commited
 	if err != nil {
+		storeTx.Rollback()
 		receiptHandler.CommitCurrentReceipt()
 		return r, nil
 	}


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request

This change fixes receipts that fail to create the `TxHash` when a transaction fails, failing transactions should register a receipt too, but those receipts should have the status equals `0`

Related to issue reported https://github.com/loomnetwork/loomchain/issues/1157