### PR TITLE
Add Binance Singed Tx To Auth Middleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ BTCD_GIT_REV = 7d2daa5bfef28c5e282571bc06416516936115ee
 # google.golang.org/genproto seems to be pulled in by the grpc package.
 GENPROTO_GIT_REV = b515fa19cec88c32f305a962f34ae60068947aea
 # Specifies the loomnetwork/binance-tgoracle branch/revision to use.
-BINANCE_TG_GIT_REV = oracle-verify-token-creation
+BINANCE_TG_GIT_REV = HEAD
 # Lock down certusone/yubihsm-go revision
 YUBIHSM_REV = 0299fd5d703d2a576125b414abbe172eaec9f65e
 

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = binance-chain-signer
+GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
-TG_GIT_REV = binance-chain-contract-mapping
+TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch
 ETHEREUM_GIT_REV = 1fb6138d017a4309105d91f187c126cf979c93f9
 # use go-plugin we get 'timeout waiting for connection info' error

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = binance-chain-signer
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
-TG_GIT_REV = HEAD
+TG_GIT_REV = binance-chain-contract-mapping
 # loomnetwork/go-ethereum loomchain branch
 ETHEREUM_GIT_REV = 1fb6138d017a4309105d91f187c126cf979c93f9
 # use go-plugin we get 'timeout waiting for connection info' error
@@ -43,7 +43,7 @@ BTCD_GIT_REV = 7d2daa5bfef28c5e282571bc06416516936115ee
 # google.golang.org/genproto seems to be pulled in by the grpc package.
 GENPROTO_GIT_REV = b515fa19cec88c32f305a962f34ae60068947aea
 # Specifies the loomnetwork/binance-tgoracle branch/revision to use.
-BINANCE_TG_GIT_REV = init-build
+BINANCE_TG_GIT_REV = oracle-verify-token-creation
 # Lock down certusone/yubihsm-go revision
 YUBIHSM_REV = 0299fd5d703d2a576125b414abbe172eaec9f65e
 
@@ -198,7 +198,7 @@ $(TRANSFER_GATEWAY_DIR):
 	cd $(TRANSFER_GATEWAY_DIR) && git checkout master && git pull && git checkout $(TG_GIT_REV)
 
 $(BINANCE_TGORACLE_DIR):
-	git clone -q git@github.com:loomnetwork/binace-tgoracle.git $@
+	git clone -q git@github.com:loomnetwork/binance-tgoracle.git $@
 	cd $(BINANCE_TGORACLE_DIR) && git checkout master && git pull && git checkout $(BINANCE_TG_GIT_REV)
 
 validators-tool: $(TRANSFER_GATEWAY_DIR)

--- a/auth/chainconfig_middleware_test.go
+++ b/auth/chainconfig_middleware_test.go
@@ -49,10 +49,10 @@ func TestChainConfigMiddlewareSingleChain(t *testing.T) {
 
 func TestChainConfigMiddlewareMultipleChain(t *testing.T) {
 	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
-	state.SetFeature(loomchain.AuthSigTxDefault, true)
-	state.SetFeature(loomchain.AuthSigTxEth, true)
-	state.SetFeature(loomchain.AuthSigTxTron, true)
-	state.SetFeature(loomchain.AuthSigTxBinance, true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"default", true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"eth", true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"tron", true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"binance", true)
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
 	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
 	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))

--- a/auth/chainconfig_middleware_test.go
+++ b/auth/chainconfig_middleware_test.go
@@ -49,9 +49,10 @@ func TestChainConfigMiddlewareSingleChain(t *testing.T) {
 
 func TestChainConfigMiddlewareMultipleChain(t *testing.T) {
 	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
-	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"default", true)
-	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"tron", true)
-	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"eth", true)
+	state.SetFeature(loomchain.AuthSigTxDefault, true)
+	state.SetFeature(loomchain.AuthSigTxEth, true)
+	state.SetFeature(loomchain.AuthSigTxTron, true)
+	state.SetFeature(loomchain.AuthSigTxBinance, true)
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
 	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
 	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))
@@ -69,6 +70,10 @@ func TestChainConfigMiddlewareMultipleChain(t *testing.T) {
 		},
 		"tron": {
 			TxType:      TronSignedTxType,
+			AccountType: MappedAccountType,
+		},
+		"binance": {
+			TxType:      BinanceSignedTxType,
 			AccountType: MappedAccountType,
 		},
 	}

