### PR TITLE
Checking app/evm.db root on startup

### DIFF
--- a/store/evmstore.go
+++ b/store/evmstore.go
@@ -219,7 +219,7 @@ func (s *EvmStore) Commit(version int64) []byte {
 func (s *EvmStore) LoadVersion(targetVersion int64) error {
 	s.cache = make(map[string]cacheItem)
 	// find the last saved root
-	root, version := s.getLastSavedRoot(targetVersion)
+	root, version := s.GetLastSavedRoot(targetVersion)
 	if bytes.Equal(root, defaultRoot) {
 		root = []byte{}
 	}
@@ -240,7 +240,7 @@ func (s *EvmStore) Version() ([]byte, int64) {
 	return s.rootHash, s.version
 }
 
-func (s *EvmStore) getLastSavedRoot(targetVersion int64) ([]byte, int64) {
+func (s *EvmStore) GetLastSavedRoot(targetVersion int64) ([]byte, int64) {
 	start := util.PrefixKey(vmPrefix, evmRootPrefix)
 	end := prefixRangeEnd(evmRootKey(targetVersion))
 	iter := s.evmDB.ReverseIterator(start, end)
@@ -264,7 +264,7 @@ func (s *EvmStore) GetSnapshot(version int64) db.Snapshot {
 	if exist {
 		targetRoot = val.([]byte)
 	} else {
-		targetRoot, _ = s.getLastSavedRoot(version)
+		targetRoot, _ = s.GetLastSavedRoot(version)
 	}
 	return NewEvmStoreSnapshot(s.evmDB.GetSnapshot(), targetRoot)
 }

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -82,7 +82,7 @@ func NewMultiWriterAppStore(appStore *IAVLStore, evmStore *EvmStore, saveEVMStat
 			appStoreEvmRoot = defaultRoot
 		}
 	}
-	evmStoreEvmRoot, version := store.evmStore.getLastSavedRoot(store.appStore.Version())
+	evmStoreEvmRoot, version := store.evmStore.GetLastSavedRoot(store.appStore.Version())
 	if !bytes.Equal(appStoreEvmRoot, evmStoreEvmRoot) {
 		return nil, fmt.Errorf("EVM roots mismatch, evm.db(%d): %X, app.db(%d): %X",
 			version, evmStoreEvmRoot, appStore.Version(), appStoreEvmRoot)


### PR DESCRIPTION
Since the app.db evm root and evm.db root sometimes different on startup.
We should add the logic that check and change app.db version to evm.db version.

This PR will..

- Change `getEvmRoot` function for use outside it's package
- Check iavlstore and evmstore version before load `MultiWriterAppstore`

ref : https://github.com/loomnetwork/loomchain/issues/1359
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request