### PR TITLE
Load the UserDeployerWhitelist contract by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -259,7 +259,7 @@ func DefaultDeployerWhitelistConfig() *DeployerWhitelistConfig {
 
 func DefaultUserDeployerWhitelistConfig() *UserDeployerWhitelistConfig {
 	return &UserDeployerWhitelistConfig{
-		ContractEnabled: false,
+		ContractEnabled: true,
 	}
 }
 


### PR DESCRIPTION
This makes it easier to deploy the contract to the production cluster
because validators won't have to muck about with loom.yml.