### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/e2e/chainconfig-routine.toml
+++ b/e2e/chainconfig-routine.toml
@@ -30,7 +30,7 @@
   Expected = ['Error']
 
 [[TestCases]]
-  RunCmd = "wait_block_height_to_increase 0 2"
+  RunCmd = "wait_for_block_height_to_increase 0 2"
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} chain-cfg get-feature auto-enabled:feature-1"

--- a/e2e/chainconfig-routine.toml
+++ b/e2e/chainconfig-routine.toml
@@ -24,12 +24,15 @@
   Expected = ['auto-enabled:feature-1','auto-enabled:feature-2','auto-enabled:feature-3']
   
 [[TestCases]]
+  Delay = 20000
   RunCmd = "{{ $.LoomPath }} chain-cfg add-feature chaincfg:v1.2 --build 0 -k {{index $.NodePrivKeyPathList 0}}"
   Condition = "excludes"
   Expected = ['Error']
 
 [[TestCases]]
-  Delay = 20000
+  RunCmd = "wait_block_height_to_increase 0 2"
+
+[[TestCases]]
   RunCmd = "{{ $.LoomPath }} chain-cfg get-feature auto-enabled:feature-1"
   Condition = "contains"
   Expected = ['ENABLED','100']

--- a/e2e/dpos-jail-validator.toml
+++ b/e2e/dpos-jail-validator.toml
@@ -69,39 +69,38 @@
   Condition = "contains"
   Expected = ["periods"]
 
-# wait block height to increase 
+# wait node 1 to catch up
 [[TestCases]]
   RunCmd = "wait_node_to_catch_up 1"
 
-# wait block height to increase 
+# wait block height to increase at least 5 blocks
 [[TestCases]]
   RunCmd = "wait_block_height_to_increase 0 5"
 
 # check downtime periods, it should be cleared out after 5 blocks
 [[TestCases]]
-  Delay = 5000
   RunCmd = "{{ $.LoomPath }} dpos3 downtime-record {{index $.NodeAddressList 1}} -u {{index $.NodeProxyAppAddressList 2}}"
   Condition = "contains"
   Expected = ["periods"]
 
-# check if node 1 is jailed
+# node 1 should be jailed as it is offline for 15s
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-candidates -u {{index $.NodeProxyAppAddressList 2}}"
   Condition = "contains"
   Expected = ["jailed\": true"]
 
-# check downtime periods, it should be cleared out after 5 blocks
+# check downtime periods before unjailing the validator
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 downtime-record {{index $.NodeAddressList 1}} -u {{index $.NodeProxyAppAddressList 2}}"
   Condition = "contains"
