### PR TITLE
Karma Coin Test - Alternate Solution

### DIFF
--- a/builtin/plugins/karma/mock_state_context.go
+++ b/builtin/plugins/karma/mock_state_context.go
@@ -20,7 +20,7 @@ type FakeStateContext struct {
 func CreateFakeStateContext(state loomchain.State, reg registry.Registry, caller, address loom.Address, pluginVm vm.VM) *FakeStateContext {
 	fakeContext := plugin.CreateFakeContext(caller, address)
 	return &FakeStateContext{
-		FakeContext: *fakeContext.WithSender(caller),
+		FakeContext: *fakeContext,
 		state:       state.WithPrefix(loom.DataPrefix(address)),
 		registry:    reg,
 		VM:          pluginVm,


### PR DESCRIPTION
1)Remove usage of MockStateContext containing FakeStateContext. FakeContext is used instead.
2)Remove usage of test helpers.
Please note these files are still there, just not being used.
Now, TestKarmaCoin Code is very analogous to other module units tests which uses coin contract.
Some features that were missing earlier include specifying sender explicitly in context.
