### PR TITLE
Increase test timeout to 35 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ GOFLAGS_NOEVM = -ldflags "$(GOFLAGS_BASE)"
 
 WINDOWS_BUILD_VARS = CC=x86_64-w64-mingw32-gcc CGO_ENABLED=1 GOOS=windows GOARCH=amd64 BIN_EXTENSION=.exe
 
-E2E_TESTS_TIMEOUT = 28m
+E2E_TESTS_TIMEOUT = 35m
 
 .PHONY: all clean test install get_lint update_lint deps proto builtin oracles tgoracle loomcoin_tgoracle tron_tgoracle binance_tgoracle pcoracle dposv2_oracle plasmachain-cleveldb loom-cleveldb lint
 


### PR DESCRIPTION
OSX Jenkins slaves are a bit slow and need more time to run all the tests.