### PR TITLE
Fix /query/eth_getBlockByNumber returning zero block number

### DIFF
--- a/e2e/tests/truffle/test/EthFunctions.js
+++ b/e2e/tests/truffle/test/EthFunctions.js
@@ -98,6 +98,12 @@ contract('MyToken', async (accounts) => {
     assert.equal(txObject.hash.toLowerCase(), receipt.transactionHash.toLowerCase(), "receipt tx hash and block transaction hash, full = false");
   });
 
+  it('eth_getBlockByNumber', async () => {
+    await MyToken.deployed();
+    const blockInfo = await web3js.eth.getBlock("latest");
+    assert(blockInfo.number > 0, "block number must be greater than zero");
+  });
+
   it('eth_getBlockTransactionCountByHash', async () => {
     const tokenContract = await MyToken.deployed();
     const result = await tokenContract.mintToken(105, { from: alice });

--- a/eth/query/block.go
+++ b/eth/query/block.go
@@ -263,15 +263,10 @@ func DeprecatedGetBlockByNumber(
 	blockinfo := types.EthBlockInfo{
 		Hash:       blockresult.BlockMeta.BlockID.Hash,
 		ParentHash: blockresult.Block.Header.LastBlockID.Hash,
-
-		Timestamp: int64(blockresult.Block.Header.Time.Unix()),
+		Timestamp:  int64(blockresult.Block.Header.Time.Unix()),
+		Number:     height,
+		LogsBloom:  evmAuxStore.GetBloomFilter(uint64(height)),
 	}
-	if state.Block().Height == height {
-		blockinfo.Number = 0
-	} else {
-		blockinfo.Number = height
-	}
-	blockinfo.LogsBloom = evmAuxStore.GetBloomFilter(uint64(height))
 
 	txHashList, err := evmAuxStore.GetTxHashList(uint64(height))
 	if err != nil {


### PR DESCRIPTION
When eth_getBlockNumber is called with "latest" as the block number
parameter then block info returned has the block number set as zero,
it should just return the latest block height.

The /eth endpoint appears to work correctly.