### PR TITLE
Auto adjust name column length

### DIFF
--- a/cmd/loom/chainconfig/cmd.go
+++ b/cmd/loom/chainconfig/cmd.go
@@ -436,7 +436,11 @@ func ListValidatorsInfoCmd() *cobra.Command {
 
 			nameList := make(map[string]string)
 			for _, c := range respDPOS.Candidates {
-				nameList[loom.UnmarshalAddressPB(c.Candidate.Address).Local.String()] = c.Candidate.GetName()
+				n := c.Candidate.GetName()
+				nameList[loom.UnmarshalAddressPB(c.Candidate.Address).Local.String()] = n
+				if ml.Name < len(n) {
+					ml.Name = len(n)
+				}
 			}
 
 			fmt.Printf(


### PR DESCRIPTION
Fix response column name.
Now auto adjust by the longest name length.