### PR TITLE
Tests illustrating DPOSv2 bugs

### DIFF
--- a/builtin/plugins/dposv2/dpos_test.go
+++ b/builtin/plugins/dposv2/dpos_test.go
@@ -2438,12 +2438,12 @@ func TestDedoublingDelegation(t *testing.T) {
 
 // after we migrate we want to have all delegations that were in plasma-* nodes, on plasma-0
 func TestPlasmaDelegationMigration(t *testing.T) {
-	expectedValidator := plasmaValidators[0]
+	expectedValidator := PlasmaValidators[0]
 	someDelegator := loom.MustParseAddress("default:0xDc93E46f6d22D47De9D7E6d26ce8c3b7A13d89Cb")
 	someAmount := types.BigUInt{Value: *loom.NewBigUIntFromInt(100)}
 
 	// check that all plasma validators get reset to plasma-0
-	for _, v := range plasmaValidators {
+	for _, v := range PlasmaValidators {
 		migratedDelegation := Delegation{
 			Validator: v.MarshalPB(),
 			Delegator: someDelegator.MarshalPB(),
@@ -2462,6 +2462,101 @@ func TestPlasmaDelegationMigration(t *testing.T) {
 	}
 	migratedValidator := adjustValidatorIfInPlasmaValidators(migratedDelegationWithoutChange)
 	assert.True(t, migratedValidator.Local.Compare(someValidator.Local) == 0)
+}
+
+// On line: https://github.com/loomnetwork/loomchain/blob/e70bf8c95bd262dc0f2f838682756c2a1e184696/builtin/plugins/dposv2/dpos.go#L2364,
+// the function creates indices for storing index counter
+// with a unique key combined of validator and delegator addresses.
+// If the validator of delegation is plasma validator, it will set
+// validator to `plasma-0`. This causes the issue. If a user has multiple
+// plasma-x delegations, he or she will end up having multiple
+// plasma-0 delegations with the same index 1 during the migration
+// and when the `initializationState` is set, some delegations
+// will get lost.
+func TestPlasmaDuplicatesLostBug(t *testing.T) {
+	pctx := plugin.CreateFakeContext(addr1, addr1)
+
+	// Deploy the coin contract (DPOS Init() will attempt to resolve it)
+	coinContract := &coin.Coin{}
+	coinAddr := pctx.CreateContract(coin.Contract)
+	coinCtx := pctx.WithAddress(coinAddr)
+	coinContract.Init(contractpb.WrapPluginContext(coinCtx), &coin.InitRequest{
+		Accounts: []*coin.InitialAccount{
+			makeAccount(delegatorAddress1, 1000000000000000000),
+			makeAccount(PlasmaValidators[0], 1000000000000000000),
+			makeAccount(PlasmaValidators[1], 1000000000000000000),
+			makeAccount(PlasmaValidators[2], 1000000000000000000),
+			makeAccount(PlasmaValidators[3], 1000000000000000000),
+			makeAccount(PlasmaValidators[4], 1000000000000000000),
+			makeAccount(PlasmaValidators[5], 1000000000000000000),
+		},
+	})
+
+	registrationFee := loom.BigZeroPB()
+
+	dposContract := &DPOS{}
+	dposAddr := pctx.CreateContract(contractpb.MakePluginContract(dposContract))
+	dposCtx := pctx.WithAddress(dposAddr)
+	err := dposContract.Init(contractpb.WrapPluginContext(dposCtx.WithSender(addr1)), &InitRequest{
+		Params: &Params{
+			ValidatorCount:          21,
+			RegistrationRequirement: registrationFee,
+		},
+	})
+	require.NoError(t, err)
+
+	// Registering 5 plasma candidates
+	for i, _ := range PlasmaValidators {
+		err = coinContract.Approve(contractpb.WrapPluginContext(coinCtx.WithSender(PlasmaValidators[i])), &coin.ApproveRequest{
+			Spender: dposAddr.MarshalPB(),
+			Amount:  registrationFee,
+		})
+
+		err = dposContract.RegisterCandidate2(contractpb.WrapPluginContext(dposCtx.WithSender(PlasmaValidators[i])), &RegisterCandidateRequest{
+			PubKey: PlasmaPubKeys[i],
+		})
+		require.Nil(t, err)
+	}
+
+	err = Elect(contractpb.WrapPluginContext(dposCtx))
+	require.Nil(t, err)
+
+	// We'll make 1 delegation to each of the validators
+	delegationAmount := loom.NewBigUIntFromInt(10000000)
+	totalAmount := loom.NewBigUIntFromInt(60000000)
+	err = coinContract.Approve(contractpb.WrapPluginContext(coinCtx.WithSender(delegatorAddress1)), &coin.ApproveRequest{
+		Spender: dposAddr.MarshalPB(),
+		Amount:  &types.BigUInt{Value: *totalAmount},
+	})
+
+	for i, _ := range PlasmaValidators {
+		err = dposContract.Delegate2(contractpb.WrapPluginContext(dposCtx.WithSender(delegatorAddress1)), &DelegateRequest{
+			ValidatorAddress: PlasmaValidators[i].MarshalPB(),
+			Amount:           &types.BigUInt{Value: *delegationAmount},
+		})
+		require.Nil(t, err)
+	}
+
+	err = Elect(contractpb.WrapPluginContext(dposCtx))
+	require.Nil(t, err)
+
+	// Then we'll inspect the post initialization state and notice
+	// that we have multiple delegations with the same index
+	data, err := dposContract.ViewStateDump(
+		contractpb.WrapPluginContext(dposCtx),
+		&ViewStateDumpRequest{},
+	)
+
+	newDelegations := data.NewState.Delegations
+	for i, _ := range newDelegations {
+		localVal := loom.LocalAddressFromPublicKey(PlasmaPubKeys[0])
+		assert.True(t, newDelegations[i].Validator.Local.Compare(localVal) == 0)
+		// THIS is the bug. If it were implemented properly,
+		// we'd have all delegations to plasma-0, but their index would be 1-7
+		// instead of all 1's. When the migration executes, only 1 is applied
+		// since they all have the same index.
+		assert.Equal(t, newDelegations[i].Index, uint64(1))
+	}
 }
 
 // UTILITIES

--- a/builtin/plugins/dposv2/util.go
+++ b/builtin/plugins/dposv2/util.go
@@ -3,6 +3,7 @@ package dposv2
 import (
 	"math/big"
 
+	"encoding/base64"
 	loom "github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/common"
 	contract "github.com/loomnetwork/go-loom/plugin/contractpb"
@@ -14,7 +15,7 @@ import (
 const billionthsBasisPointRatio = 100000
 
 var (
-	plasmaValidators = []loom.Address{
+	PlasmaValidators = []loom.Address{
 		loom.MustParseAddress("default:0x0e99fc16e32e568971908f2ce54b967a42663a26"), // plasma-0
 		loom.MustParseAddress("default:0xac3211caecc45940a6d2ba006ca465a647d8464f"), // plasma-1
 		loom.MustParseAddress("default:0x69c48768dbac492908161be787b7a5658192df35"), // plasma-2
@@ -22,6 +23,21 @@ var (
 		loom.MustParseAddress("default:0x4a1b8b15e50ce63cc6f65603ea79be09206cae70"), // plasma-4
 		loom.MustParseAddress("default:0x0ce7b61c97a6d5083356f115288f9266553e191e"), // plasma-5
 	}
+	plasma_0, _   = base64.StdEncoding.DecodeString("tjiLc0c2cbcDFjz/aW1j+r39sNsDwMLP1aO6UQhXvuk=")
+	plasma_1, _   = base64.StdEncoding.DecodeString("0SiG28GKnzTH4B/gQMpSVr/r7BfobB+sKzmP+X50g0o=")
+	plasma_2, _   = base64.StdEncoding.DecodeString("fSUZhwy4iYKi4MTnlqIvqRcjiYI+sQrbTcVnUMSnM9E=")
+	plasma_3, _   = base64.StdEncoding.DecodeString("7e9iIJRppRs2u9RWZchLFbVvh/UXSus8sez1923gdyU=")
+	plasma_4, _   = base64.StdEncoding.DecodeString("HnV3NSK2+ywytglQLhso8VdBCkGdFdhVqJ8ggT9VF8k=")
+	plasma_5, _   = base64.StdEncoding.DecodeString("ycMgCVxkI9tRxfv3jElE4tTOI2AYJssglkGNZnda9xc=")
+	PlasmaPubKeys = [][]byte{
+		plasma_0,
+		plasma_1,
+		plasma_2,
+		plasma_3,
+		plasma_4,
+		plasma_5,
+	}
+
 	doubledDelegator = loom.MustParseAddress("default:0xDc93E46f6d22D47De9D7E6d26ce8c3b7A13d89Cb")
 	doubledValidator = loom.MustParseAddress("default:0xa38c27e8cf4a443e805065065aefb250b1e1cef2")
 	basisPoints      = loom.BigUInt{big.NewInt(1e4)} // do not change
@@ -52,9 +68,9 @@ var TierBonusMap = map[LocktimeTier]loom.BigUInt{
 /// If the validator is one of the plasma nodes, it sets it to plasma-0
 func adjustValidatorIfInPlasmaValidators(delegation Delegation) *types.Address {
 	validator := delegation.Validator
-	for _, plasmaValidator := range plasmaValidators {
+	for _, plasmaValidator := range PlasmaValidators {
 		if validator.Local.Compare(plasmaValidator.Local) == 0 {
-			return plasmaValidators[0].MarshalPB()
+			return PlasmaValidators[0].MarshalPB()
 		}
 	}
 	return validator


### PR DESCRIPTION
This PR adds 2 tests illustrating the bugs found on DposV2 -- these are not present on the currently runnning v3.

## Migration: 
On line: https://github.com/loomnetwork/loomchain/blob/e70bf8c95bd262dc0f2f838682756c2a1e184696/builtin/plugins/dposv2/dpos.go#L2364, the function creates indices for storing index counter with a unique key combined of validator and delegator addresses. If the validator of delegation is plasma validator, it will set validator to . This causes the issue. If a user has multiple plasma-x delegations, he or she will end up having multiple plasma-0 delegations with the same index 1 during the migration and when the migration is done, some delegations will get lost.

## Redelegate
Suppose a user has two delegations on validator A and validator B, and he redelegates less than full amount from validator B to validator A, the delegation amount on validator A will get overwritten by the new delegation amount.


Both were found by @pathornteng 