### PR TITLE
Fix time-until-election command show negative response

### DIFF
--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -1234,7 +1234,13 @@ func (c *DPOS) TimeUntilElection(ctx contract.StaticContext, req *TimeUntilElect
 		return nil, err
 	}
 
-	remainingTime := state.Params.ElectionCycleLength - (ctx.Now().Unix() - state.LastElectionTime)
+	var remainingTime int64
+	if state.Params.ElectionCycleLength == 0 {
+		remainingTime = 0
+	} else {
+		remainingTime = state.Params.ElectionCycleLength - ((ctx.Now().Unix() - state.LastElectionTime) % state.Params.ElectionCycleLength)
+	}
+
 	return &TimeUntilElectionResponse{
 		TimeUntilElection: remainingTime,
 	}, nil

--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -1227,7 +1227,9 @@ func applyPowerCap(validators []*Validator) []*Validator {
 	return validators
 }
 
-func (c *DPOS) TimeUntilElection(ctx contract.StaticContext, req *TimeUntilElectionRequest) (*TimeUntilElectionResponse, error) {
+func (c *DPOS) TimeUntilElection(
+	ctx contract.StaticContext, req *TimeUntilElectionRequest,
+) (*TimeUntilElectionResponse, error) {
 	ctx.Logger().Debug("DPOSv3 TimeUntilEleciton", "request", req)
 
 	state, err := LoadState(ctx)
@@ -1236,10 +1238,9 @@ func (c *DPOS) TimeUntilElection(ctx contract.StaticContext, req *TimeUntilElect
 	}
 
 	var remainingTime int64
-	if state.Params.ElectionCycleLength == 0 {
-		remainingTime = 0
-	} else {
-		remainingTime = state.Params.ElectionCycleLength - ((ctx.Now().Unix() - state.LastElectionTime) % state.Params.ElectionCycleLength)
+	if state.Params.ElectionCycleLength > 0 {
+		remainingTime = state.Params.ElectionCycleLength -
+			((ctx.Now().Unix() - state.LastElectionTime) % state.Params.ElectionCycleLength)
 	}
 
 	return &TimeUntilElectionResponse{

--- a/builtin/plugins/dposv3/dpos_test.go
+++ b/builtin/plugins/dposv3/dpos_test.go
@@ -175,6 +175,9 @@ func TestChangeParams(t *testing.T) {
 
 	stateResponse, err = dposContract.GetState(contractpb.WrapPluginContext(dposCtx.WithSender(oracleAddr)), &GetStateRequest{})
 	assert.Equal(t, stateResponse.State.Params.ElectionCycleLength, int64(100))
+
+	resp, err := dposContract.TimeUntilElection(contractpb.WrapPluginStaticContext(dposCtx.WithSender(addr2)), &TimeUntilElectionRequest{})
+	assert.Equal(t, stateResponse.State.Params.ElectionCycleLength, resp.TimeUntilElection)
 }
 
 func TestRegisterWhitelistedCandidate(t *testing.T) {
@@ -809,6 +812,7 @@ func TestReward(t *testing.T) {
 	// checking that distribution is roughtly equal to 5% of delegation after one year
 	assert.Equal(t, rewardTotal.Cmp(&loom.BigUInt{big.NewInt(490000000000)}), 1)
 	assert.Equal(t, rewardTotal.Cmp(&loom.BigUInt{big.NewInt(510000000000)}), -1)
+
 }
 
 func TestElectWhitelists(t *testing.T) {


### PR DESCRIPTION
Negative value response happens when we did not set `ElectionCycleLength` and the election process never happened.

We should just
- set the remaining time untill election to 0 when `ElectionCycleLength` never set before.

ref : #1363 