### PR TITLE
TxReceipt: get tx index from blockstore not receipt.

### DIFF
--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -790,11 +790,8 @@ func (s *QueryServer) EthGetTransactionReceipt(hash eth.Data) (*eth.JsonTxReceip
 		return nil, err
 	}
 	txReceipt.TransactionIndex, err = s.getTransactionIndex(&txReceipt)
-	if int32(len(blockResult.Block.Data.Txs)) <= txReceipt.TransactionIndex {
-		return nil, errors.Errorf(
-			"Transaction index %v out of bounds for transactions in block %v",
-			txReceipt.TransactionIndex, len(blockResult.Block.Data.Txs),
-		)
+	if err != nil {
+		return nil, err
 	}
 	txResults, err := s.BlockStore.GetTxResult(blockResult.Block.Data.Txs[txReceipt.TransactionIndex].Hash())
 	if err != nil {


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request

Addresses https://github.com/loomnetwork/loomchain/issues/1365
This gets the transaction index from the TM-BlockStore rather than the receipt database. 

The tx Index should be the same in both, however, for some historic reason it a difference might occur. In this case, the value in the TM-blockstore is the correct one. This should take slightly longer but guaranteed always returning the correct tx index value.
