### PR TITLE
Fix `make loom` to keep building loom with TG support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ loom: proto $(TRANSFER_GATEWAY_DIR)
 	go build $(GOFLAGS_GATEWAY) $(PKG)/cmd/$@
 
 loom-generic: proto
-	go build $(GOFLAGS) $(PKG)/cmd/$@
+	go build $(GOFLAGS) $(PKG)/cmd/loom
 
 loom-windows:
 	$(WINDOWS_BUILD_VARS) make loom

--- a/config/config.go
+++ b/config/config.go
@@ -385,18 +385,9 @@ func DefaultConfig() *Config {
 		CallEnabled:   true,
 		DPOSVersion:   1,
 	}
-	cfg.TransferGateway = &TransferGatewayConfig{
-		ContractEnabled: false,
-		Unsafe:          false,
-	}
-	cfg.LoomCoinTransferGateway = &TransferGatewayConfig{
-		ContractEnabled: false,
-		Unsafe:          false,
-	}
-	cfg.TronTransferGateway = &TransferGatewayConfig{
-		ContractEnabled: false,
-		Unsafe:          false,
-	}
+	cfg.TransferGateway = DefaultTGConfig(cfg.RPCProxyPort)
+	cfg.LoomCoinTransferGateway = DefaultLoomCoinTGConfig(cfg.RPCProxyPort)
+	cfg.TronTransferGateway = DefaultTronTGConfig(cfg.RPCProxyPort)
 	cfg.PlasmaCash = plasmacfg.DefaultConfig()
 	cfg.AppStore = store.DefaultConfig()
 	cfg.HsmConfig = hsmpv.DefaultConfig()

--- a/config/gateway_config.go
+++ b/config/gateway_config.go
@@ -8,6 +8,18 @@ import (
 
 type TransferGatewayConfig = gateway.TransferGatewayConfig
 
+func DefaultTGConfig(rpcProxyPort int32) *TransferGatewayConfig {
+	return gateway.DefaultConfig(rpcProxyPort)
+}
+
+func DefaultLoomCoinTGConfig(rpcProxyPort int32) *TransferGatewayConfig {
+	return gateway.DefaultLoomCoinTGConfig(rpcProxyPort)
+}
+
+func DefaultTronTGConfig(rpcProxyPort int32) *TransferGatewayConfig {
+	return gateway.DefaultTronConfig(rpcProxyPort)
+}
+
 const transferGatewayLoomYamlTemplate = `
 #
 # Transfer Gateway

--- a/config/no_gateway_config.go
+++ b/config/no_gateway_config.go
@@ -3,17 +3,19 @@
 package config
 
 type TransferGatewayConfig struct {
-	// Enables the Transfer Gateway Go contract on the node, must be the same on all nodes.
 	ContractEnabled bool
-	// Loads the Unsafe gateway methods
-	Unsafe bool
 }
 
-func DefaultTransferGatewayConfig(rpcProxyPort int32) *TransferGatewayConfig {
-	return &TransferGatewayConfig{
-		ContractEnabled: false,
-		Unsafe:          false,
-	}
+func DefaultTGConfig(rpcProxyPort int32) *TransferGatewayConfig {
+	return &TransferGatewayConfig{}
+}
+
+func DefaultLoomCoinTGConfig(rpcProxyPort int32) *TransferGatewayConfig {
+	return &TransferGatewayConfig{}
+}
+
+func DefaultTronTGConfig(rpcProxyPort int32) *TransferGatewayConfig {
+	return &TransferGatewayConfig{}
 }
 
 // Clone returns a deep clone of the config.


### PR DESCRIPTION
Need a non-PlasmaChain build with TG support to deploy on test clusters
and extdev, at least until the PlasmaChain build variant is repurposed.