### PR TITLE
Fix flaky jailing validator e2e test

### DIFF
--- a/e2e/dpos-jail-validator.toml
+++ b/e2e/dpos-jail-validator.toml
@@ -77,8 +77,11 @@
   Condition = "contains"
   Expected = [""]
 
+# Send a tx to increase block height
 [[TestCases]]
-  Delay = 2000
+  RunCmd = "{{ $.LoomPath }} coin approve dposV3 10 -k {{index $.NodePrivKeyPathList 2}}"
+
+[[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-candidates"
   Condition = "excludes"
   Excluded = ["jailed\": true"]

--- a/e2e/dpos-jail-validator.toml
+++ b/e2e/dpos-jail-validator.toml
@@ -77,11 +77,15 @@
   Condition = "contains"
   Expected = [""]
 
-# Send a tx to increase block height
+# Send txs to increase block height
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} coin approve dposV3 10 -k {{index $.NodePrivKeyPathList 2}}"
 
 [[TestCases]]
+  RunCmd = "{{ $.LoomPath }} coin approve dposV3 10 -k {{index $.NodePrivKeyPathList 2}}"
+
+[[TestCases]]
+  Delay = 2000
   RunCmd = "{{ $.LoomPath }} dpos3 list-candidates"
   Condition = "excludes"
   Excluded = ["jailed\": true"]


### PR DESCRIPTION
Currently, `dpos-jail-validator` test is flaky. I am suspecting that the list-candidates request is sent to the cluster before the block height increases so the cluster returns a snapshot of the previous block. This PR fixes the problem by sending a tx to increase block height before querying the candidate list. 

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request