### PR TITLE
Wait the offline node to start before unjailing it

### DIFF
--- a/e2e/dpos-jail-validator.toml
+++ b/e2e/dpos-jail-validator.toml
@@ -58,19 +58,32 @@
   Condition = "contains"
   Expected = ["chainId\": \"default"]
 
+# kill node 1 for 15s, it should be jailed after going offline for 15s
 [[TestCases]]
-  RunCmd = "kill_and_restart_node 10 1"
+  RunCmd = "kill_and_restart_node 15 1"
 
+# wait node 1 to start, maximum time is 30s
 [[TestCases]]
-  Delay = 17000
+  RunCmd = "wait_node_to_start 1 30"
+
+# add some delay so that downtime periods of node 1 are cleared out
+[[TestCases]]
+  Delay = 10000
   RunCmd = "{{ $.LoomPath }} dpos3 downtime-record {{index $.NodeAddressList 1}}"
   Condition = "contains"
   Expected = ["periods"]
 
+# check if node 1 is jailed
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-candidates"
   Condition = "contains"
   Expected = ["jailed\": true"]
+
+# check downtime periods, it should be cleared out
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} dpos3 downtime-record {{index $.NodeAddressList 1}}"
+  Condition = "contains"
+  Expected = ["periods"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 unjail-validator -k {{index $.NodePrivKeyPathList 1}}"

--- a/e2e/engine/cmd.go
+++ b/e2e/engine/cmd.go
@@ -220,8 +220,7 @@ func (e *engineCmd) Run(ctx context.Context, eventC chan *node.Event) error {
 								nodeStarted = true
 								break
 							}
-							time.Sleep(time.Duration(1) * time.Second)
-
+							time.Sleep(time.Duration(time.Second))
 						}
 						if !nodeStarted {
 							return fmt.Errorf("node %s did not start", cmd.Args[1])


### PR DESCRIPTION
Jailing offline validator e2e test is still flaky. I am suspecting that the offline node has not started and downtime periods are not cleared out before we unjail it. As a result, the node is jailed again immediately after it is unjailed. 

The test depends on `Delay` which is not reliable. This PR implements `wait_node_to_start` command that makes the test wait until the offline node has started and downtime periods have been cleared out before unjailing the offline node.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request