### PR TITLE
Emit slash delegation event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = dpos3-slash-delegation-event
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = dpos3-slash-delegation-event
+GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -144,7 +144,7 @@ type (
 	DposElectionEvent               = dtypes.DposElectionEvent
 	DposSlashEvent                  = dtypes.DposSlashEvent
 	DposSlashDelegationEvent        = dtypes.DposSlashDelegationEvent
-	DposSlasWhitelistAmountEvent    = dtypes.DposSlashWhitelistAmountEvent
+	DposSlashWhitelistAmountEvent   = dtypes.DposSlashWhitelistAmountEvent
 	DposJailEvent                   = dtypes.DposJailEvent
 	DposUnjailEvent                 = dtypes.DposUnjailEvent
 	DposCandidateRegistersEvent     = dtypes.DposCandidateRegistersEvent
@@ -1860,7 +1860,8 @@ func slashValidatorDelegations(
 		updatedAmount.Sub(&statistic.WhitelistAmount.Value, &toSlash)
 		statistic.WhitelistAmount = &types.BigUInt{Value: *updatedAmount}
 		if err := emitSlashWhitelistAmountEvent(
-			ctx, validatorAddress.MarshalPB(), beforeSlashedWhitelistAmount, &types.BigUInt{Value: toSlash}, statistic.SlashPercentage,
+			ctx, validatorAddress.MarshalPB(), beforeSlashedWhitelistAmount,
+			&types.BigUInt{Value: toSlash}, statistic.SlashPercentage,
 		); err != nil {
 			return err
 		}
@@ -2473,9 +2474,9 @@ func emitSlashDelegationEvent(
 }
 
 func emitSlashWhitelistAmountEvent(
-	ctx contract.Context, validator *types.Address, whitelistAmount *types.BigUInt, slashAmount *types.BigUInt, slashPercentage *types.BigUInt,
+	ctx contract.Context, validator *types.Address, whitelistAmount, slashAmount, slashPercentage *types.BigUInt,
 ) error {
-	marshalled, err := proto.Marshal(&DposSlasWhitelistAmountEvent{
+	marshalled, err := proto.Marshal(&DposSlashWhitelistAmountEvent{
 		Validator:       validator,
 		WhitelistAmount: whitelistAmount,
 		SlashAmount:     slashAmount,


### PR DESCRIPTION
This PR makes DPOSv3 contract emit an event when a delegation or whitelist amount is slashed. 

Ref: https://github.com/loomnetwork/loomchain/issues/1406
go-loom: https://github.com/loomnetwork/go-loom/pull/439

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request