### PR TITLE
Fix jailing jailed validator

### DIFF
--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -1521,7 +1521,10 @@ func UpdateDowntimeRecord(ctx contract.Context, downtimePeriod uint64, jailingEn
 	if ctx.FeatureEnabled(features.DPOSVersion3_4, false) {
 		jailOfflineValidator = jailingEnabled
 	}
-	if jailOfflineValidator && !statistic.Jailed {
+	if ctx.FeatureEnabled(features.DPOSVersion3_6, false) {
+		jailOfflineValidator = jailOfflineValidator && !statistic.Jailed
+	}
+	if jailOfflineValidator {
 		downtime := getDowntimeRecord(ctx, statistic)
 		if downtime.Periods[0] == downtimePeriod &&
 			downtime.Periods[1] == downtimePeriod &&

--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -1521,10 +1521,7 @@ func UpdateDowntimeRecord(ctx contract.Context, downtimePeriod uint64, jailingEn
 	if ctx.FeatureEnabled(features.DPOSVersion3_4, false) {
 		jailOfflineValidator = jailingEnabled
 	}
-	if ctx.FeatureEnabled(features.DPOSVersion3_6, false) {
-		jailOfflineValidator = jailOfflineValidator && !statistic.Jailed
-	}
-	if jailOfflineValidator {
+	if jailOfflineValidator && !statistic.Jailed {
 		downtime := getDowntimeRecord(ctx, statistic)
 		if downtime.Periods[0] == downtimePeriod &&
 			downtime.Periods[1] == downtimePeriod &&

--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -1521,7 +1521,7 @@ func UpdateDowntimeRecord(ctx contract.Context, downtimePeriod uint64, jailingEn
 	if ctx.FeatureEnabled(features.DPOSVersion3_4, false) {
 		jailOfflineValidator = jailingEnabled
 	}
-	if jailOfflineValidator {
+	if jailOfflineValidator && !statistic.Jailed {
 		downtime := getDowntimeRecord(ctx, statistic)
 		if downtime.Periods[0] == downtimePeriod &&
 			downtime.Periods[1] == downtimePeriod &&

--- a/features/features.go
+++ b/features/features.go
@@ -41,8 +41,6 @@ const (
 	DPOSVersion3_4 = "dpos:v3.4"
 	// Fixes prefixing of referrer keys so that ListReferrers method works
 	DPOSVersion3_5 = "dpos:v3.5"
-	// Enables checking validator jailing status before jailing
-	DPOSVersion3_6 = "dpos:v3.6"
 
 	// Enables rewards to be distributed even when a delegator owns less than 0.01% of the validator's stake
 	// Also makes whitelists give bonuses correctly if whitelist locktime tier is set to be 0-3 (else defaults to 5%)

--- a/features/features.go
+++ b/features/features.go
@@ -41,6 +41,8 @@ const (
 	DPOSVersion3_4 = "dpos:v3.4"
 	// Fixes prefixing of referrer keys so that ListReferrers method works
 	DPOSVersion3_5 = "dpos:v3.5"
+	// Enables checking validator jailing status before jailing
+	DPOSVersion3_6 = "dpos:v3.6"
 
 	// Enables rewards to be distributed even when a delegator owns less than 0.01% of the validator's stake
 	// Also makes whitelists give bonuses correctly if whitelist locktime tier is set to be 0-3 (else defaults to 5%)


### PR DESCRIPTION
It's pointless to jail the validator that is already jailed.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request