### PR TITLE
Coin contract need to validate some field in the request

### DIFF
--- a/builtin/plugins/coin/coin.go
+++ b/builtin/plugins/coin/coin.go
@@ -234,7 +234,6 @@ func (c *Coin) BalanceOf(
 	ctx contract.StaticContext,
 	req *BalanceOfRequest,
 ) (*BalanceOfResponse, error) {
-
 	if req.Owner == nil {
 		return nil, ErrInvalidRequest
 	}
@@ -346,7 +345,6 @@ func (c *Coin) Allowance(
 }
 
 func (c *Coin) TransferFrom(ctx contract.Context, req *TransferFromRequest) error {
-
 	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) {
 		if req.Amount == nil || req.From == nil || req.To == nil {
 			return ErrInvalidRequest
@@ -434,9 +432,6 @@ func loadAccount(
 }
 
 func saveAccount(ctx contract.Context, acct *Account) error {
-	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && (acct.Owner == nil || acct.Balance == nil) {
-		return ErrInvalidRequest
-	}
 	owner := loom.UnmarshalAddressPB(acct.Owner)
 	return ctx.Set(accountKey(owner), acct)
 }
@@ -461,11 +456,6 @@ func loadAllowance(
 }
 
 func saveAllowance(ctx contract.Context, allow *Allowance) error {
-	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) {
-		if allow.Owner == nil || allow.Spender == nil || allow.Amount == nil {
-			return ErrInvalidRequest
-		}
-	}
 	owner := loom.UnmarshalAddressPB(allow.Owner)
 	spender := loom.UnmarshalAddressPB(allow.Spender)
 	return ctx.Set(allowanceKey(owner, spender), allow)

--- a/builtin/plugins/coin/coin.go
+++ b/builtin/plugins/coin/coin.go
@@ -108,6 +108,9 @@ func (c *Coin) Init(ctx contract.Context, req *InitRequest) error {
 
 // MintToGateway adds loom coins to the loom coin Gateway contract balance, and updates the total supply.
 func (c *Coin) MintToGateway(ctx contract.Context, req *MintToGatewayRequest) error {
+	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && req.Amount == nil {
+		return ErrInvalidRequest
+	}
 	gatewayAddr, err := ctx.Resolve("loomcoin-gateway")
 	if err != nil {
 		return errUtil.Wrap(err, "failed to mint Loom coin")

--- a/builtin/plugins/coin/coin.go
+++ b/builtin/plugins/coin/coin.go
@@ -235,10 +235,9 @@ func (c *Coin) BalanceOf(
 	req *BalanceOfRequest,
 ) (*BalanceOfResponse, error) {
 
-	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && req.Owner == nil {
+	if req.Owner == nil {
 		return nil, ErrInvalidRequest
 	}
-
 	owner := loom.UnmarshalAddressPB(req.Owner)
 	acct, err := loadAccount(ctx, owner)
 	if err != nil {
@@ -330,7 +329,7 @@ func (c *Coin) Allowance(
 	ctx contract.StaticContext,
 	req *AllowanceRequest,
 ) (*AllowanceResponse, error) {
-	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && (req.Spender == nil || req.Owner == nil) {
+	if req.Spender == nil || req.Owner == nil {
 		return nil, ErrInvalidRequest
 	}
 	owner := loom.UnmarshalAddressPB(req.Owner)

--- a/builtin/plugins/coin/coin_test.go
+++ b/builtin/plugins/coin/coin_test.go
@@ -574,23 +574,4 @@ func TestNilRequest(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-
-	err = saveAccount(ctx, &Account{
-		Owner:   nil,
-		Balance: nil,
-	})
-	require.Equal(t, err, ErrInvalidRequest)
-	err = saveAccount(ctx, &Account{
-		Owner: addr1.MarshalPB(),
-		Balance: &types.BigUInt{
-			Value: *amount,
-		}})
-	require.NoError(t, err)
-	err = saveAllowance(ctx, &Allowance{
-		Owner:   nil,
-		Spender: nil,
-		Amount:  nil,
-	})
-	require.Equal(t, err, ErrInvalidRequest)
-
 }

--- a/builtin/plugins/ethcoin/eth_coin.go
+++ b/builtin/plugins/ethcoin/eth_coin.go
@@ -42,6 +42,7 @@ type (
 
 var (
 	ErrSenderBalanceTooLow = errors.New("sender balance is too low")
+	ErrInvalidRequest      = errors.New("[ETH coin contract] invalid request")
 )
 
 var (
@@ -78,6 +79,9 @@ func (c *ETHCoin) Init(ctx contract.Context, req *InitRequest) error {
 
 // MintToGateway adds ETH to the Gateway contract balance, and updates the total supply.
 func (c *ETHCoin) MintToGateway(ctx contract.Context, req *MintToGatewayRequest) error {
+	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && req.Amount == nil {
+		return ErrInvalidRequest
+	}
 	gatewayAddr, err := ctx.Resolve("gateway")
 	if err != nil {
 		return errors.Wrap(err, "failed to mint ETH")
@@ -141,6 +145,9 @@ func (c *ETHCoin) TotalSupply(ctx contract.StaticContext, req *TotalSupplyReques
 }
 
 func (c *ETHCoin) BalanceOf(ctx contract.StaticContext, req *BalanceOfRequest) (*BalanceOfResponse, error) {
+	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && req.Owner == nil {
+		return nil, ErrInvalidRequest
+	}
 	owner := loom.UnmarshalAddressPB(req.Owner)
 	balance, err := BalanceOf(ctx, owner)
 	if err != nil {
@@ -205,6 +212,9 @@ func SetBalance(ctx contract.Context, addr loom.Address, amount *loom.BigUInt) e
 }
 
 func (c *ETHCoin) Transfer(ctx contract.Context, req *TransferRequest) error {
+	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && (req.Amount == nil || req.To == nil) {
+		return ErrInvalidRequest
+	}
 	from := ctx.Message().Sender
 	to := loom.UnmarshalAddressPB(req.To)
 	amount := req.Amount.Value
@@ -259,6 +269,9 @@ func transfer(ctx contract.Context, from, to loom.Address, amount *loom.BigUInt)
 }
 
 func (c *ETHCoin) Approve(ctx contract.Context, req *ApproveRequest) error {
+	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && (req.Spender == nil || req.Amount == nil) {
+		return ErrInvalidRequest
+	}
 	owner := ctx.Message().Sender
 	spender := loom.UnmarshalAddressPB(req.Spender)
 
@@ -282,6 +295,9 @@ func (c *ETHCoin) Approve(ctx contract.Context, req *ApproveRequest) error {
 }
 
 func (c *ETHCoin) Allowance(ctx contract.StaticContext, req *AllowanceRequest) (*AllowanceResponse, error) {
+	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && (req.Owner == nil || req.Spender == nil) {
+		return nil, ErrInvalidRequest
+	}
 	owner := loom.UnmarshalAddressPB(req.Owner)
 	spender := loom.UnmarshalAddressPB(req.Spender)
 
@@ -296,6 +312,10 @@ func (c *ETHCoin) Allowance(ctx contract.StaticContext, req *AllowanceRequest) (
 }
 
 func (c *ETHCoin) TransferFrom(ctx contract.Context, req *TransferFromRequest) error {
+	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) &&
+		(req.Amount == nil || req.From == nil || req.To == nil) {
+		return ErrInvalidRequest
+	}
 	if ctx.FeatureEnabled(loomchain.CoinVersion1_1Feature, false) {
 		return c.transferFrom(ctx, req)
 	}

--- a/builtin/plugins/ethcoin/eth_coin.go
+++ b/builtin/plugins/ethcoin/eth_coin.go
@@ -145,7 +145,7 @@ func (c *ETHCoin) TotalSupply(ctx contract.StaticContext, req *TotalSupplyReques
 }
 
 func (c *ETHCoin) BalanceOf(ctx contract.StaticContext, req *BalanceOfRequest) (*BalanceOfResponse, error) {
-	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && req.Owner == nil {
+	if req.Owner == nil {
 		return nil, ErrInvalidRequest
 	}
 	owner := loom.UnmarshalAddressPB(req.Owner)
@@ -295,7 +295,7 @@ func (c *ETHCoin) Approve(ctx contract.Context, req *ApproveRequest) error {
 }
 
 func (c *ETHCoin) Allowance(ctx contract.StaticContext, req *AllowanceRequest) (*AllowanceResponse, error) {
-	if ctx.FeatureEnabled(loomchain.CoinVersion1_2Feature, false) && (req.Owner == nil || req.Spender == nil) {
+	if req.Owner == nil || req.Spender == nil {
 		return nil, ErrInvalidRequest
 	}
 	owner := loom.UnmarshalAddressPB(req.Owner)

--- a/features.go
+++ b/features.go
@@ -74,7 +74,7 @@ const (
 	// Enables Coin v1.1 contract (also applies to ETHCoin)
 	CoinVersion1_1Feature = "coin:v1.1"
 
-	// Enables Coin v1.2 to validate fields in request
+	// Enables Coin v1.2 to validate fields in request of Coin and ETH Coin contract
 	CoinVersion1_2Feature = "coin:v1.2"
 
 	// Force ReceiptHandler to write BloomFilter and EVM TxHash only to receipts_db, otherwise it'll

--- a/features.go
+++ b/features.go
@@ -66,6 +66,9 @@ const (
 	// Enables Coin v1.1 contract (also applies to ETHCoin)
 	CoinVersion1_1Feature = "coin:v1.1"
 
+	// Enables Coin v1.2 to validate fields in request
+	CoinVersion1_2Feature = "coin:v1.2"
+
 	// Force ReceiptHandler to write BloomFilter and EVM TxHash only to receipts_db, otherwise it'll
 	// write BloomFilter and EVM TxHash to both receipts_db & app.db.
 	AuxEvmDBFeature = "db:auxevm"


### PR DESCRIPTION
Since some method in coin contract did't check the value before trying to unmarshal.
So It is possible to unmarshal `nil` variable.
To prevent this we should validate variable before unmarshal.

In order to do that we need ...
- Check the variable before unmarshal. 
- This change needs to be enabled by feature flag `coin:v1.2`
- Add coin contract unit test for flag `coin:v1.2` is enabled.

ref : #902 
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request