-  Expected = ["periods"]
+  Expected = ["periods", "0"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 unjail-validator -k {{index $.NodePrivKeyPathList 1}} -u {{index $.NodeProxyAppAddressList 2}}"
   Condition = "contains"
   Expected = [""]
 
-# wait block height to increase 
+# wait block height to increase at least 2 blocks
 [[TestCases]]
   RunCmd = "wait_block_height_to_increase 0 2"
 

--- a/e2e/dpos-jail-validator.toml
+++ b/e2e/dpos-jail-validator.toml
@@ -69,11 +69,11 @@
   Condition = "contains"
   Expected = ["periods"]
 
-# wait node 1 to catch up
+# wait for node 1 to catch up
 [[TestCases]]
   RunCmd = "wait_for_node_to_catch_up 1"
 
-# wait block height to increase at least 5 blocks
+# wait for block height to increase at least 5 blocks
 [[TestCases]]
   RunCmd = "wait_for_block_height_to_increase 0 5"
 
@@ -100,7 +100,7 @@
   Condition = "contains"
   Expected = [""]
 
-# wait block height to increase at least 2 blocks
+# wait for block height to increase at least 2 blocks
 [[TestCases]]
   RunCmd = "wait_for_block_height_to_increase 0 2"
 

--- a/e2e/dpos-jail-validator.toml
+++ b/e2e/dpos-jail-validator.toml
@@ -71,11 +71,11 @@
 
 # wait node 1 to catch up
 [[TestCases]]
-  RunCmd = "wait_node_to_catch_up 1"
+  RunCmd = "wait_for_node_to_catch_up 1"
 
 # wait block height to increase at least 5 blocks
 [[TestCases]]
-  RunCmd = "wait_block_height_to_increase 0 5"
+  RunCmd = "wait_for_block_height_to_increase 0 5"
 
 # check downtime periods, it should be cleared out after 5 blocks
 [[TestCases]]
@@ -102,7 +102,7 @@
 
 # wait block height to increase at least 2 blocks
 [[TestCases]]
-  RunCmd = "wait_block_height_to_increase 0 2"
+  RunCmd = "wait_for_block_height_to_increase 0 2"
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-candidates -u {{index $.NodeProxyAppAddressList 2}}"

--- a/e2e/dpos-jail-validator.toml
+++ b/e2e/dpos-jail-validator.toml
@@ -62,43 +62,50 @@
 [[TestCases]]
   RunCmd = "kill_and_restart_node 15 1"
 
-# wait node 1 to start, maximum time is 30s
-[[TestCases]]
-  RunCmd = "wait_node_to_start 1 30"
-
 # add some delay so that downtime periods of node 1 are cleared out
 [[TestCases]]
-  Delay = 10000
-  RunCmd = "{{ $.LoomPath }} dpos3 downtime-record {{index $.NodeAddressList 1}}"
+  Delay = 15000
+  RunCmd = "{{ $.LoomPath }} dpos3 downtime-record {{index $.NodeAddressList 1}} -u {{index $.NodeProxyAppAddressList 2}}"
+  Condition = "contains"
+  Expected = ["periods"]
+
+# wait block height to increase 
+[[TestCases]]
+  RunCmd = "wait_node_to_catch_up 1"
+
+# wait block height to increase 
+[[TestCases]]
+  RunCmd = "wait_block_height_to_increase 0 5"
+
+# check downtime periods, it should be cleared out after 5 blocks
+[[TestCases]]
+  Delay = 5000
+  RunCmd = "{{ $.LoomPath }} dpos3 downtime-record {{index $.NodeAddressList 1}} -u {{index $.NodeProxyAppAddressList 2}}"
   Condition = "contains"
   Expected = ["periods"]
 
 # check if node 1 is jailed
 [[TestCases]]
-  RunCmd = "{{ $.LoomPath }} dpos3 list-candidates"
+  RunCmd = "{{ $.LoomPath }} dpos3 list-candidates -u {{index $.NodeProxyAppAddressList 2}}"
   Condition = "contains"
   Expected = ["jailed\": true"]
 
-# check downtime periods, it should be cleared out
+# check downtime periods, it should be cleared out after 5 blocks
 [[TestCases]]
-  RunCmd = "{{ $.LoomPath }} dpos3 downtime-record {{index $.NodeAddressList 1}}"
+  RunCmd = "{{ $.LoomPath }} dpos3 downtime-record {{index $.NodeAddressList 1}} -u {{index $.NodeProxyAppAddressList 2}}"
   Condition = "contains"
   Expected = ["periods"]
 
 [[TestCases]]
-  RunCmd = "{{ $.LoomPath }} dpos3 unjail-validator -k {{index $.NodePrivKeyPathList 1}}"
+  RunCmd = "{{ $.LoomPath }} dpos3 unjail-validator -k {{index $.NodePrivKeyPathList 1}} -u {{index $.NodeProxyAppAddressList 2}}"
   Condition = "contains"
   Expected = [""]
 
-# Send txs to increase block height
+# wait block height to increase 
 [[TestCases]]
-  RunCmd = "{{ $.LoomPath }} coin approve dposV3 10 -k {{index $.NodePrivKeyPathList 2}}"
+  RunCmd = "wait_block_height_to_increase 0 2"
 
 [[TestCases]]
-  RunCmd = "{{ $.LoomPath }} coin approve dposV3 10 -k {{index $.NodePrivKeyPathList 2}}"
-
-[[TestCases]]
-  Delay = 2000
-  RunCmd = "{{ $.LoomPath }} dpos3 list-candidates"
+  RunCmd = "{{ $.LoomPath }} dpos3 list-candidates -u {{index $.NodeProxyAppAddressList 2}}"
   Condition = "excludes"
   Excluded = ["jailed\": true"]

--- a/e2e/engine/cmd.go
+++ b/e2e/engine/cmd.go
@@ -232,7 +232,7 @@ func (e *engineCmd) Run(ctx context.Context, eventC chan *node.Event) error {
 						}
 					}
 
