### PR TITLE
Move DPOSv2 Oracle from loomchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ TRANSFER_GATEWAY_DIR=$(GOPATH)/src/$(PKG_TRANSFER_GATEWAY)
 #       specific commit.
 GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
-TG_GIT_REV = move-dpos-oracle
+TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch
 ETHEREUM_GIT_REV = 1fb6138d017a4309105d91f187c126cf979c93f9
 # use go-plugin we get 'timeout waiting for connection info' error


### PR DESCRIPTION
Also the in-process mode of the DPOSv2 Oracle has been removed to simplify things a bit.