### PR TITLE
Fix BlockStore.GetTxResult to return ResponseDeliverTx.Code 

### DIFF
--- a/store/block_store.go
+++ b/store/block_store.go
@@ -288,6 +288,7 @@ func (s *TendermintBlockStore) GetTxResult(txHash []byte) (*ctypes.ResultTx, err
 		Index:  txResult.Index,
 		Height: txResult.Height,
 		TxResult: abci.ResponseDeliverTx{
+			Code: txResult.TxResult.Code,
 			Data: txResult.TxResult.Data,
 			Info: txResult.TxResult.Info,
 		},


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request