### PR TITLE
Split Hsm config out of loom.yml

### DIFF
--- a/cmd/loom/common/config.go
+++ b/cmd/loom/common/config.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"log"
 	"path/filepath"
 
 	"github.com/loomnetwork/loomchain/config"
@@ -12,17 +13,24 @@ func ParseConfig() (*config.Config, error) {
 	v := viper.New()
 	v.AutomaticEnv()
 	v.SetEnvPrefix("LOOM")
+	PasreConfigFileName("loom", v)
+	PasreConfigFileName("loom_hsm", v) // load hsm config if loom_hsm.yaml  exist
 
-	v.SetConfigName("loom")                       // name of config file (without extension)
-	v.AddConfigPath(".")                          // search root directory
-	v.AddConfigPath(filepath.Join(".", "config")) // search root directory /config
-	v.AddConfigPath("./../../../")
-
-	v.ReadInConfig()
 	conf := config.DefaultConfig()
 	err := v.Unmarshal(conf)
 	if err != nil {
 		return nil, err
 	}
 	return conf, err
+}
+
+func PasreConfigFileName(name string, v *viper.Viper) {
+
+	v.SetConfigName(name)                         // name of config file (without extension)
+	v.AddConfigPath(".")                          // search root directory
+	v.AddConfigPath(filepath.Join(".", "config")) // search root directory /config
+	v.AddConfigPath("./../../../")
+	if err := v.ReadInConfig(); err != nil {
+		log.Fatalf("Error reading config file, %s", err)
+	}
 }

--- a/cmd/loom/common/config_test.go
+++ b/cmd/loom/common/config_test.go
@@ -1,0 +1,23 @@
+package common
+
+import (
+	"os"
+	"testing"
+
+	"github.com/loomnetwork/loomchain/config"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	exampleHsm = "loom_hsm_test"
+)
+
+func TestParseConfigFileName(t *testing.T) {
+	conf_hsm := config.DefaultConfig()
+	conf_hsm.WriteToFile(exampleHsm + ".yaml")
+	v_actual := viper.New()
+	PasreConfigFileName(exampleHsm, v_actual)
+	assert.Equal(t, conf_hsm.HsmConfig.HsmDevType, v_actual.GetString("HsmConfig.HsmDevType"))
+	_ = os.Remove(exampleHsm + ".yaml")
+}


### PR DESCRIPTION
Added function and test ParseConfigFileName for specify configuration file.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request