### PR TITLE
Manually set objectives Prometheus metrics

### DIFF
--- a/app.go
+++ b/app.go
@@ -304,23 +304,26 @@ func init() {
 		Help:      "Number of requests received.",
 	}, fieldKeys)
 	deliverTxLatency = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "application",
-		Name:      "delivertx_latency_microseconds",
-		Help:      "Total duration of delivertx in microseconds.",
+		Namespace:  "loomchain",
+		Subsystem:  "application",
+		Name:       "delivertx_latency_microseconds",
+		Help:       "Total duration of delivertx in microseconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, []string{"method", "error", "evm"})
 
 	checkTxLatency = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "application",
-		Name:      "checktx_latency_microseconds",
-		Help:      "Total duration of checktx in microseconds.",
+		Namespace:  "loomchain",
+		Subsystem:  "application",
+		Name:       "checktx_latency_microseconds",
+		Help:       "Total duration of checktx in microseconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, fieldKeys)
 	commitBlockLatency = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "application",
-		Name:      "commit_block_latency_microseconds",
-		Help:      "Total duration of commit block in microseconds.",
+		Namespace:  "loomchain",
+		Subsystem:  "application",
+		Name:       "commit_block_latency_microseconds",
+		Help:       "Total duration of commit block in microseconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, fieldKeys)
 
 	committedBlockCount = kitprometheus.NewCounterFrom(stdprometheus.CounterOpts{
@@ -331,10 +334,11 @@ func init() {
 	}, fieldKeys)
 
 	validatorFuncLatency = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "application",
-		Name:      "validator_election_latency",
-		Help:      "Total duration of validator election in seconds.",
+		Namespace:  "loomchain",
+		Subsystem:  "application",
+		Name:       "validator_election_latency",
+		Help:       "Total duration of validator election in seconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, []string{})
 }
 

--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -1185,10 +1185,11 @@ func initQueryService(
 		Help:      "Number of requests received.",
 	}, fieldKeys)
 	requestLatency := kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "query_service",
-		Name:      "request_latency_microseconds",
-		Help:      "Total duration of requests in microseconds.",
+		Namespace:  "loomchain",
+		Subsystem:  "query_service",
+		Name:       "request_latency_microseconds",
+		Help:       "Total duration of requests in microseconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, fieldKeys)
 
 	regVer, err := registry.RegistryVersionFromInt(cfg.RegistryVersion)

--- a/event.go
+++ b/event.go
@@ -133,10 +133,11 @@ func NewInstrumentingEventHandler(handler EventHandler) EventHandler {
 	// initialize metrics
 	fieldKeys := []string{"method", "error"}
 	methodDuration := kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "event_handler",
-		Name:      "method_duration",
-		Help:      "Total duration of requests in seconds.",
+		Namespace:  "loomchain",
+		Subsystem:  "event_handler",
+		Name:       "method_duration",
+		Help:       "Total duration of requests in seconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, fieldKeys)
 
 	return &InstrumentingEventHandler{

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -44,16 +44,18 @@ func init() {
 		Help:      "Number of evm transactions received.",
 	}, fieldKeys)
 	txLatency = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "application",
-		Name:      "evmtx_latency_microseconds",
-		Help:      "Total duration of go-ethereum EVM tx in microseconds.",
+		Namespace:  "loomchain",
+		Subsystem:  "application",
+		Name:       "evmtx_latency_microseconds",
+		Help:       "Total duration of go-ethereum EVM tx in microseconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, fieldKeys)
 	txGas = kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "application",
-		Name:      "evm_tx_gas_cost",
-		Help:      "Gas cost of EVM transaction.",
+		Namespace:  "loomchain",
+		Subsystem:  "application",
+		Name:       "evm_tx_gas_cost",
+		Help:       "Gas cost of EVM transaction.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, fieldKeys)
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -144,10 +144,11 @@ func NewInstrumentingTxMiddleware() TxMiddleware {
 		Help:      "Number of requests received.",
 	}, fieldKeys)
 	requestLatency := kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "tx_service",
