### PR TITLE
Prefix hash before using it as a key

### DIFF
--- a/app.go
+++ b/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/loomnetwork/go-loom/types"
 	"github.com/loomnetwork/loomchain/log"
 	"github.com/loomnetwork/loomchain/store"
+	blockindex "github.com/loomnetwork/loomchain/store/block_index"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/common"
@@ -275,7 +276,7 @@ type Application struct {
 	QueryHandler
 	EventHandler
 	ReceiptHandlerProvider
-	store.BlockIndexStore
+	blockindex.BlockIndexStore
 	CreateValidatorManager   ValidatorsManagerFactoryFunc
 	CreateChainConfigManager ChainConfigManagerFactoryFunc
 	OriginHandler

--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -65,6 +65,7 @@ import (
 	registry "github.com/loomnetwork/loomchain/registry/factory"
 	"github.com/loomnetwork/loomchain/rpc"
 	"github.com/loomnetwork/loomchain/store"
+	blockindex "github.com/loomnetwork/loomchain/store/block_index"
 	"github.com/loomnetwork/loomchain/throttle"
 	"github.com/loomnetwork/loomchain/tx_handler"
 	"github.com/loomnetwork/loomchain/vm"
@@ -1192,9 +1193,9 @@ func loadApp(
 		logger.Info("Karma disabled, upkeep enabled ignored")
 	}
 
-	var blockIndexStore store.BlockIndexStore
+	var blockIndexStore blockindex.BlockIndexStore
 	if cfg.BlockIndexStore.Enabled {
-		blockIndexStore, err = store.NewBlockIndexStore(
+		blockIndexStore, err = blockindex.NewBlockIndexStore(
 			cfg.BlockIndexStore.DBBackend,
 			cfg.BlockIndexStore.DBName,
 			cfg.RootPath(),

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ import (
 	receipts "github.com/loomnetwork/loomchain/receipts/handler"
 	registry "github.com/loomnetwork/loomchain/registry/factory"
 	"github.com/loomnetwork/loomchain/store"
+	blockindex "github.com/loomnetwork/loomchain/store/block_index"
 	"github.com/loomnetwork/loomchain/throttle"
 	"github.com/spf13/viper"
 
@@ -98,7 +99,7 @@ type Config struct {
 	PlasmaCash *plasmacfg.PlasmaCashSerializableConfig
 	// Blockstore config
 	BlockStore      *store.BlockStoreConfig
-	BlockIndexStore *store.BlockIndexStoreConfig
+	BlockIndexStore *blockindex.BlockIndexStoreConfig
 	// Cashing store
 	CachingStoreConfig *store.CachingStoreConfig
 
@@ -395,7 +396,7 @@ func DefaultConfig() *Config {
 	cfg.DPOSv2OracleConfig = dposv2OracleCfg.DefaultConfig()
 	cfg.CachingStoreConfig = store.DefaultCachingStoreConfig()
 	cfg.BlockStore = store.DefaultBlockStoreConfig()
-	cfg.BlockIndexStore = store.DefaultBlockIndexStoreConfig()
+	cfg.BlockIndexStore = blockindex.DefaultBlockIndexStoreConfig()
 	cfg.Metrics = DefaultMetrics()
 	cfg.Karma = DefaultKarmaConfig()
 	cfg.ChainConfig = DefaultChainConfigConfig(cfg.RPCProxyPort)

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -29,6 +29,7 @@ import (
 	registry "github.com/loomnetwork/loomchain/registry/factory"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/store"
+	blockindex "github.com/loomnetwork/loomchain/store/block_index"
 	lvm "github.com/loomnetwork/loomchain/vm"
 	sha3 "github.com/miguelmota/go-solidity-sha3"
 	pubsub "github.com/phonkee/go-pubsub"
@@ -114,7 +115,7 @@ type QueryServer struct {
 	loomchain.ReceiptHandlerProvider
 	RPCListenAddress string
 	store.BlockStore
-	store.BlockIndexStore
+	blockindex.BlockIndexStore
 	EventStore store.EventStore
 	AuthCfg    *auth.Config
 }

--- a/store/block_index/store.go
+++ b/store/block_index/store.go
@@ -1,4 +1,4 @@
-package store
+package blockindex
 
 import (
 	"encoding/binary"

--- a/store/block_index/store_test.go
+++ b/store/block_index/store_test.go
@@ -1,4 +1,4 @@
-package store
+package blockindex
 
 import (
 	"os"


### PR DESCRIPTION
Currently, `BlockIndexStore` uses block hash as a key without a prefix which is not a good practice. This PR prefixes `hash` before using it as a key.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request