### PR TITLE
[WIP] Gradually delete vm keys

### DIFF
--- a/cmd/loom/db/evm.go
+++ b/cmd/loom/db/evm.go
@@ -175,7 +175,7 @@ func newDumpEVMStateMultiWriterAppStoreCommand() *cobra.Command {
 				return err
 			}
 
-			appStore, err := store.NewMultiWriterAppStore(iavlStore, evmStore, false)
+			appStore, err := store.NewMultiWriterAppStore(iavlStore, evmStore, false, cfg.AppStore.DeletedVMKeysPerBlock)
 			if err != nil {
 				return err
 			}

--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -640,7 +640,9 @@ func loadAppStore(cfg *config.Config, logger *loom.Logger, targetVersion int64) 
 		if err != nil {
 			return nil, err
 		}
-		appStore, err = store.NewMultiWriterAppStore(iavlStore, evmStore, cfg.AppStore.SaveEVMStateToIAVL)
+		appStore, err = store.NewMultiWriterAppStore(
+			iavlStore, evmStore, cfg.AppStore.SaveEVMStateToIAVL, cfg.AppStore.DeletedVMKeysPerBlock,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -715,6 +715,8 @@ AppStore:
   # If true the app store will write EVM state to both IAVLStore and EvmStore
   # This config works with AppStore Version 3 (MultiWriterAppStore) only
   SaveEVMStateToIAVL: {{ .AppStore.SaveEVMStateToIAVL }}
+  # Number of VM keys deleted per block
+  DeletedVMKeysPerBlock: {{ .AppStore.DeletedVMKeysPerBlock }}
 {{if .EventStore -}}
 #
 # EventStore

--- a/store/config.go
+++ b/store/config.go
@@ -27,21 +27,24 @@ type AppStoreConfig struct {
 	// If true the app store will write EVM state to both IAVLStore and EvmStore
 	// This config works with AppStore Version 3 (MultiWriterAppStore) only
 	SaveEVMStateToIAVL bool
+	// Number of VM keys deleted per block
+	DeletedVMKeysPerBlock int
 }
 
 func DefaultConfig() *AppStoreConfig {
 	return &AppStoreConfig{
-		Version:              3,
-		CompactOnLoad:        false,
-		MaxVersions:          0,
-		PruneInterval:        0,
-		PruneBatchSize:       50,
-		LatestStateDBBackend: "goleveldb",
-		LatestStateDBName:    "app_state",
-		NodeDBVersion:        NodeDBV1,
-		NodeCacheSize:        10000,
-		SnapshotVersion:      MultiReaderIAVLStoreSnapshotV1,
-		SaveEVMStateToIAVL:   false,
+		Version:               3,
+		CompactOnLoad:         false,
+		MaxVersions:           0,
+		PruneInterval:         0,
+		PruneBatchSize:        50,
+		LatestStateDBBackend:  "goleveldb",
+		LatestStateDBName:     "app_state",
+		NodeDBVersion:         NodeDBV1,
+		NodeCacheSize:         10000,
+		SnapshotVersion:       MultiReaderIAVLStoreSnapshotV1,
+		SaveEVMStateToIAVL:    false,
+		DeletedVMKeysPerBlock: 1000,
 	}
 }
 

--- a/store/multi_writer_app_store_test.go
+++ b/store/multi_writer_app_store_test.go
@@ -222,7 +222,7 @@ func mockMultiWriterStore() (*MultiWriterAppStore, error) {
 	}
 	memDb, _ = db.LoadMemDB()
 	evmStore := NewEvmStore(memDb, 100)
-	multiWriterStore, err := NewMultiWriterAppStore(iavlStore, evmStore, false)
+	multiWriterStore, err := NewMultiWriterAppStore(iavlStore, evmStore, false, 1000)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, EVM state has been moved out of app.db to evm.db but the keys have not been deleted yet. To further improve PlasmaChain performance, we should gradually remove VM keys from app.db. This PR gradually removes vm keys in every block commit. The number of deleted keys in each block must be carefully determined because too many delete operations could degrade chain performance. A feature flag (AppStore 3.1) might be used to activate this behavior.

Rref: https://github.com/loomnetwork/loomchain/issues/1178

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request