### PR TITLE
Add Update Mainnet Hot Wallet Address Cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = hot-wallet-muliple-deposits-per-user
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
-TG_GIT_REV = HEAD
+TG_GIT_REV = hot-wallet-muliple-deposits-per-user
 # loomnetwork/go-ethereum loomchain branch
 ETHEREUM_GIT_REV = 1fb6138d017a4309105d91f187c126cf979c93f9
 # use go-plugin we get 'timeout waiting for connection info' error

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = hot-wallet-muliple-deposits-per-user
+GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
-TG_GIT_REV = hot-wallet-muliple-deposits-per-user
+TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch
 ETHEREUM_GIT_REV = 1fb6138d017a4309105d91f187c126cf979c93f9
 # use go-plugin we get 'timeout waiting for connection info' error

--- a/cmd/loom/gateway/gateway_cmd.go
+++ b/cmd/loom/gateway/gateway_cmd.go
@@ -27,6 +27,7 @@ func NewGatewayCommand() *cobra.Command {
 		newWithdrawalReceiptCommand(),
 		newMapBinanceContractsCommand(),
 		newUpdateMainnetGatewayAddressCommand(),
+		newUpdateMainnetHotWalletAddressCommand(),
 	)
 	return cmd
 }


### PR DESCRIPTION
This PR adds `update-hot-wallet-address` sub command to `gateway` command, which will allow updating hot wallet address state on Transfer Gateway Contract.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request