### PR TITLE
[WIP] Cache Feature Flags and Cfg Settings

### DIFF
--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -220,12 +220,12 @@ func (s *MultiWriterAppStore) SaveVersion() ([]byte, int64, error) {
 }
 
 func (s *MultiWriterAppStore) loadFeaturesAndCfgSettings() {
-	featureRange := s.Range(featurePrefix)
+	featureRange := s.appStore.Range(featurePrefix)
 	for _, feature := range featureRange {
 		s.multiWriterStoreCache.Set(feature.Key, feature.Value)
 	}
 
-	configRange := s.Range(configPrefix)
+	configRange := s.appStore.Range(configPrefix)
 	for _, config := range configRange {
 		s.multiWriterStoreCache.Set(config.Key, config.Value)
 	}

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -388,6 +388,9 @@ func (c *multiWriterStoreCache) Delete(key []byte) {
 }
 
 func (c *multiWriterStoreCache) Range(prefix []byte) plugin.RangeData {
+	c.RLock()
+	defer c.RUnlock()
+
 	keys := []string{}
 	for key := range c.cache {
 		if util.HasPrefix([]byte(key), prefix) {

--- a/store/multi_writer_app_store_test.go
+++ b/store/multi_writer_app_store_test.go
@@ -214,7 +214,7 @@ func (m *MultiWriterAppStoreTestSuite) TestMultiWriterAppStoreSaveVersion() {
 	require.False(store.Has(vmPrefixKey("gg")))
 }
 
-func (m *MultiWriterAppStoreTestSuite) TestMultiWriterStoreCacheRange() {
+func (m *MultiWriterAppStoreTestSuite) TestMultiWriterStoreCache() {
 	require := m.Require()
 	store, err := mockMultiWriterStore()
 	require.NoError(err)
@@ -232,6 +232,16 @@ func (m *MultiWriterAppStoreTestSuite) TestMultiWriterStoreCacheRange() {
 	require.Equal(rangeData[0].Value, rangeDataAppStore[0].Value)
 	require.Equal(rangeData[1].Value, rangeDataAppStore[1].Value)
 	require.Equal(rangeData[2].Value, rangeDataAppStore[2].Value)
+
+	cachedData := store.Get(featureKey("db:evm"))
+	diskData := store.appStore.Get(featureKey("db:evm"))
+	require.Equal(cachedData, diskData)
+
+	store.Delete(featureKey("dpos:v3.1"))
+	cachedData = store.Get(featureKey("dpos:v3.1"))
+	diskData = store.appStore.Get(featureKey("dpos:v3.1"))
+	require.Equal(diskData, cachedData)
+	require.Equal(0, len(cachedData))
 }
 
 func mockMultiWriterStore() (*MultiWriterAppStore, error) {

--- a/store/multi_writer_app_store_test.go
+++ b/store/multi_writer_app_store_test.go
@@ -214,6 +214,26 @@ func (m *MultiWriterAppStoreTestSuite) TestMultiWriterAppStoreSaveVersion() {
 	require.False(store.Has(vmPrefixKey("gg")))
 }
 
+func (m *MultiWriterAppStoreTestSuite) TestMultiWriterStoreCacheRange() {
+	require := m.Require()
+	store, err := mockMultiWriterStore()
+	require.NoError(err)
+
+	store.Set(featureKey("db:evm"), []byte("true"))
+	store.Set(featureKey("chainconfig:v1.1"), []byte("true"))
+	store.Set(featureKey("dpos:v3.1"), []byte("true"))
+
+	rangeData := store.Range(featurePrefix)
+	rangeDataAppStore := store.appStore.Range(featurePrefix)
+	require.Equal(rangeData[0].Key, rangeDataAppStore[0].Key)
+	require.Equal(rangeData[1].Key, rangeDataAppStore[1].Key)
+	require.Equal(rangeData[2].Key, rangeDataAppStore[2].Key)
+
+	require.Equal(rangeData[0].Value, rangeDataAppStore[0].Value)
+	require.Equal(rangeData[1].Value, rangeDataAppStore[1].Value)
+	require.Equal(rangeData[2].Value, rangeDataAppStore[2].Value)
+}
+
 func mockMultiWriterStore() (*MultiWriterAppStore, error) {
 	memDb, _ := db.LoadMemDB()
 	iavlStore, err := NewIAVLStore(memDb, 0, 0, 0)
@@ -231,4 +251,12 @@ func mockMultiWriterStore() (*MultiWriterAppStore, error) {
 
 func vmPrefixKey(key string) []byte {
 	return util.PrefixKey([]byte("vm"), []byte(key))
+}
+
+func featureKey(key string) []byte {
+	return util.PrefixKey(featurePrefix, []byte(key))
+}
+
+func configKey(key string) []byte {
+	return util.PrefixKey(configPrefix, []byte(key))
 }


### PR DESCRIPTION
Features and Cfg settings are going to be read from app.db every block by several managers (such as dpos manager and chainconfig manager). We should cache it in `MultiWriterAppStore` to reduce IOPS.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request