### PR TITLE
Fix wrong lock type

### DIFF
--- a/eth/subs/d_reset-hub.go
+++ b/eth/subs/d_reset-hub.go
@@ -34,8 +34,8 @@ func (h *LegacyEthResetHub) CloseSubscriber(subscriber pubsub.Subscriber) {
 // Publish publishes message to subscribers
 // todo Warning this function can throw an exception
 func (h *LegacyEthResetHub) Publish(message pubsub.Message) int {
-	h.mutex.RLock()
-	defer h.mutex.RUnlock()
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
 
 	count := 0
 	// iterate over all subscribers, and publish messages


### PR DESCRIPTION
The cluster panics with `fatal error: concurrent map iteration and map write` message. After the investigation, it is found that `LegacyEthResetHub.Publish` use the wrong lock type. It uses `Mutex.RLock` to modify a hash map. It can be easily fixed by replacing `Mutex.RLock` with `Mutex.Lock`