### PR TITLE
Fix flaky eth e2e tests

### DIFF
--- a/e2e/engine/cmd.go
+++ b/e2e/engine/cmd.go
@@ -228,6 +228,22 @@ func (e *engineCmd) Run(ctx context.Context, eventC chan *node.Event) error {
 							time.Sleep(time.Duration(time.Second))
 						}
 					}
+				} else if cmd.Args[0] == "wait_for_block_height_to_reach" {
+					if len(cmd.Args) > 2 {
+						maxWaitingTime := 60 // 60s
+						targetBlock, err := strconv.Atoi(cmd.Args[2])
+						if err != nil {
+							return fmt.Errorf("target block number is not defined, err: %s", err)
+						}
+						for i := maxWaitingTime; i > 0; i-- {
+							currentBlockHeight, _ := getLastBlockHeight(e.conf.Nodes[cmd.Args[1]])
+							fmt.Printf("current block height %d\n", currentBlockHeight)
+							if currentBlockHeight >= int64(targetBlock) {
+								break
+							}
+							time.Sleep(time.Duration(time.Second))
+						}
+					}
 				} else {
 					out, err = cmd.CombinedOutput()
 				}

--- a/e2e/eth-3-test.toml
+++ b/e2e/eth-3-test.toml
@@ -78,6 +78,9 @@
               ]
 
 [[TestCases]]
+  RunCmd = "wait_for_block_height_to_reach 0 2"
+  
+[[TestCases]]
   RunCmd = '/usr/bin/curl -X POST --data {"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2",true],"id":83} {{index $.NodeProxyAppAddressList 0}}/eth'
   Condition = "contains"
   Expected = [

--- a/e2e/eth-4-test.toml
+++ b/e2e/eth-4-test.toml
@@ -13,6 +13,8 @@
               '"id": 83'
              ]
 
+[[TestCases]]
+  RunCmd = "wait_for_block_height_to_reach 0 2"
 
 [[TestCases]]
   RunCmd = '/usr/bin/curl -X POST --data {"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByNumber","params":["0x2"],"id":83} {{index $.NodeProxyAppAddressList 0}}/eth'

--- a/e2e/eth-6-test.toml
+++ b/e2e/eth-6-test.toml
@@ -19,9 +19,15 @@
   ]
 
 [[TestCases]]
+  RunCmd = "wait_for_block_height_to_reach 0 2"
+
+[[TestCases]]
   RunCmd = '/usr/bin/curl -X POST --data {"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x2",true],"id":83} {{index $.NodeProxyAppAddressList 0}}/eth'
   Condition = "excludes"
   Expected = [ '"transactions": [],' ]
+
+[[TestCases]]
+  RunCmd = "wait_for_block_height_to_reach 0 3"
 
 [[TestCases]]
   RunCmd = '/usr/bin/curl -X POST --data {"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByNumber","params":["0x3"],"id":83} {{index $.NodeProxyAppAddressList 0}}/eth'


### PR DESCRIPTION
This PR adds `wait_for_block_height_to_reach` command to make eth e2e tests more reliable.

Ref: https://github.com/loomnetwork/loomchain/issues/1424

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request