-				} else if cmd.Args[0] == "wait_block_height_to_increase" {
+				} else if cmd.Args[0] == "wait_for_block_height_to_increase" {
 					if len(cmd.Args) > 2 {
 						maxWaitingTime := 60 // 60s
 						maxRetries := 3
@@ -259,7 +259,7 @@ func (e *engineCmd) Run(ctx context.Context, eventC chan *node.Event) error {
 							time.Sleep(time.Duration(time.Second))
 						}
 					}
-				} else if cmd.Args[0] == "wait_node_to_catch_up" {
+				} else if cmd.Args[0] == "wait_for_node_to_catch_up" {
 					if len(cmd.Args) > 1 {
 						maxWaitingTime := 60 // 60s
 						for i := maxWaitingTime; i > 0; i-- {

--- a/e2e/engine/cmd.go
+++ b/e2e/engine/cmd.go
@@ -261,7 +261,7 @@ func (e *engineCmd) Run(ctx context.Context, eventC chan *node.Event) error {
 					}
 				} else if cmd.Args[0] == "wait_for_node_to_catch_up" {
 					if len(cmd.Args) > 1 {
-						maxWaitingTime := 60 // 60s
+						maxWaitingTime := 120 // 120s
 						for i := maxWaitingTime; i > 0; i-- {
 							cachingUp, err := nodeCatchingUp(e.conf.Nodes[cmd.Args[1]])
 							if err == nil && !cachingUp {
@@ -409,7 +409,8 @@ func checkNodeReady(n *node.Node) error {
 
 func nodeCatchingUp(n *node.Node) (bool, error) {
 	type CatchingUp struct {
-		CatchingUp bool `json:"catching_up"`
+		CatchingUp         bool   `json:"catching_up"`
+		LastestBlockHeight string `json:"latest_block_height"`
 	}
 	type SyncInfo struct {
 		CatchingUpResult CatchingUp `json:"sync_info"`

--- a/e2e/engine/cmd.go
+++ b/e2e/engine/cmd.go
@@ -232,6 +232,44 @@ func (e *engineCmd) Run(ctx context.Context, eventC chan *node.Event) error {
 						}
 					}
 
+				} else if cmd.Args[0] == "wait_block_height_to_increase" {
+					if len(cmd.Args) > 2 {
+						maxWaitingTime := 60 // 60s
+						maxRetries := 3
+						waitNBlocks, err := strconv.Atoi(cmd.Args[2])
+						if err != nil {
+							return fmt.Errorf("waiting block number is not defined, err: %s", err)
+						}
+						var lastBlockHeight int64
+						for i := maxRetries; i > 0; i-- {
+							lastBlockHeight, err = getLastBlockHeight(e.conf.Nodes[cmd.Args[1]])
+							if err != nil {
+								break
+							}
+						}
+						if lastBlockHeight == 0 {
+							return fmt.Errorf("cannot get last block height from node %s", cmd.Args[1])
+						}
+						for i := maxWaitingTime; i > 0; i-- {
+							currentBlockHeight, _ := getLastBlockHeight(e.conf.Nodes[cmd.Args[1]])
+							if currentBlockHeight > lastBlockHeight+int64(waitNBlocks) {
+								break
+							}
+							fmt.Printf("current block height %d\n", currentBlockHeight)
+							time.Sleep(time.Duration(time.Second))
+						}
+					}
+				} else if cmd.Args[0] == "wait_node_to_catch_up" {
+					if len(cmd.Args) > 1 {
+						maxWaitingTime := 60 // 60s
+						for i := maxWaitingTime; i > 0; i-- {
+							cachingUp, err := nodeCatchingUp(e.conf.Nodes[cmd.Args[1]])
+							if err == nil && !cachingUp {
+								break
+							}
+							time.Sleep(time.Duration(time.Second))
+						}
+					}
 				} else {
 					out, err = cmd.CombinedOutput()
 				}
@@ -367,6 +405,71 @@ func checkNodeReady(n *node.Node) error {
 		return fmt.Errorf("LastBlockHeight: %d", lastBlockHeight)
 	}
 	return nil
+}
+
+func nodeCatchingUp(n *node.Node) (bool, error) {
+	type CatchingUp struct {
+		CatchingUp bool `json:"catching_up"`
+	}
+	type SyncInfo struct {
+		CatchingUpResult CatchingUp `json:"sync_info"`
+	}
+	type Response struct {
+		Result SyncInfo `json:"result"`
+	}
+
+	u := fmt.Sprintf("%s/status", n.RPCAddress)
+	client := http.Client{
+		Timeout: 500 * time.Millisecond,
+	}
+	rawResp, err := client.Get(u)
+	if err != nil {
+		return true, err
+	}
+	defer rawResp.Body.Close()
+	respBytes, _ := ioutil.ReadAll(rawResp.Body)
+	var resp Response
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return true, err
+	}
+
+	fmt.Printf("SyncInfo %+v\n", resp.Result)
+
+	return resp.Result.CatchingUpResult.CatchingUp, nil
+}
+
+func getLastBlockHeight(n *node.Node) (int64, error) {
+	type ResponseInfo struct {
+		LastBlockHeight string `json:"last_block_height"`
+	}
+	type ResultABCIInfo struct {
+		Response ResponseInfo `json:"response"`
+	}
+	type Response struct {
+		Result ResultABCIInfo `json:"result"`
+	}
+
+	u := fmt.Sprintf("%s/abci_info", n.RPCAddress)
+	client := http.Client{
+		Timeout: 500 * time.Millisecond,
+	}
+	rawResp, err := client.Get(u)
+	if err != nil {
+		return 0, err
+	}
+	defer rawResp.Body.Close()
+	respBytes, _ := ioutil.ReadAll(rawResp.Body)
+	var resp Response
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return 0, err
+	}
+
+	lastBlockHeight, err := strconv.ParseInt(resp.Result.Response.LastBlockHeight, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return lastBlockHeight, nil
 }
 
 func checkValidators(node *node.Node) ([]byte, error) {


### PR DESCRIPTION
The jailing validator is flaky because, after the node starts, its downtime period will not be cleared out until it catches up the other nodes and starts signing blocks. This PR fixes flaky e2e test by adding two commands `wait_block_height_to_increase` and `wait_node_to_catch_up`. So now we can make sure that the node has started and caught up before we unjail it. 

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request