--- a/auth/eth.go
+++ b/auth/eth.go
@@ -8,8 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func verifySolidity66Byte(tx SignedTx) ([]byte, error) {
-	ethAddr, err := evmcompat.RecoverAddressFromTypedSig(sha3.SoliditySHA3(tx.Inner), tx.Signature)
+func verifySolidity66Byte(tx SignedTx, allowSigTypes []evmcompat.SignatureType) ([]byte, error) {
+	ethAddr, err := evmcompat.RecoverAddressFromTypedSig(sha3.SoliditySHA3(tx.Inner), tx.Signature, allowSigTypes)
 	if err != nil {
 		return nil, errors.Wrap(err, "verify solidity key")
 	}
@@ -17,8 +17,8 @@ func verifySolidity66Byte(tx SignedTx) ([]byte, error) {
 	return ethAddr.Bytes(), nil
 }
 
-func verifyTron(tx SignedTx) ([]byte, error) {
-	tronAddr, err := evmcompat.RecoverAddressFromTypedSig(sha3.SoliditySHA3(tx.Inner), tx.Signature)
+func verifyTron(tx SignedTx, allowSigTypes []evmcompat.SignatureType) ([]byte, error) {
+	tronAddr, err := evmcompat.RecoverAddressFromTypedSig(sha3.SoliditySHA3(tx.Inner), tx.Signature, allowSigTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/multi_chain_sigtx_middleware_test.go
+++ b/auth/multi_chain_sigtx_middleware_test.go
@@ -172,9 +172,7 @@ func TestBinanceSigning(t *testing.T) {
 
 func TestEthAddressMappingVerification(t *testing.T) {
 	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
-	state.SetFeature(loomchain.AuthSigTxEth, true)
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
-	fakeCtx.SetFeature(loomchain.AuthSigTxEth, true)
 	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
 	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))
 
@@ -226,7 +224,6 @@ func TestEthAddressMappingVerification(t *testing.T) {
 		To:        ethPublicAddr.MarshalPB(),
 		Signature: sig,
 	}
-	mapping = mapping
 	require.NoError(t, am.AddIdentityMapping(amCtx, &mapping))
 
 	// tx using address mapping from eth account. No error this time as mapped loom account is found.
@@ -235,11 +232,16 @@ func TestEthAddressMappingVerification(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestBinancesAddressMappingVerification(t *testing.T) {
+func TestBinanceAddressMappingVerification(t *testing.T) {
 	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
-	state.SetFeature(loomchain.AuthSigTxBinance, true)
+	state.SetFeature(loomchain.AddressMapperVersion1_1, true)
+	state.SetFeature(loomchain.MultiChainSigTxMiddlewareVersion1_1, true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"binance", true)
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
-	fakeCtx.SetFeature(loomchain.AuthSigTxBinance, true)
+	// FIXME: Having to set feature flags twice is pretty stupid... need to fix this state/ctx mess.
+	fakeCtx.SetFeature(loomchain.AddressMapperVersion1_1, true)
+	state.SetFeature(loomchain.MultiChainSigTxMiddlewareVersion1_1, true)
+	fakeCtx.SetFeature(loomchain.AuthSigTxFeaturePrefix+"binance", true)
 	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
 	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))
 
@@ -291,7 +293,6 @@ func TestBinancesAddressMappingVerification(t *testing.T) {
 		To:        foreignPublicAddr.MarshalPB(),
 		Signature: sig,
 	}
-	mapping = mapping
 	require.NoError(t, am.AddIdentityMapping(amCtx, &mapping))
 
 	// tx using address mapping from binance account. No error this time as mapped loom account is found.
@@ -302,15 +303,15 @@ func TestBinancesAddressMappingVerification(t *testing.T) {
 
 func TestChainIdVerification(t *testing.T) {
 	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
-	state.SetFeature(loomchain.AuthSigTxDefault, true)
-	state.SetFeature(loomchain.AuthSigTxEth, true)
-	state.SetFeature(loomchain.AuthSigTxTron, true)
-	state.SetFeature(loomchain.AuthSigTxBinance, true)
+	state.SetFeature(loomchain.AddressMapperVersion1_1, true)
+	state.SetFeature(loomchain.MultiChainSigTxMiddlewareVersion1_1, true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"tron", true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"binance", true)
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
-	fakeCtx.SetFeature(loomchain.AuthSigTxDefault, true)
-	fakeCtx.SetFeature(loomchain.AuthSigTxEth, true)
-	fakeCtx.SetFeature(loomchain.AuthSigTxTron, true)
-	fakeCtx.SetFeature(loomchain.AuthSigTxBinance, true)
+	state.SetFeature(loomchain.AddressMapperVersion1_1, true)
+	state.SetFeature(loomchain.MultiChainSigTxMiddlewareVersion1_1, true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"tron", true)
+	state.SetFeature(loomchain.AuthSigTxFeaturePrefix+"binance", true)
 	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
 	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))
 
@@ -330,7 +331,7 @@ func TestChainIdVerification(t *testing.T) {
 			AccountType: NativeAccountType,
 		},
 		"binance": {
-			TxType:      TronSignedTxType,
+			TxType:      BinanceSignedTxType,
 			AccountType: NativeAccountType,
 		},
 	}

--- a/auth/multi_chain_sigtx_middleware_test.go
+++ b/auth/multi_chain_sigtx_middleware_test.go
@@ -80,7 +80,8 @@ func TestSigning(t *testing.T) {
 	}
 
 	// Decode
-	recoverdAddr, err := evmcompat.RecoverAddressFromTypedSig(hash, tx.Signature)
+	allowedSigTypes := []evmcompat.SignatureType{evmcompat.SignatureType_EIP712}
+	recoverdAddr, err := evmcompat.RecoverAddressFromTypedSig(hash, tx.Signature, allowedSigTypes)
 	require.NoError(t, err)
 	require.True(t, bytes.Equal(recoverdAddr.Bytes(), ethLocalAdr))
 
@@ -130,9 +131,50 @@ func TestTronSigning(t *testing.T) {
 	require.True(t, bytes.Equal(ethLocalAdr, ethLocalAdr2))
 }
 
+func TestBinanceSigning(t *testing.T) {
+	privateKey, err := crypto.HexToECDSA(ethPrivateKey)
+	require.NoError(t, err)
+	signer := auth.NewSecp256k1Signer(crypto.FromECDSA(privateKey))
+	publicKey := signer.PublicKey()
+	require.NoError(t, err)
+	to := contract
+	nonce := uint64(7)
+
+	// Encode
+	nonceTx := []byte("nonceTx")
+	foreignLocalAddr, err := loom.LocalAddressFromHexString(evmcompat.BitcoinAddress(publicKey).Hex())
+	require.NoError(t, err)
+	hash := sha3.SoliditySHA3(
+		sha3.Address(common.BytesToAddress(foreignLocalAddr)),
+		sha3.Address(common.BytesToAddress(to.Local)),
+		sha3.Uint64(nonce),
+		nonceTx,
+	)
+
+	signature, err := evmcompat.GenerateTypedSig(hash, privateKey, evmcompat.SignatureType_BINANCE)
+	require.NoError(t, err)
+
+	tx := &auth.SignedTx{
+		Inner:     nonceTx,
+		Signature: signature,
+		PublicKey: publicKey,
+	}
+
+	// Decode
+	allowedSigTypes := []evmcompat.SignatureType{evmcompat.SignatureType_BINANCE}
+	recoverdAddr, err := evmcompat.RecoverAddressFromTypedSig(hash, tx.Signature, allowedSigTypes)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(recoverdAddr.Bytes(), foreignLocalAddr))
+
+	signatureNoRecoverID := signature[1 : len(tx.Signature)-1] // remove recovery ID
+	require.True(t, crypto.VerifySignature(tx.PublicKey, hash, signatureNoRecoverID))
+}
+
 func TestEthAddressMappingVerification(t *testing.T) {
 	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
+	state.SetFeature(loomchain.AuthSigTxEth, true)
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
+	fakeCtx.SetFeature(loomchain.AuthSigTxEth, true)
 	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
 	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))
 
@@ -145,10 +187,6 @@ func TestEthAddressMappingVerification(t *testing.T) {
 		},
 		"eth": {
 			TxType:      EthereumSignedTxType,
-			AccountType: MappedAccountType,
-		},
-		"tron": {
-			TxType:      TronSignedTxType,
 			AccountType: MappedAccountType,
 		},
 	}
@@ -181,7 +219,7 @@ func TestEthAddressMappingVerification(t *testing.T) {
 	require.Error(t, err)
 
 	// set up address mapping between eth and loom accounts
-	sig, err := address_mapper.SignIdentityMapping(addr1, ethPublicAddr, ethKey)
+	sig, err := address_mapper.SignIdentityMapping(addr1, ethPublicAddr, ethKey, evmcompat.SignatureType_EIP712)
 	require.NoError(t, err)
 	mapping := amtypes.AddressMapperAddIdentityMappingRequest{
 		From:      addr1.MarshalPB(),
@@ -197,9 +235,82 @@ func TestEthAddressMappingVerification(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBinancesAddressMappingVerification(t *testing.T) {
+	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
+	state.SetFeature(loomchain.AuthSigTxBinance, true)
+	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
+	fakeCtx.SetFeature(loomchain.AuthSigTxBinance, true)
+	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
+	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))
+
+	ctx := context.WithValue(state.Context(), ContextKeyOrigin, origin)
+
+	chains := map[string]ChainConfig{
+		"default": {
+			TxType:      LoomSignedTxType,
+			AccountType: NativeAccountType,
+		},
+		"binance": {
+			TxType:      BinanceSignedTxType,
+			AccountType: MappedAccountType,
+		},
+	}
+	tmx := NewMultiChainSignatureTxMiddleware(
+		chains,
+		func(state loomchain.State) (contractpb.StaticContext, error) { return amCtx, nil },
+	)
+
+	// Normal loom transaction without address mapping
+	txSigned := mockEd25519SignedTx(t, priKey1)
+	_, err := throttleMiddlewareHandler(tmx, state, txSigned, ctx)
+	require.NoError(t, err)
+
+	// Init the contract
+	am := address_mapper.AddressMapper{}
+	require.NoError(t, am.Init(amCtx, &address_mapper.InitRequest{}))
+
+	// generate eth key
+	// ethKey, err := crypto.GenerateKey()
+	privKey, err := crypto.HexToECDSA(ethPrivateKey)
+	require.NoError(t, err)
+	signer := auth.NewBinanceSigner(crypto.FromECDSA(privKey))
+	foreignLocalAddr, err := loom.LocalAddressFromHexString(evmcompat.BitcoinAddress(signer.PublicKey()).Hex())
+	require.NoError(t, err)
+	foreignPublicAddr := loom.Address{ChainID: "binance", Local: foreignLocalAddr}
+
+	// tx using address mapping from eth account. Gives error.
+	txSigned = mockBinanceSignedTx(t, "binance", signer)
+	_, err = throttleMiddlewareHandler(tmx, state, txSigned, ctx)
+	require.Error(t, err)
+
+	// set up address mapping between eth and loom accounts
+	sig, err := address_mapper.SignIdentityMapping(addr1, foreignPublicAddr, privKey, evmcompat.SignatureType_BINANCE)
+	require.NoError(t, err)
+	mapping := amtypes.AddressMapperAddIdentityMappingRequest{
+		From:      addr1.MarshalPB(),
+		To:        foreignPublicAddr.MarshalPB(),
+		Signature: sig,
+	}
+	mapping = mapping
+	require.NoError(t, am.AddIdentityMapping(amCtx, &mapping))
+
+	// tx using address mapping from binance account. No error this time as mapped loom account is found.
+	txSigned = mockBinanceSignedTx(t, "binance", signer)
+	_, err = throttleMiddlewareHandler(tmx, state, txSigned, ctx)
+	require.NoError(t, err)
+}
+
 func TestChainIdVerification(t *testing.T) {
 	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
+	state.SetFeature(loomchain.AuthSigTxDefault, true)
+	state.SetFeature(loomchain.AuthSigTxEth, true)
+	state.SetFeature(loomchain.AuthSigTxTron, true)
+	state.SetFeature(loomchain.AuthSigTxBinance, true)
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
+	fakeCtx.SetFeature(loomchain.AuthSigTxDefault, true)
+	fakeCtx.SetFeature(loomchain.AuthSigTxEth, true)
+	fakeCtx.SetFeature(loomchain.AuthSigTxTron, true)
+	fakeCtx.SetFeature(loomchain.AuthSigTxBinance, true)
 	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
 	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))
 
@@ -215,6 +326,10 @@ func TestChainIdVerification(t *testing.T) {
 			AccountType: NativeAccountType,
 		},
 		"tron": {
+			TxType:      TronSignedTxType,
+			AccountType: NativeAccountType,
+		},
+		"binance": {
 			TxType:      TronSignedTxType,
 			AccountType: NativeAccountType,
 		},
@@ -252,6 +367,11 @@ func TestChainIdVerification(t *testing.T) {
 	// to a DAppChain account.
 	// Don't try this in production.
 	txSigned = mockSignedTx(t, "tron", &auth.TronSigner{ethKey})
+	_, err = throttleMiddlewareHandler(tmx, state, txSigned, ctx)
+	require.NoError(t, err)
+
+	// Binance
+	txSigned = mockBinanceSignedTx(t, "binance", auth.NewBinanceSigner(crypto.FromECDSA(ethKey)))
 	_, err = throttleMiddlewareHandler(tmx, state, txSigned, ctx)
 	require.NoError(t, err)
 }
@@ -307,6 +427,17 @@ func mockSignedTx(t *testing.T, chainID string, signer auth.Signer) []byte {
 	ethLocalAdr, err := loom.LocalAddressFromHexString(crypto.PubkeyToAddress(*privateKey).Hex())
 	require.NoError(t, err)
 	nonceTx := mockNonceTx(t, loom.Address{ChainID: chainID, Local: ethLocalAdr}, sequence)
+
+	signedTx := auth.SignTx(signer, nonceTx)
+	marshalledSignedTx, err := proto.Marshal(signedTx)
+	require.NoError(t, err)
+	return marshalledSignedTx
+}
+
+func mockBinanceSignedTx(t *testing.T, chainID string, signer auth.Signer) []byte {
+	foreignLocalAddr, err := loom.LocalAddressFromHexString(evmcompat.BitcoinAddress(signer.PublicKey()).Hex())
+	require.NoError(t, err)
+	nonceTx := mockNonceTx(t, loom.Address{ChainID: chainID, Local: foreignLocalAddr}, sequence)
 
 	signedTx := auth.SignTx(signer, nonceTx)
 	marshalledSignedTx, err := proto.Marshal(signedTx)

--- a/auth/noeth.go
+++ b/auth/noeth.go
@@ -4,12 +4,14 @@ package auth
 
 import (
 	"fmt"
+
+	"github.com/loomnetwork/go-loom/common/evmcompat"
 )
 
-func verifySolidity66Byte(_ SignedTx) ([]byte, error) {
+func verifySolidity66Byte(_ SignedTx, _ []evmcompat.SignatureType) ([]byte, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func verifyTron(_ SignedTx) ([]byte, error) {
+func verifyTron(_ SignedTx, _ []evmcompat.SignatureType) ([]byte, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/builtin/plugins/address_mapper/noevm_address_mapper.go
+++ b/builtin/plugins/address_mapper/noevm_address_mapper.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/loomnetwork/go-loom"
 	amtypes "github.com/loomnetwork/go-loom/builtin/types/address_mapper"
+	"github.com/loomnetwork/go-loom/common/evmcompat"
 	"github.com/loomnetwork/go-loom/plugin"
 	contract "github.com/loomnetwork/go-loom/plugin/contractpb"
 )
@@ -42,7 +43,7 @@ func (am *AddressMapper) AddIdentityMapping(_ contract.Context, _ *AddIdentityMa
 	return nil
 }
 
-func SignIdentityMapping(_, _ loom.Address, _ *ecdsa.PrivateKey) ([]byte, error) {
+func SignIdentityMapping(_, _ loom.Address, _ *ecdsa.PrivateKey, _ evmcompat.SignatureType) ([]byte, error) {
 	return nil, nil
 }
 

--- a/builtin/plugins/plasma_cash/plasma_cash.go
+++ b/builtin/plugins/plasma_cash/plasma_cash.go
@@ -376,8 +376,13 @@ func (c *PlasmaCash) verifyPlasmaRequest(ctx contract.Context, req *PlasmaTxRequ
 		return errors.Wrapf(err, "unable to calculate plasmaTx hash")
 	}
 
-	allowedSigTypes := evmcompat.GetAllowedSignatureTypes(ctx)
-	senderEthAddressFromPlasmaSig, err := evmcompat.RecoverAddressFromTypedSig(calculatedPlasmaTxHash, req.Plasmatx.Signature, allowedSigTypes)
+	senderEthAddressFromPlasmaSig, err := evmcompat.RecoverAddressFromTypedSig(
+		calculatedPlasmaTxHash, req.Plasmatx.Signature, []evmcompat.SignatureType{
+			evmcompat.SignatureType_EIP712,
+			evmcompat.SignatureType_GETH,
+			evmcompat.SignatureType_TREZOR,
+		},
+	)
 	if err != nil {
 		return errors.Wrapf(err, "unable to recover sender address from plasmatx signature")
 	}

--- a/builtin/plugins/plasma_cash/plasma_cash.go
+++ b/builtin/plugins/plasma_cash/plasma_cash.go
@@ -376,7 +376,8 @@ func (c *PlasmaCash) verifyPlasmaRequest(ctx contract.Context, req *PlasmaTxRequ
 		return errors.Wrapf(err, "unable to calculate plasmaTx hash")
 	}
 
-	senderEthAddressFromPlasmaSig, err := evmcompat.RecoverAddressFromTypedSig(calculatedPlasmaTxHash, req.Plasmatx.Signature)
+	allowedSigTypes := evmcompat.GetAllowedSignatureTypes(ctx)
+	senderEthAddressFromPlasmaSig, err := evmcompat.RecoverAddressFromTypedSig(calculatedPlasmaTxHash, req.Plasmatx.Signature, allowedSigTypes)
 	if err != nil {
 		return errors.Wrapf(err, "unable to recover sender address from plasmatx signature")
 	}

--- a/builtin/plugins/plasma_cash/plasma_cash_test.go
+++ b/builtin/plugins/plasma_cash/plasma_cash_test.go
@@ -1058,7 +1058,9 @@ func setupPlasmaTxAuthWithKey(ctx contractpb.Context, ethPrivKey *ecdsa.PrivateK
 		return loom.Address{}, err
 	}
 
-	ethLocalAddress, err := evmcompat.RecoverAddressFromTypedSig(hash, signature, []evmcompat.SignatureType{evmcompat.SignatureType_EIP712})
+	ethLocalAddress, err := evmcompat.RecoverAddressFromTypedSig(
+		hash, signature, []evmcompat.SignatureType{evmcompat.SignatureType_EIP712},
+	)
 	if err != nil {
 		return loom.Address{}, err
 	}

--- a/builtin/plugins/plasma_cash/plasma_cash_test.go
+++ b/builtin/plugins/plasma_cash/plasma_cash_test.go
@@ -1058,7 +1058,7 @@ func setupPlasmaTxAuthWithKey(ctx contractpb.Context, ethPrivKey *ecdsa.PrivateK
 		return loom.Address{}, err
 	}
 
-	ethLocalAddress, err := evmcompat.RecoverAddressFromTypedSig(hash, signature)
+	ethLocalAddress, err := evmcompat.RecoverAddressFromTypedSig(hash, signature, []evmcompat.SignatureType{evmcompat.SignatureType_EIP712})
 	if err != nil {
 		return loom.Address{}, err
 	}

--- a/cmd/loom/addressmapper.go
+++ b/cmd/loom/addressmapper.go
@@ -1,3 +1,5 @@
+// +build evm
+
 package main
 
 import (
@@ -7,8 +9,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	loom "github.com/loomnetwork/go-loom"
+	"github.com/loomnetwork/go-loom/auth"
 	amtypes "github.com/loomnetwork/go-loom/builtin/types/address_mapper"
 	"github.com/loomnetwork/go-loom/cli"
+	"github.com/loomnetwork/go-loom/common/evmcompat"
 	lcrypto "github.com/loomnetwork/go-loom/crypto"
 	"github.com/loomnetwork/loomchain/builtin/plugins/address_mapper"
 	"github.com/pkg/errors"
@@ -36,6 +40,7 @@ func AddIdentityMappingCmd() *cobra.Command {
 
 			var privkey *ecdsa.PrivateKey
 			var foreignLocalAddr loom.LocalAddress
+			var sigType = evmcompat.SignatureType_EIP712
 
 			switch strings.TrimSpace(chainId) {
 			case "eth":
@@ -56,11 +61,22 @@ func AddIdentityMappingCmd() *cobra.Command {
 				if err != nil {
 					return errors.Wrapf(err, "bad tron private key from file% v", args[1])
 				}
+			case "binance":
+				privkey, err = crypto.LoadECDSA(args[1])
+				if err != nil {
+					return errors.Wrapf(err, "read binance private key from file %v", args[1])
+				}
+				signer := auth.NewBinanceSigner(crypto.FromECDSA(privkey))
+				foreignLocalAddr, err = loom.LocalAddressFromHexString(evmcompat.BitcoinAddress(signer.PublicKey()).Hex())
+				if err != nil {
+					return errors.Wrapf(err, "bad binance private key from file %v", args[1])
+				}
+				sigType = evmcompat.SignatureType_BINANCE
 			}
 
 			foreignAddr := loom.Address{ChainID: chainId, Local: foreignLocalAddr}
 			mapping.To = foreignAddr.MarshalPB()
-			mapping.Signature, err = address_mapper.SignIdentityMapping(user, foreignAddr, privkey)
+			mapping.Signature, err = address_mapper.SignIdentityMapping(user, foreignAddr, privkey, sigType)
 			if err != nil {
 				return errors.Wrapf(err, "sigining mapping with %s key", chainId)
 			}

--- a/cmd/loom/gateway/gateway_cmd.go
+++ b/cmd/loom/gateway/gateway_cmd.go
@@ -25,6 +25,7 @@ func NewGatewayCommand() *cobra.Command {
 		newUpdateTrustedValidatorsCommand(),
 		newSetWithdrawFeeCommand(),
 		newWithdrawalReceiptCommand(),
+		newMapBinanceContractsCommand(),
 	)
 	return cmd
 }

--- a/cmd/loom/gateway/mapping_cmds.go
+++ b/cmd/loom/gateway/mapping_cmds.go
@@ -220,12 +220,14 @@ func newMapAccountsCommand() *cobra.Command {
 					foreignOwnerAddr.Local.String(),
 				)
 
-				sign, err := getSignatureInteractive(hash)
+				sign, err := getSignatureInteractive(hash, evmcompat.SignatureType_GETH)
 				if err != nil {
 					return err
 				}
+				// allow only SignatureType_GETH for the recover address function
+				allowSigTypes := []evmcompat.SignatureType{evmcompat.SignatureType_GETH}
 				// Do a local recovery on the signature to make sure the user is passing the correct byte
-				signer, err := evmcompat.RecoverAddressFromTypedSig(hash, sign[:])
+				signer, err := evmcompat.RecoverAddressFromTypedSig(hash, sign[:], allowSigTypes)
 				if err != nil {
 					return err
 				}
@@ -402,7 +404,7 @@ func newGetContractMappingCommand() *cobra.Command {
 	return cmd
 }
 
-func getSignatureInteractive(hash []byte) ([prefixedSigLength]byte, error) {
+func getSignatureInteractive(hash []byte, sigType evmcompat.SignatureType) ([prefixedSigLength]byte, error) {
 	// get it from the signature
 	fmt.Printf("Please paste the following hash to your signing software. After signing it, paste the signature below (prefixed with 0x)\n")
 	fmt.Printf("0x%v\n", hex.EncodeToString(hash))
@@ -430,7 +432,7 @@ func getSignatureInteractive(hash []byte) ([prefixedSigLength]byte, error) {
 
 	// create the prefixed sig so that it matches the way it's verified on address mapper
 	var sigBytes [prefixedSigLength]byte
-	prefix := byte(evmcompat.SignatureType_GETH)
+	prefix := byte(sigType)
 	typedSig := append(make([]byte, 0, prefixedSigLength), prefix)
 	copy(sigBytes[:], append(typedSig, sigStripped...))
 
@@ -453,4 +455,97 @@ func getDAppChainClient() *client.DAppChainRPCClient {
 	writeURI := gatewayCmdFlags.URI + "/rpc"
 	readURI := gatewayCmdFlags.URI + "/query"
 	return client.NewDAppChainRPCClient(gatewayCmdFlags.ChainID, writeURI, readURI)
+}
+
+const mapBinanceContractsCmdExample = `
+./loom gateway map-binance-contracts \
+	0x2a6b071aD396cEFdd16c731454af0d8c95ECD4B2 LOOM-172 \
+	--eth-key path/to/binance_priv.key \
+	--key path/to/loom_priv.key
+./loom gateway map-binance-contracts \
+	0x2a6b071aD396cEFdd16c731454af0d8c95ECD4B2 LOOM-172 \
+	--key <base64-encoded-private-key-of-gateway-owner>
+	--authorized
+`
+
+func newMapBinanceContractsCommand() *cobra.Command {
+	var authorized bool
+	var chainID string
+	var gatewayType = "binance-gateway"
+	cmd := &cobra.Command{
+		Use:     "map-binance-contracts <local-contract-addr> <token-name>",
+		Short:   "Links a DAppChain token contract to an Binance token via the Transfer Gateway.",
+		Example: mapBinanceContractsCmdExample,
+		Args:    cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			loomKeyPath := gatewayCmdFlags.PrivKeyPath
+			ethKeyPath := gatewayCmdFlags.EthPrivKeyPath
+			hsmPath := gatewayCmdFlags.HSMConfigPath
+			algo := gatewayCmdFlags.Algo
+			signer, err := cli.GetSigner(loomKeyPath, hsmPath, algo)
+			if err != nil {
+				return err
+			}
+
+			localContractAddr, err := hexToLoomAddress(args[0])
+			if err != nil {
+				return errors.Wrap(err, "failed to resolve local contract address")
+			}
+
+			tokenNameHex := hex.EncodeToString([]byte(args[1]))
+			foreignContractAddr := common.HexToAddress(tokenNameHex)
+
+			rpcClient := getDAppChainClient()
+			gatewayAddr, err := rpcClient.Resolve(gatewayType)
+			if err != nil {
+				return errors.Wrap(err, "failed to resolve DAppChain Gateway address")
+			}
+			gateway := client.NewContract(rpcClient, gatewayAddr.Local)
+
+			if authorized {
+				req := &tgtypes.TransferGatewayAddContractMappingRequest{
+					ForeignContract: loom.Address{
+						ChainID: chainID,
+						Local:   foreignContractAddr.Bytes(),
+					}.MarshalPB(),
+					LocalContract: localContractAddr.MarshalPB(),
+				}
+
+				_, err = gateway.Call("AddAuthorizedContractMapping", req, signer, nil)
+				return err
+			}
+
+			creatorKey, err := crypto.LoadECDSA(ethKeyPath)
+			if err != nil {
+				return errors.Wrap(err, "failed to load creator Ethereum key")
+			}
+
+			hash := ssha.SoliditySHA3(
+				[]string{"address", "address"},
+				foreignContractAddr,
+				localContractAddr.Local.String(),
+			)
+			sig, err := evmcompat.GenerateTypedSig(hash, creatorKey, evmcompat.SignatureType_BINANCE)
+			if err != nil {
+				return errors.Wrap(err, "failed to generate creator signature")
+			}
+
+			// no ForeignContractTxHash for binance
+			req := &tgtypes.TransferGatewayAddContractMappingRequest{
+				ForeignContract: loom.Address{
+					ChainID: chainID,
+					Local:   foreignContractAddr.Bytes(),
+				}.MarshalPB(),
+				LocalContract:             localContractAddr.MarshalPB(),
+				ForeignContractCreatorSig: sig,
+			}
+
+			_, err = gateway.Call("AddContractMapping", req, signer, nil)
+			return err
+		},
+	}
+	cmdFlags := cmd.Flags()
+	cmdFlags.BoolVar(&authorized, "authorized", false, "Add contract mapping authorized by the Gateway owner")
+	cmdFlags.StringVar(&chainID, "chain-id", "binance", "Foreign chain id")
+	return cmd
 }

--- a/e2e/loom-4-genesis.json
+++ b/e2e/loom-4-genesis.json
@@ -52,6 +52,14 @@
             {
               "name":"migration:1",
               "status":"WAITING"
+            },
+            {
+              "name":"mw:mulcsigtx:v1.1",
+              "status":"WAITING"
+            },
+            {
+              "name":"addrmapper:v1.1",
+              "status":"WAITING"
             }
           ]
       }

--- a/e2e/loom-4-genesis.json
+++ b/e2e/loom-4-genesis.json
@@ -42,6 +42,10 @@
               "status":"WAITING"
             },
             {
+              "name":"auth:sigtx:binance",
+              "status":"WAITING"
+            },
+            {
               "name":"tx:migration",
               "status":"WAITING"
             },

--- a/e2e/loom-4-loom.yaml
+++ b/e2e/loom-4-loom.yaml
@@ -20,3 +20,6 @@ Auth:
     tron:
       TxType: "tron"
       AccountType: 1
+    binance:
+      TxType: "binance"
+      AccountType: 1

--- a/e2e/loom-4-test.toml
+++ b/e2e/loom-4-test.toml
@@ -1,7 +1,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} chain-cfg list-features"
   Condition = "contains"
-  Expected = [ "auth:sigtx:default","auth:sigtx:tron", "auth:sigtx:eth" ]
+  Expected = [ "auth:sigtx:default","auth:sigtx:tron", "auth:sigtx:eth", "auth:sigtx:binance" ]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} migration --id 1 -k {{index $.NodePrivKeyPathList 0}}"
@@ -26,6 +26,11 @@
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} chain-cfg feature-enabled auth:sigtx:default"
+  Condition = "contains"
+  Expected = [ "true" ]
+
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} chain-cfg feature-enabled auth:sigtx:binance"
   Condition = "contains"
   Expected = [ "true" ]
 
@@ -68,9 +73,9 @@
   Expected = [ "Call response: ", "[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 219]" ]
   Datafiles = [ { Filename = "inputGet.bin", Contents = "6d4ce63c" } ]
 
-#tron
+# tron
 [[TestCases]]
-  RunCmd = "{{ $.LoomPath }} addressmapper add-identity-mapping default:{{index $.AccountAddressList 1}} {{index $.EthAccountPrivKeyPathList 1}} -c tron -k {{index $.AccountPrivKeyPathList 1}}"
+  RunCmd = "{{ $.LoomPath }} addressmapper add-identity-mapping default:{{index $.AccountAddressList 1}} {{index $.TronAccountPrivKeyPathList 1}} -c tron -k {{index $.AccountPrivKeyPathList 1}}"
   Condition = "contains"
   Expected = [ "mapping successful" ]
 
@@ -80,7 +85,7 @@
   Expected = ["default" , "tron" ]
 
 [[TestCases]]
-  RunCmd = "{{ $.LoomPath }} deploy -b SimpleStore.bin -n SimpleStoreTron --algo tron --chain default --caller-chain tron -k {{index $.EthAccountPrivKeyPathList 1}}"
+  RunCmd = "{{ $.LoomPath }} deploy -b SimpleStore.bin -n SimpleStoreTron --algo tron --chain default --caller-chain tron -k {{index $.TronAccountPrivKeyPathList 1}}"
   Condition = "contains"
   Expected = [ "New contract deployed with address: "  ]
   Datafiles = [
@@ -88,13 +93,44 @@
   ]
 
 [[TestCases]]
-  RunCmd = "{{ $.LoomPath }} callevm -i inputSet987.bin -n SimpleStoreTron --algo tron --chain default --caller-chain tron -k {{index $.EthAccountPrivKeyPathList 1}}"
+  RunCmd = "{{ $.LoomPath }} callevm -i inputSet987.bin -n SimpleStoreTron --algo tron --chain default --caller-chain tron -k {{index $.TronAccountPrivKeyPathList 1}}"
   Condition = "contains"
   Expected = [ "Call response: " ]
   Datafiles = [ { Filename = "inputSet987.bin", Contents = "60fe47b100000000000000000000000000000000000000000000000000000000000003db" } ]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} static-call-evm -i inputGet.bin -n SimpleStoreTron"
+  Condition = "contains"
+  Expected = [ "Call response: ", "[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 219]" ]
+  Datafiles = [ { Filename = "inputGet.bin", Contents = "6d4ce63c" } ]
+
+# Binance
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} addressmapper add-identity-mapping default:{{index $.AccountAddressList 2}} {{index $.EthAccountPrivKeyPathList 2}} -c binance -k {{index $.AccountPrivKeyPathList 2}}"
+  Condition = "contains"
+  Expected = [ "mapping successful" ]
+
+ [[TestCases]]
+  RunCmd = "{{ $.LoomPath }} addressmapper list-mappings"
+  Condition = "contains"
+  Expected = ["default" , "binance" ]
+
+ [[TestCases]]
+  RunCmd = "{{ $.LoomPath }} deploy -b SimpleStore.bin -n SimpleStoreBinance --algo binance --chain default --caller-chain binance -k {{index $.EthAccountPrivKeyPathList 2}}"
+  Condition = "contains"
+  Expected = [ "New contract deployed with address: "  ]
+  Datafiles = [
+    { Filename = "SimpleStore.bin", Contents = "6060604052341561000f57600080fd5b60d38061001d6000396000f3006060604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c14606e575b600080fd5b3415605857600080fd5b606c60048080359060200190919050506094565b005b3415607857600080fd5b607e609e565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a723058202b229fba38c096f9c9c81ba2633fb4a7b418032de7862b60d1509a4054e2d6bb0029" }
+  ]
+
+ [[TestCases]]
+  RunCmd = "{{ $.LoomPath }} callevm -i inputSet987.bin -n SimpleStoreBinance --algo binance --chain default --caller-chain binance -k {{index $.EthAccountPrivKeyPathList 2}}"
+  Condition = "contains"
+  Expected = [ "Call response: " ]
+  Datafiles = [ { Filename = "inputSet987.bin", Contents = "60fe47b100000000000000000000000000000000000000000000000000000000000003db" } ]
+
+ [[TestCases]]
+  RunCmd = "{{ $.LoomPath }} static-call-evm -i inputGet.bin -n SimpleStoreBinance"
   Condition = "contains"
   Expected = [ "Call response: ", "[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 219]" ]
   Datafiles = [ { Filename = "inputGet.bin", Contents = "6d4ce63c" } ]

--- a/e2e/loom_test.go
+++ b/e2e/loom_test.go
@@ -19,7 +19,7 @@ func TestE2eEvm(t *testing.T) {
 	}{
 		{"evm", "loom-1-test.toml", 4, 10, 0, "empty-genesis.json", "loom.yaml"},
 		{"ethSignature-type1", "loom-3-test.toml", 1, 1, 1, "loom-3-genesis.json", "loom-3-loom.yaml"},
-		{"ethSignature-type2", "loom-4-test.toml", 1, 2, 2, "loom-4-genesis.json", "loom-4-loom.yaml"},
+		{"ethSignature-type2", "loom-4-test.toml", 1, 4, 4, "loom-4-genesis.json", "loom-4-loom.yaml"},
 		{"migration-tx", "loom-5-test.toml", 3, 3, 3, "loom-5-genesis.json", "loom-5-loom.yaml"},
 		{"evm-state-migration", "loom-6-test.toml", 4, 4, 4, "loom-6-genesis.json", "loom-6-loom.yaml"},
 		{"evm-name-option-not-allow", "loom-7-test.toml", 2, 2, 0, "loom-7-genesis.json", "loom-7-loom.yaml"},

--- a/features.go
+++ b/features.go
@@ -13,6 +13,11 @@ const (
 	// Enables processing of txs via MultiChainSignatureTxMiddleware, there's a feature flag per
 	// allowed chain ID, e.g. auth:sigtx:default, auth:sigtx:eth
 	AuthSigTxFeaturePrefix = "auth:sigtx:"
+	// The list of allowed feature flags for multi chain signature tx
+	AuthSigTxDefault = "auth:sigtx:default"
+	AuthSigTxEth     = "auth:sigtx:eth"
+	AuthSigTxTron    = "auth:sigtx:tron"
+	AuthSigTxBinance = "auth:sigtx:binance"
 
 	// Enables DPOS v3
 	// NOTE: The DPOS v3 contract must be loaded & deployed first!

--- a/features.go
+++ b/features.go
@@ -8,16 +8,20 @@ const (
 	TGHotWalletFeature = "tg:hot-wallet"
 	// Enables prevention of zero amount token withdrawals in the Gateway contract
 	TGCheckZeroAmount = "tg:check-zamt"
-	//Enables workaround for handling of ERC721 deposits in the Gateway contract
+	// Enables workaround for handling of ERC721 deposits in the Gateway contract
 	TGFixERC721Feature = "tg:fix-erc721"
+	// Enables support for Binance contract mappings in the Binance Gateway contract
+	TGBinanceContractMappingFeature = "tg:binance-cm"
+
+	// Enables support for mapping DAppChain accounts to Binance accounts
+	AddressMapperVersion1_1 = "addrmapper:v1.1"
+
 	// Enables processing of txs via MultiChainSignatureTxMiddleware, there's a feature flag per
 	// allowed chain ID, e.g. auth:sigtx:default, auth:sigtx:eth
 	AuthSigTxFeaturePrefix = "auth:sigtx:"
-	// The list of allowed feature flags for multi chain signature tx
-	AuthSigTxDefault = "auth:sigtx:default"
-	AuthSigTxEth     = "auth:sigtx:eth"
-	AuthSigTxTron    = "auth:sigtx:tron"
-	AuthSigTxBinance = "auth:sigtx:binance"
+
+	// Enables stricter chain-specific signature verification in MultiChainSignatureTxMiddleware
+	MultiChainSigTxMiddlewareVersion1_1 = "mw:mulcsigtx:v1.1"
 
 	// Enables DPOS v3
 	// NOTE: The DPOS v3 contract must be loaded & deployed first!


### PR DESCRIPTION
- [x] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request

This PR adds Binance signer to auth middleware so the client can use send txn using Binance private key (in secp256k1 format) with Bitcoin's style address.