### PR TITLE
eth_getTransactionReceipt logs returning caller rather than contract in address field

### DIFF
--- a/rpc/eth/jsonrpc_conversion.go
+++ b/rpc/eth/jsonrpc_conversion.go
@@ -174,7 +174,7 @@ func EncEvent(log types.EventData) JsonLog {
 	jLog := JsonLog{
 		TransactionHash:  EncBytes(log.TxHash),
 		BlockNumber:      EncUint(log.BlockHeight),
-		Address:          EncAddress(log.Caller),
+		Address:          EncAddress(log.Address),
 		Data:             data,
 		TransactionIndex: EncInt(int64(log.TransactionIndex)),
 		BlockHash:        EncBytes(log.BlockHash),


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request

fix for https://github.com/loomnetwork/loomchain/issues/1289