### PR TITLE
Add mutex for KeyTable hash map in VersionedCachingStore 

### DIFF
--- a/store/versioned_cachingstore.go
+++ b/store/versioned_cachingstore.go
@@ -50,9 +50,8 @@ func newVersionedBigCache(config *CachingStoreConfig, cacheLogger *loom.Logger) 
 		return nil, err
 	}
 	versionedCache := &versionedBigCache{
-		cacheLogger:   cacheLogger,
-		keyTableMutex: sync.RWMutex{},
-		keyTable:      map[string]KeyVersionTable{},
+		cacheLogger: cacheLogger,
+		keyTable:    map[string]KeyVersionTable{},
 	}
 
 	// when a key get evicted from BigCache, KeyVersionTable and KeyTable must be updated


### PR DESCRIPTION
`VersionedCachingStore` has a `KeyTable` for keeping versions of keys. Since hash map is not thread safe and it is called by multi threads, it is going to crash the system. Fix this by adding mutex.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request