### PR TITLE
Return txReceipts for all txHash

### DIFF
--- a/eth/query/tx.go
+++ b/eth/query/tx.go
@@ -20,6 +20,7 @@ func GetTxByHash(state loomchain.ReadOnlyState, txHash []byte, readReceipts loom
 	if err != nil {
 		return eth.GetEmptyTxObject(), errors.Wrap(err, "reading receipt")
 	}
+	to := eth.EncBytes(txReceipt.ContractAddress)
 	return eth.JsonTxObject{
 		Nonce:            eth.EncInt(txReceipt.Nonce),
 		Hash:             eth.EncBytes(txHash),
@@ -27,7 +28,7 @@ func GetTxByHash(state loomchain.ReadOnlyState, txHash []byte, readReceipts loom
 		BlockNumber:      eth.EncInt(txReceipt.BlockNumber),
 		TransactionIndex: eth.EncInt(int64(txReceipt.TransactionIndex)),
 		From:             eth.EncAddress(txReceipt.CallerAddress),
-		To:               eth.EncBytes(txReceipt.ContractAddress),
+		To:               &to,
 
 		Gas:      eth.EncInt(0),
 		GasPrice: eth.EncInt(0),

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -1123,9 +1123,9 @@ func completeReceipt(txResults *ctypes.ResultTx, blockResult *ctypes.ResultBlock
 		txReceipt.Status = StatusTxFail
 	}
 	jsonReceipt := eth.EncTxReceipt(*txReceipt)
-	if txResults.TxResult.Info == utils.CallEVM && len(jsonReceipt.To) == 0 {
+	if txResults.TxResult.Info == utils.CallEVM && (jsonReceipt.To == nil || len(*jsonReceipt.To) == 0) {
 		jsonReceipt.To = jsonReceipt.ContractAddress
-		jsonReceipt.ContractAddress = eth.Data("")
+		jsonReceipt.ContractAddress = nil
 	}
 	return jsonReceipt
 }


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request

Addresses https://github.com/loomnetwork/loomchain/issues/1157
Should also provide a fix for https://github.com/loomnetwork/loomchain/issues/1190 `eth_getTransactionReceipt`

Allows accessing receipts using both Tendermint and loom tx hashes. 
In block, inquiries will display tendermint tx hash if no loom tx hash is available, for example, if the transaction failed.
Will return a receipt if the input is a valid hash (starts `0x`) and the loomchian is ok. If the hash cannot be identified as either a loom-tx-hash or tendermint-tx-hash, an empty receipt with status ~ failed is returned.