### PR TITLE
Only write changed evm root to app.db

### DIFF
--- a/features.go
+++ b/features.go
@@ -46,4 +46,7 @@ const (
 
 	// Enables Coin v1.1 contract (also applies to ETHCoin)
 	CoinVersion1_1Feature = "coin:v1.1"
+
+	// Force MultiWriterAppStore to write EVM root to app.db only if the root changes
+	AppStoreVersion3_1 = "appstore:v3.1"
 )


### PR DESCRIPTION
Currently, `MultiWriterAppStore` writes EVM root to app.db every block commit. This causes app hash to change every block. As a result, `CreateEmptyBlocks: false` in loom.yaml does not work with AppStore version 3 anymore. To fix this problem and also improve the performance, we need to check EVM root before saving it in app.db. This change requires a feature flag to activate the change. 

There is also an on-going issue regarding this problem. https://github.com/tendermint/tendermint/issues/1909

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request