### PR TITLE
Remove redundant coin e2e test runs

### DIFF
--- a/e2e/coin-test-loom.yaml
+++ b/e2e/coin-test-loom.yaml
@@ -1,1 +1,0 @@
-ReceiptsVersion: 2

--- a/e2e/coin_test.go
+++ b/e2e/coin_test.go
@@ -18,11 +18,7 @@ func TestContractCoin(t *testing.T) {
 	}{
 		{"coin-1", "coin.toml", 1, 10, "coin.genesis.json", ""},
 		{"coin-2", "coin.toml", 2, 10, "coin.genesis.json", ""},
-		{"coin-2-r2", "coin.toml", 2, 10, "coin.genesis.json", "coin-test-loom.yaml"},
 		{"coin-4", "coin.toml", 4, 10, "coin.genesis.json", ""},
-		{"coin-4-r2", "coin.toml", 4, 10, "coin.genesis.json", "coin-test-loom.yaml"},
-		{"coin-6", "coin.toml", 6, 10, "coin.genesis.json", ""},
-		{"coin-8", "coin.toml", 8, 10, "coin.genesis.json", ""},
 	}
 	common.LoomPath = "../loom"
 	common.ContractDir = "../contracts"


### PR DESCRIPTION
`ReceiptsVersion: 2` is the default now, so the two test runs that explicitly set that config setting do exactly the same thing as the two that don't. The 6 & 8 node test runs do exactly the same thing as the 1, 2, and 4 node runs, they're just wasting time and overloading the Jenkins machines.