### PR TITLE
Reformat dpos3 commands

### DIFF
--- a/e2e/deployerwhitelist.toml
+++ b/e2e/deployerwhitelist.toml
@@ -109,4 +109,4 @@
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   All = true
   Condition = "contains"
-  Expected = ["local"]
+  Expected = ["Address"]

--- a/e2e/dpos-2-validators.toml
+++ b/e2e/dpos-2-validators.toml
@@ -3,7 +3,7 @@
   Delay = 1000
   All = true
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} coin approve dposV3 1250000 -k {{index $.NodePrivKeyPathList 0}}"
@@ -41,7 +41,7 @@
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   All = true
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} coin approve dposV3 6 -k {{index $.NodePrivKeyPathList 0}}"

--- a/e2e/dpos-4-validators.toml
+++ b/e2e/dpos-4-validators.toml
@@ -2,7 +2,7 @@
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   All = true
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}", "{{index $.NodeBase64AddressList 2}}", "{{index $.NodeBase64AddressList 3}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}", "{{index $.NodeAddressList 2}}", "{{index $.NodeAddressList 3}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} coin transfer dposV3 90 -k {{index $.NodePrivKeyPathList 0}}"
@@ -94,7 +94,7 @@
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   All = true
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}", "{{index $.NodeBase64AddressList 2}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeddressList 1}}", "{{index $.NodeAddressList 2}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 unbond {{index $.NodeAddressList 0}} 0 0 -k {{index $.NodePrivKeyPathList 0}}"
@@ -112,7 +112,7 @@
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   All = true
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}", "{{index $.NodeBase64AddressList 2}}", "{{index $.NodeBase64AddressList 3}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}", "{{index $.NodeAddressList 2}}", "{{index $.NodeAddressList 3}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 check-rewards"

--- a/e2e/dpos-downtime.toml
+++ b/e2e/dpos-downtime.toml
@@ -44,7 +44,7 @@
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Node = 0
   Condition = "contains"
-  Expected = ["address"]
+  Expected = ["Address"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} coin approve dposV3 1250000 -k {{index $.NodePrivKeyPathList 2}}"
@@ -67,13 +67,13 @@
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Node = 0
   Condition = "contains"
-  Expected = ["address"]
+  Expected = ["Address"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Node = 1
   Condition = "contains"
-  Expected = ["address"]
+  Expected = ["Address"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} coin approve dposV3 1250000 -k {{index $.NodePrivKeyPathList 1}}"
@@ -104,7 +104,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 1}}", "{{index $.NodeBase64AddressList 2}}", "{{index $.NodeBase64AddressList 3}}"]
+  Expected = ["{{index $.NodeAddressList 1}}", "{{index $.NodeAddressList 2}}", "{{index $.NodeAddressList 3}}"]
 
 # Checking that killed node is indeed offline
 [[TestCases]]

--- a/e2e/dpos-elect-time-2-validators.toml
+++ b/e2e/dpos-elect-time-2-validators.toml
@@ -1,7 +1,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} coin transfer dposV3 90 -k {{index $.NodePrivKeyPathList 0}}"
@@ -74,7 +74,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}"]
+  Expected = ["{{index $.NodeAddressList 0}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 delegate {{index $.NodeAddressList 0}} 11 -k {{index $.NodePrivKeyPathList 0}}"
@@ -96,7 +96,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
   Delay = 15000
 
 [[TestCases]]
@@ -117,12 +117,12 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 check-delegator-rewards {{index $.NodeAddressList 0}}"
@@ -132,7 +132,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 check-delegator-rewards {{index $.NodeAddressList 0}}"
@@ -142,7 +142,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 check-delegator-rewards {{index $.NodeAddressList 0}}"
@@ -152,7 +152,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 check-delegator-rewards {{index $.NodeAddressList 0}}"
@@ -162,7 +162,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 check-delegator-rewards {{index $.NodeAddressList 0}}"
@@ -172,7 +172,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 check-delegator-rewards {{index $.NodeAddressList 0}}"
@@ -182,7 +182,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["{{index $.NodeBase64AddressList 0}}", "{{index $.NodeBase64AddressList 1}}"]
+  Expected = ["{{index $.NodeAddressList 0}}", "{{index $.NodeAddressList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 check-delegator-rewards {{index $.NodeAddressList 0}}"

--- a/e2e/dposv3-delegation.toml
+++ b/e2e/dposv3-delegation.toml
@@ -133,7 +133,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["\"Value\": 12500", "{{index $.NodeBase64AddressList 1}}", "{{index $.NodeBase64AddressList 2}}"]
+  Expected = ["\"DelegationTotal\": \"12500", "{{index $.NodeAddressList 1}}", "{{index $.NodeAddressList 2}}"]
 
 [[TestCases]]
   RunCmd = "check_validators"
@@ -159,7 +159,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["\"Value\": 12500", "{{index $.NodeBase64AddressList 3}}", "{{index $.NodeBase64AddressList 2}}"]
+  Expected = ["\"DelegationTotal\": \"12500", "{{index $.NodeAddressList 3}}", "{{index $.NodeAddressList 2}}"]
 
 [[TestCases]]
   RunCmd = "check_validators"
@@ -194,7 +194,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["\"Value\": 1250025", "{{index $.NodeBase64AddressList 1}}", "{{index $.NodeBase64AddressList 2}}"]
+  Expected = ["\"DelegationTotal\": \"1250025", "{{index $.NodeAddressList 1}}", "{{index $.NodeAddressList 2}}"]
 
 [[TestCases]]
   RunCmd = "check_validators"

--- a/e2e/loom-5-test.toml
+++ b/e2e/loom-5-test.toml
@@ -78,7 +78,7 @@
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "contains"
-  Expected = ["local"]
+  Expected = ["Address"]
 
 [[TestCases]]
   RunCmd = "check_validators"
@@ -87,13 +87,13 @@
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-candidates"
-  Condition = "contains"
+  Condition = "excludes"
   Excluded = ["{{index $.NodePubKeyList 1}}"]
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
   Condition = "excludes"
-  Excludes = ["{{index $.NodeBase64AddressList 0}}"]
+  Excludes = ["{{index $.NodeAddressList 0}}"]
 
 [[TestCases]]
   RunCmd = "check_validators"


### PR DESCRIPTION
This PR goal is to make JSON response from `dpos3` command more reable.
for example : 
- change `Address` field from base64 to hex
- change fields that has value as `Unix` time to `ISO` date time
- change `LockTimeTier` field (TIER_ZERO=2 weeks, TIER_ONE=3 months,TIER_TWO= 6 months, TIER_THREE=1 year)
- change amount and value field to base 10 number with 18 decimals

And more you can request.

ref : https://github.com/loomnetwork/loomchain/issues/1287
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request