### PR TITLE
Fix missing version info in TG Oracles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,6 @@ builders['linux'] = {
               gsutil cp tgoracle gs://downloads.loomx.io/loom/linux/build-$BUILD_NUMBER/tgoracle
               gsutil cp loomcoin_tgoracle gs://downloads.loomx.io/loom/linux/build-$BUILD_NUMBER/loomcoin_tgoracle
               gsutil cp tron_tgoracle gs://downloads.loomx.io/loom/linux/build-$BUILD_NUMBER/tron_tgoracle
-              gsutil cp dposv2_oracle gs://downloads.loomx.io/loom/linux/build-$BUILD_NUMBER/dposv2_oracle
               gsutil cp loom-generic gs://downloads.loomx.io/loom/linux/latest/loom
               gsutil cp loom-gateway gs://downloads.loomx.io/loom/linux/latest/loom-gateway
               gsutil cp loom-cleveldb gs://downloads.loomx.io/loom/linux/latest/loom-cleveldb
@@ -59,7 +58,6 @@ builders['linux'] = {
               gsutil cp tgoracle gs://downloads.loomx.io/loom/linux/latest/tgoracle
               gsutil cp loomcoin_tgoracle gs://downloads.loomx.io/loom/linux/latest/loomcoin_tgoracle
               gsutil cp tron_tgoracle gs://downloads.loomx.io/loom/linux/latest/tron_tgoracle
-              gsutil cp dposv2_oracle gs://downloads.loomx.io/loom/linux/latest/dposv2_oracle
               gsutil cp install.sh gs://downloads.loomx.io/install.sh
               docker build --build-arg BUILD_NUMBER=${BUILD_NUMBER} -t loomnetwork/loom:latest .
               docker tag loomnetwork/loom:latest loomnetwork/loom:${BUILD_NUMBER}
@@ -129,7 +127,6 @@ builders['osx'] = {
               gsutil cp tgoracle gs://downloads.loomx.io/loom/osx/build-$BUILD_NUMBER/tgoracle
               gsutil cp loomcoin_tgoracle gs://downloads.loomx.io/loom/osx/build-$BUILD_NUMBER/loomcoin_tgoracle
               gsutil cp tron_tgoracle gs://downloads.loomx.io/loom/osx/build-$BUILD_NUMBER/tron_tgoracle
-              gsutil cp dposv2_oracle gs://downloads.loomx.io/loom/osx/build-$BUILD_NUMBER/dposv2_oracle
               gsutil cp loom-generic gs://downloads.loomx.io/loom/osx/latest/loom
               gsutil cp loom-gateway gs://downloads.loomx.io/loom/osx/latest/loom-gateway
               gsutil cp loom-cleveldb gs://downloads.loomx.io/loom/osx/latest/loom-cleveldb
@@ -139,7 +136,6 @@ builders['osx'] = {
               gsutil cp tgoracle gs://downloads.loomx.io/loom/osx/latest/tgoracle
               gsutil cp loomcoin_tgoracle gs://downloads.loomx.io/loom/osx/latest/loomcoin_tgoracle
               gsutil cp tron_tgoracle gs://downloads.loomx.io/loom/osx/latest/tron_tgoracle
-              gsutil cp dposv2_oracle gs://downloads.loomx.io/loom/osx/latest/dposv2_oracle
             '''
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -98,22 +98,19 @@ contracts/plasmacash.so.1.0.0:
 	go build -buildmode=plugin -o $@ $(GOFLAGS) $(PKG)/builtin/plugins/plasma_cash/plugin
 
 tgoracle: $(TRANSFER_GATEWAY_DIR)
-	go build $(GOFLAGS_GATEWAY) -o $@ $(PKG_TRANSFER_GATEWAY)/cmd/$@
+	cd $(TRANSFER_GATEWAY_DIR) && make tgoracle
 
 loomcoin_tgoracle: $(TRANSFER_GATEWAY_DIR)
-	go build $(GOFLAGS_GATEWAY) -o $@ $(PKG_TRANSFER_GATEWAY)/cmd/$@
+	cd $(TRANSFER_GATEWAY_DIR) && make loomcoin_tgoracle
 
 tron_tgoracle: $(TRANSFER_GATEWAY_DIR)
-	go build $(GOFLAGS_GATEWAY) -o $@ $(PKG_TRANSFER_GATEWAY)/cmd/$@
+	cd $(TRANSFER_GATEWAY_DIR) && make tron_tgoracle
 
 binance_tgoracle: $(BINANCE_TGORACLE_DIR)
-	go build $(GOFLAGS_GATEWAY) -o $@ $(PKG_BINANCE_TRORACLE)/cmd/$@
+	cd $(BINANCE_TGORACLE_DIR) && make binance_tgoracle
 
 pcoracle:
 	go build $(GOFLAGS) -o $@ $(PKG)/cmd/$@
-
-dposv2_oracle: $(TRANSFER_GATEWAY_DIR)
-	go build $(GOFLAGS_GATEWAY) -o $@ $(PKG_TRANSFER_GATEWAY)/cmd/$@
 
 loom: proto
 	go build $(GOFLAGS) $(PKG)/cmd/$@

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -32,10 +32,10 @@ make validators-tool
 
 # build the oracles
 cd $TG_DIR
-make tgoracle
-make tron_tgoracle
-make loomcoin_tgoracle
-make dposv2_oracle
+PKG=$PKG_TRANSFER_GATEWAY make tgoracle
+PKG=$PKG_TRANSFER_GATEWAY make tron_tgoracle
+PKG=$PKG_TRANSFER_GATEWAY make loomcoin_tgoracle
+PKG=$PKG_TRANSFER_GATEWAY make dposv2_oracle
 # move them to the loomchain dir to make post-build steps simpler
 mv tgoracle $LOOM_SRC/tgoracle
 mv tron_tgoracle $LOOM_SRC/tron_tgoracle

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -8,8 +8,10 @@ PKG=github.com/loomnetwork/loomchain
 export GOPATH=/tmp/gopath-$BUILD_TAG
 export
 export PATH=$GOPATH:$PATH:/var/lib/jenkins/workspace/commongopath/bin:$GOPATH/bin
+export PKG_TRANSFER_GATEWAY=github.com/loomnetwork/loomchain/vendor/github.com/loomnetwork/transfer-gateway
 
 LOOM_SRC=$GOPATH/src/$PKG
+TG_DIR=$GOPATH/src/$PKG_TRANSFER_GATEWAY
 mkdir -p $LOOM_SRC
 rsync -r --delete . $LOOM_SRC
 
@@ -19,8 +21,6 @@ export CGO_LDFLAGS="-L/usr/local/lib/ -L/usr/lib/x86_64-linux-gnu/ -lsnappy"
 #elif [[ "$OSTYPE" == "darwin"* ]]; then #osx
 fi
 
-export PKG_TRANSFER_GATEWAY=github.com/loomnetwork/loomchain/vendor/github.com/loomnetwork/transfer-gateway
-
 cd $LOOM_SRC
 make clean
 make get_lint
@@ -29,10 +29,20 @@ make lint || true
 make linterrors
 make  # on OSX we don't need any C precompiles like cleveldb
 make validators-tool
+
+# build the oracles
+cd $TG_DIR
 make tgoracle
 make tron_tgoracle
 make loomcoin_tgoracle
 make dposv2_oracle
+# move them to the loomchain dir to make post-build steps simpler
+mv tgoracle $LOOM_SRC/tgoracle
+mv tron_tgoracle $LOOM_SRC/tron_tgoracle
+mv loomcoin_tgoracle $LOOM_SRC/loomcoin_tgoracle
+# don't care about dpos oracle, don't need to move it
+
+# build the various loom node variants
 make basechain
 # copy the generic loom binary so it can be published later, the loom binary will be replaced by the
 # gateway variant when make loom-gateway executes
@@ -42,7 +52,6 @@ cp loom loom-gateway
 
 make loom-cleveldb
 make basechain-cleveldb
-
 
 export LOOM_BIN=`pwd`/loom
 export LOOM_VALIDATORS_TOOL=`pwd`/e2e/validators-tool

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -43,6 +43,7 @@ mv loomcoin_tgoracle $LOOM_SRC/loomcoin_tgoracle
 # don't care about dpos oracle, don't need to move it
 
 # build the various loom node variants
+cd $LOOM_SRC
 make basechain
 # copy the generic loom binary so it can be published later, the loom binary will be replaced by the
 # gateway variant when make loom-gateway executes


### PR DESCRIPTION
The git SHAs of the various packages used to build the Oracle binaries
are supposed to be filled in via build flags, the flags weren't set
correctly in the loomchain Makefile so the Oracle binaries were being
built with no versioning info. The Oracle targets in the loomchain
Makefile now delegate the actual build to the transfer-gateway Makefile
so that the versioning info is embedded in the Oracle binaries as
intended.