### PR TITLE
Make Web3 JSON-RPC endpoint accept string IDs in requests

### DIFF
--- a/rpc/eth/http_handler.go
+++ b/rpc/eth/http_handler.go
@@ -61,11 +61,11 @@ func (m *HttpRPCFunc) getInputValues(input JsonRpcRequest) (resp []reflect.Value
 	return inValues, nil
 }
 
-func (m *HttpRPCFunc) GetResponse(result json.RawMessage, id int64) (*JsonRpcResponse, *Error) {
+func (m *HttpRPCFunc) GetResponse(result json.RawMessage, ID *json.RawMessage) (*JsonRpcResponse, *Error) {
 	return &JsonRpcResponse{
 		Result:  result,
 		Version: "2.0",
-		ID:      id,
+		ID:      ID,
 	}, nil
 }
 
@@ -74,10 +74,10 @@ func (m *HttpRPCFunc) UnmarshalParamsAndCall(input JsonRpcRequest, _ *websocket.
 	if jsonErr != nil {
 		return resp, jsonErr
 	}
-	return m.call(inValues, input.ID)
+	return m.call(inValues)
 }
 
-func (m *HttpRPCFunc) call(inValues []reflect.Value, id int64) (resp json.RawMessage, jsonErr *Error) {
+func (m *HttpRPCFunc) call(inValues []reflect.Value) (resp json.RawMessage, jsonErr *Error) {
 	outValues := m.method.Call(inValues)
 
 	if outValues[1].Interface() != nil {

--- a/rpc/eth/jsonrpc_types.go
+++ b/rpc/eth/jsonrpc_types.go
@@ -9,26 +9,29 @@ import (
 
 type RPCFunc interface {
 	UnmarshalParamsAndCall(JsonRpcRequest, *websocket.Conn) (json.RawMessage, *Error)
-	GetResponse(json.RawMessage, int64) (*JsonRpcResponse, *Error)
+	GetResponse(result json.RawMessage, ID *json.RawMessage) (*JsonRpcResponse, *Error)
 }
 
 type JsonRpcRequest struct {
 	Version string          `json:"jsonrpc"`
 	Method  string          `json:"method"`
 	Params  json.RawMessage `json:"params"`
-	ID      int64           `json:"id"`
+	// The request ID can be a string, number, or may be missing entirely.
+	// We just pass it through as is in the response/error without unmarshalling.
+	// Related: https://github.com/ethereum/go-ethereum/issues/295
+	ID *json.RawMessage `json:"id"`
 }
 
 type JsonRpcResponse struct {
-	Result  json.RawMessage `json:"result"`
-	Version string          `json:"jsonrpc"`
-	ID      int64           `json:"id"`
+	Result  json.RawMessage  `json:"result"`
+	Version string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id"`
 }
 
 type JsonRpcErrorResponse struct {
-	Version string `json:"jsonrpc"`
-	ID      int64  `json:"id"`
-	Error   Error  `json:"error"`
+	Version string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id"`
+	Error   Error            `json:"error"`
 }
 
 // Json2 compliant error object

--- a/rpc/eth/websockets_handler.go
+++ b/rpc/eth/websockets_handler.go
@@ -8,12 +8,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-type WsJsonRpcResponse struct {
-	Result  json.RawMessage `json:"result"`
-	Version string          `json:"jsonrpc"`
-	Id      int64           `json:"id"`
-}
-
 type WSPRCFunc struct {
 	HttpRPCFunc
 }
@@ -51,5 +45,5 @@ func (w *WSPRCFunc) UnmarshalParamsAndCall(input JsonRpcRequest, conn *websocket
 		return resp, jsonErr
 	}
 	inValues = append([]reflect.Value{reflect.ValueOf(conn)}, inValues...)
-	return w.call(inValues, input.ID)
+	return w.call(inValues)
 }


### PR DESCRIPTION
The JSON-RPC can be a number, string, or could be missing entirely,
instead of attempting to decode it into an integer pass it through as is
in the response/error sent back to the client.