### PR TITLE
Fix eth_getBalance returns error when ethcoin is not deployed

### DIFF
--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -1038,7 +1038,7 @@ func (s *QueryServer) EthGetBalance(address eth.Data, block eth.BlockHeight) (et
 
 	ctx, err := s.createStaticContractCtx(snapshot, "ethcoin")
 	if err != nil {
-		if err == registry.ErrNotFound {
+		if errors.Cause(err) == registry.ErrNotFound {
 			return eth.Quantity("0x0"), nil
 		}
 		return eth.Quantity("0x0"), err

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -35,6 +35,7 @@ import (
 	lcp "github.com/loomnetwork/loomchain/plugin"
 	hsmpv "github.com/loomnetwork/loomchain/privval/hsm"
 	"github.com/loomnetwork/loomchain/receipts/common"
+	"github.com/loomnetwork/loomchain/registry"
 	registryFac "github.com/loomnetwork/loomchain/registry/factory"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/store"
@@ -1037,6 +1038,9 @@ func (s *QueryServer) EthGetBalance(address eth.Data, block eth.BlockHeight) (et
 
 	ctx, err := s.createStaticContractCtx(snapshot, "ethcoin")
 	if err != nil {
+		if err == registry.ErrNotFound {
+			return eth.Quantity("0x0"), nil
+		}
 		return eth.Quantity("0x0"), err
 	}
 	amount, err := ethcoin.BalanceOf(ctx, owner)


### PR DESCRIPTION
issue: https://github.com/loomnetwork/loomchain/issues/1471

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request