### PR TITLE
Add evm-height and app-height cmds

### DIFF
--- a/cmd/loom/db/db.go
+++ b/cmd/loom/db/db.go
@@ -16,6 +16,8 @@ func NewDBCommand() *cobra.Command {
 		newCompactDBCommand(),
 		newDumpEVMStateCommand(),
 		newDumpEVMStateMultiWriterAppStoreCommand(),
+		newGetEvmHeightCommand(),
+		newGetAppHeightCommand(),
 	)
 	return cmd
 }


### PR DESCRIPTION
This PR adds two commands for checking db height
```
loom db app-height app.db
loom db evm-height evm.db
```

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request