-		Name:      "request_latency_microseconds",
-		Help:      "Total duration of requests in microseconds.",
+		Namespace:  "loomchain",
+		Subsystem:  "tx_service",
+		Name:       "request_latency_microseconds",
+		Help:       "Total duration of requests in microseconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, fieldKeys)
 
 	return &InstrumentingTxMiddleware{

--- a/rpc/query_server_test.go
+++ b/rpc/query_server_test.go
@@ -227,10 +227,11 @@ func testQueryMetric(t *testing.T) {
 		Help:      "Number of requests received.",
 	}, fieldKeys)
 	requestLatency := kitprometheus.NewSummaryFrom(stdprometheus.SummaryOpts{
-		Namespace: "loomchain",
-		Subsystem: "query_service",
-		Name:      "request_latency_microseconds",
-		Help:      "Total duration of requests in microseconds.",
+		Namespace:  "loomchain",
+		Subsystem:  "query_service",
+		Name:       "request_latency_microseconds",
+		Help:       "Total duration of requests in microseconds.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	}, fieldKeys)
 
 	loader := &queryableContractLoader{TMLogger: llog.Root.With("module", "contract")}

--- a/store/cachingstore.go
+++ b/store/cachingstore.go
@@ -64,34 +64,38 @@ func init() {
 
 	getDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "get",
-			Help:      "How long CachingStore.Get() took to execute (in miliseconds)",
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "get",
+			Help:       "How long CachingStore.Get() took to execute (in miliseconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{"error", "isCacheHit"})
 
 	hasDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "has",
-			Help:      "How long CachingStore.Has() took to execute (in miliseconds)",
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "has",
+			Help:       "How long CachingStore.Has() took to execute (in miliseconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{"error", "isCacheHit"})
 
 	deleteDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "delete",
-			Help:      "How long CachingStore.Delete() took to execute (in miliseconds)",
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "delete",
+			Help:       "How long CachingStore.Delete() took to execute (in miliseconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{"error"})
 
 	setDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "set",
-			Help:      "How long CachingStore.Set() took to execute (in miliseconds)",
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "set",
+			Help:       "How long CachingStore.Set() took to execute (in miliseconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{"error"})
 
 	cacheHits = kitprometheus.NewCounterFrom(

--- a/store/evmstore.go
+++ b/store/evmstore.go
@@ -26,10 +26,11 @@ var (
 func init() {
 	commitDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: "loomchain",
-			Subsystem: "evmstore",
-			Name:      "commit",
-			Help:      "How long EvmStore.Commit() took to execute (in seconds)",
+			Namespace:  "loomchain",
+			Subsystem:  "evmstore",
+			Name:       "commit",
+			Help:       "How long EvmStore.Commit() took to execute (in seconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{},
 	)
 }

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -26,18 +26,20 @@ func init() {
 
 	pruneTime = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "prune_duration",
-			Help:      "How long IAVLStore.Prune() took to execute (in seconds)",
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "prune_duration",
+			Help:       "How long IAVLStore.Prune() took to execute (in seconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{"error"},
 	)
 	iavlSaveVersionDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "save_version",
-			Help:      "How long IAVLStore.SaveVersion() took to execute (in seconds)",
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "save_version",
+			Help:       "How long IAVLStore.SaveVersion() took to execute (in seconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{},
 	)
 }

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -38,19 +38,21 @@ var (
 func init() {
 	saveVersionDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: "loomchain",
-			Subsystem: "multi_writer_appstore",
-			Name:      "save_version",
-			Help:      "How long MultiWriterAppStore.SaveVersion() took to execute (in seconds)",
+			Namespace:  "loomchain",
+			Subsystem:  "multi_writer_appstore",
+			Name:       "save_version",
+			Help:       "How long MultiWriterAppStore.SaveVersion() took to execute (in seconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{},
 	)
 
 	getSnapshotDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: "loomchain",
-			Subsystem: "multi_writer_appstore",
-			Name:      "get_snapshot",
-			Help:      "How long MultiWriterAppStore.GetSnapshot() took to execute (in seconds)",
+			Namespace:  "loomchain",
+			Subsystem:  "multi_writer_appstore",
+			Name:       "get_snapshot",
+			Help:       "How long MultiWriterAppStore.GetSnapshot() took to execute (in seconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{},
 	)
 }

--- a/store/pruning_iavlstore.go
+++ b/store/pruning_iavlstore.go
@@ -27,17 +27,19 @@ func init() {
 
 	pruneDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "prune_duration",
-			Help:      "How long PruningIAVLStore.prune() took to execute (in seconds)",
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "prune_duration",
+			Help:       "How long PruningIAVLStore.prune() took to execute (in seconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{"error"})
 	deleteVersionDuration = kitprometheus.NewSummaryFrom(
 		stdprometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "delete_version_duration",
-			Help:      "How long it took to delete a single version from the IAVL store (in seconds)",
+			Namespace:  namespace,
+			Subsystem:  subsystem,
+			Name:       "delete_version_duration",
+			Help:       "How long it took to delete a single version from the IAVL store (in seconds)",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{"error"})
 }
 


### PR DESCRIPTION
Prometheus client just released version 1.0.0 on 15 June 2019 which removed default objectives from default summary. So we are required to set objectives manually or the metrics won't show up.

This PR set default objectives for all metrics that use `SummaryOpts`

Ref: https://github.com/prometheus/client_golang/blob/505041cff1d2b843800a4f384694dcf62fb3e69c/CHANGELOG.md

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request