### PR TITLE
DowntimeRecord returns all validators downtime records 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ TRANSFER_GATEWAY_DIR=$(GOPATH)/src/$(PKG_TRANSFER_GATEWAY)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = eb3c024026cc6997c24bd5d5bd986bff7b14e1be
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ TRANSFER_GATEWAY_DIR=$(GOPATH)/src/$(PKG_TRANSFER_GATEWAY)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = eb3c024026cc6997c24bd5d5bd986bff7b14e1be
+GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/builtin/plugins/dposv3/dpos_test.go
+++ b/builtin/plugins/dposv3/dpos_test.go
@@ -2397,7 +2397,6 @@ func TestDowntimeFunctions(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-
 	err = dpos.RegisterCandidate(pctx.WithSender(addr1), pubKey1, nil, nil, nil, nil, nil, nil)
 	require.Nil(t, err)
 	err = dpos.RegisterCandidate(pctx.WithSender(addr2), pubKey2, nil, nil, nil, nil, nil, nil)
@@ -2409,7 +2408,7 @@ func TestDowntimeFunctions(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 2, len(candidates))
 
-	for i := int64(0); i < int64(periodLength * 4); i++ {
+	for i := int64(0); i < int64(periodLength*4); i++ {
 		UpdateDowntimeRecord(contractpb.WrapPluginContext(dposCtx), addr1)
 		require.Nil(t, err)
 		ShiftDowntimeWindow(contractpb.WrapPluginContext(dposCtx), i, candidates)
@@ -2417,10 +2416,10 @@ func TestDowntimeFunctions(t *testing.T) {
 
 	rec1, err := dpos.DowntimeRecord(pctx, &addr1)
 	assert.Equal(t, periodLength, rec1.PeriodLength)
-	assert.Equal(t, []uint64{periodLength-1, periodLength, periodLength, periodLength}, rec1.Periods)
+	assert.Equal(t, []uint64{periodLength - 1, periodLength, periodLength, periodLength}, rec1.DowntimeRecords[0].Periods)
 	rec2, err := dpos.DowntimeRecord(pctx, &addr2)
 	assert.Equal(t, periodLength, rec2.PeriodLength)
-	assert.Equal(t, []uint64{0,0,0,0}, rec2.Periods)
+	assert.Equal(t, []uint64{0, 0, 0, 0}, rec2.DowntimeRecords[0].Periods)
 
 	for i := int64(0); i < int64(periodLength); i++ {
 		UpdateDowntimeRecord(contractpb.WrapPluginContext(dposCtx), addr2)
@@ -2429,23 +2428,26 @@ func TestDowntimeFunctions(t *testing.T) {
 	}
 
 	rec1, err = dpos.DowntimeRecord(pctx, &addr1)
-	assert.Equal(t, []uint64{0, periodLength-1, periodLength, periodLength}, rec1.Periods)
+	assert.Equal(t, []uint64{0, periodLength - 1, periodLength, periodLength}, rec1.DowntimeRecords[0].Periods)
 	rec2, err = dpos.DowntimeRecord(pctx, &addr2)
-	assert.Equal(t, []uint64{periodLength-1,1,0,0}, rec2.Periods)
+	assert.Equal(t, []uint64{periodLength - 1, 1, 0, 0}, rec2.DowntimeRecords[0].Periods)
 
 	ShiftDowntimeWindow(contractpb.WrapPluginContext(dposCtx), 0, candidates)
 
 	rec1, err = dpos.DowntimeRecord(pctx, &addr1)
-	assert.Equal(t, []uint64{0, 0, periodLength-1, periodLength}, rec1.Periods)
+	assert.Equal(t, []uint64{0, 0, periodLength - 1, periodLength}, rec1.DowntimeRecords[0].Periods)
 	rec2, err = dpos.DowntimeRecord(pctx, &addr2)
-	assert.Equal(t, []uint64{0, periodLength-1, 1, 0}, rec2.Periods)
+	assert.Equal(t, []uint64{0, periodLength - 1, 1, 0}, rec2.DowntimeRecords[0].Periods)
 
 	ShiftDowntimeWindow(contractpb.WrapPluginContext(dposCtx), 0, candidates)
 
 	rec1, err = dpos.DowntimeRecord(pctx, &addr1)
-	assert.Equal(t, []uint64{0, 0, 0, periodLength-1}, rec1.Periods)
+	assert.Equal(t, []uint64{0, 0, 0, periodLength - 1}, rec1.DowntimeRecords[0].Periods)
 	rec2, err = dpos.DowntimeRecord(pctx, &addr2)
-	assert.Equal(t, []uint64{0, 0, periodLength-1, 1}, rec2.Periods)
+	assert.Equal(t, []uint64{0, 0, periodLength - 1, 1}, rec2.DowntimeRecords[0].Periods)
+
+	recAll, err := dpos.DowntimeRecord(pctx, nil)
+	assert.Equal(t, 2, len(recAll.DowntimeRecords))
 }
 
 // UTILITIES

--- a/builtin/plugins/dposv3/test_helpers.go
+++ b/builtin/plugins/dposv3/test_helpers.go
@@ -112,10 +112,14 @@ func (dpos *testDPOSContract) CheckDelegation(ctx *plugin.FakeContext, validator
 }
 
 func (dpos *testDPOSContract) DowntimeRecord(ctx *plugin.FakeContext, validator *loom.Address) (*DowntimeRecordResponse, error) {
+	var validatorAddr *types.Address
+	if validator != nil {
+		validatorAddr = validator.MarshalPB()
+	}
 	resp, err := dpos.Contract.DowntimeRecord(
 		contract.WrapPluginContext(ctx.WithAddress(dpos.Address)),
 		&DowntimeRecordRequest{
-			Validator: validator.MarshalPB(),
+			Validator: validatorAddr,
 		},
 	)
 	if err != nil {

--- a/cmd/loom/dposV3_commands.go
+++ b/cmd/loom/dposV3_commands.go
@@ -478,18 +478,22 @@ func DowntimeRecordCmdV3() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "downtime-record [validator address]",
 		Short: "check a validator's downtime record",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			validatorAddress, err := cli.ParseAddress(args[0], flags.ChainID)
-			if err != nil {
-				return err
+			var validatorAddress *types.Address
+			if len(args) > 0 {
+				address, err := cli.ParseAddress(args[0], flags.ChainID)
+				if err != nil {
+					return err
+				}
+				validatorAddress = address.MarshalPB()
 			}
 
 			var resp dposv3.DowntimeRecordResponse
-			err = cli.StaticCallContractWithFlags(
+			err := cli.StaticCallContractWithFlags(
 				&flags, DPOSV3ContractName, "DowntimeRecord",
 				&dposv3.DowntimeRecordRequest{
-					Validator: validatorAddress.MarshalPB(),
+					Validator: validatorAddress,
 				}, &resp,
 			)
 			if err != nil {

--- a/e2e/dpos-downtime.toml
+++ b/e2e/dpos-downtime.toml
@@ -105,6 +105,11 @@
   Condition = "contains"
   Expected = ["periods"]
 
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} dpos3 downtime-record"
+  Condition = "contains"
+  Expected = ["periods"]
+
 # Attempting to do dPoS transaction with only 2 of 3 elected validators online
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} coin approve dposV3 200000 -k {{index $.AccountPrivKeyPathList 1}}"


### PR DESCRIPTION
Currently, a validator address is required to call `dposv3.DowntimeRecord`. This PR makes the method return all validator downtime records if the validator address is not specified.

- [x] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request