### PR TITLE
Add GetValidator method for RPC endpoint

### DIFF
--- a/rpc/blockatlas/jsonrpc_conversion.go
+++ b/rpc/blockatlas/jsonrpc_conversion.go
@@ -1,0 +1,15 @@
+package blockatlas
+
+type JsonGetValidators struct {
+	Validators []Validator `json:"validators,omitempty"`
+}
+
+type Validator struct {
+	Address         string `json:"address,omitempty"`
+	JailedStatus    bool   `json:"jailedStatus,omitempty"`
+	Name            string `json:"name,omitempty"`
+	Description     string `json:"description,omitempty"`
+	Image           string `json:"image,omitempty"`
+	Website         string `json:"website,omitempty"`
+	DelegationTotal string `json:"delegationTotal,omitempty"`
+}

--- a/rpc/instrumenting.go
+++ b/rpc/instrumenting.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/loomnetwork/go-loom/plugin/types"
 	"github.com/loomnetwork/loomchain/config"
+	"github.com/loomnetwork/loomchain/rpc/blockatlas"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/vm"
 	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
@@ -557,4 +558,16 @@ func (m InstrumentingMiddleware) EthGetTransactionCount(
 
 	resp, err = m.next.EthGetTransactionCount(local, block)
 	return
+}
+
+// Trust wallet
+func (m InstrumentingMiddleware) GetValidators() (*blockatlas.JsonGetValidators, error) {
+	var err error
+	defer func(begin time.Time) {
+		lvs := []string{"method", "GetValidators", "error", fmt.Sprint(err != nil)}
+		m.requestCount.With(lvs...).Add(1)
+		m.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return m.next.GetValidators()
 }

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -47,7 +47,6 @@ import (
 )
 
 type (
-	ListValidator      = dtypes.ListValidatorsResponse
 	ValidatorStatistic = dtypes.ValidatorStatistic
 	CandidateStatistic = dtypes.CandidateStatistic
 	ListCandidates     = dtypes.ListCandidatesResponse
@@ -139,7 +138,6 @@ type QueryServer struct {
 	blockindex.BlockIndexStore
 	EventStore store.EventStore
 	AuthCfg    *auth.Config
-	loomchain.VMManagerProvider
 }
 
 var _ QueryService = &QueryServer{}

--- a/rpc/query_service.go
+++ b/rpc/query_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/loomnetwork/loomchain/config"
 	"github.com/loomnetwork/loomchain/eth/subs"
 	"github.com/loomnetwork/loomchain/log"
+	"github.com/loomnetwork/loomchain/rpc/blockatlas"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/vm"
 )
@@ -63,6 +64,9 @@ type QueryService interface {
 	ContractEvents(fromBlock uint64, toBlock uint64, contract string) (*types.ContractEventsResult, error)
 
 	GetContractRecord(contractAddr string) (*types.ContractRecordResponse, error)
+
+	// Blockatlas endpoint
+	GetValidators() (*blockatlas.JsonGetValidators, error)
 
 	// deprecated function
 	EvmTxReceipt(txHash []byte) ([]byte, error)
@@ -130,6 +134,9 @@ func MakeQueryServiceHandler(svc QueryService, logger log.TMLogger, bus *QueryEv
 	routes["evmsubscribe"] = rpcserver.NewWSRPCFunc(svc.EvmSubscribe, "method,filter")
 	routes["contractevents"] = rpcserver.NewRPCFunc(svc.ContractEvents, "fromBlock,toBlock,contract")
 	routes["contractrecord"] = rpcserver.NewRPCFunc(svc.GetContractRecord, "contract")
+
+	routes["getvalidators"] = rpcserver.NewRPCFunc(svc.GetValidators, "")
+
 	rpcserver.RegisterRPCFuncs(wsmux, routes, codec, logger)
 	wm := rpcserver.NewWebsocketManager(routes, codec, rpcserver.EventSubscriber(bus))
 	wsmux.HandleFunc("/queryws", wm.WebsocketHandler)


### PR DESCRIPTION
In order to support staking with `trustwallet`, We need to provide RPC endpoints to fetch the following data:
- Validators list
- Staking pool (if applicable)
- Current annual APR 

ref : https://developer.trustwallet.com/staking#step-3-define-rpc-endpoints-for-blockatlas
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request