### PR TITLE
Refactor the State object from loomchain into a seperate package.

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -7,6 +7,7 @@ import (
 
 	cctypes "github.com/loomnetwork/go-loom/builtin/types/chainconfig"
 	"github.com/loomnetwork/loomchain/db"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -36,7 +37,7 @@ func TestOnChainConfig(t *testing.T) {
 		Height: blockHeight,
 		Time:   blockTime,
 	}
-	state := NewStoreState(
+	state := appstate.NewStoreState(
 		context.Background(), kvStore, header, nil, nil,
 	).WithOnChainConfig(curCfg)
 	// check default config

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -14,6 +14,7 @@ import (
 	loom "github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/util"
 	"github.com/loomnetwork/loomchain"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 )
 
@@ -46,7 +47,7 @@ func Origin(ctx context.Context) loom.Address {
 }
 
 var SignatureTxMiddleware = loomchain.TxMiddlewareFunc(func(
-	state loomchain.State,
+	state appstate.State,
 	txBytes []byte,
 	next loomchain.TxHandlerFunc,
 	isCheckTx bool,
@@ -91,7 +92,7 @@ func nonceKey(addr loom.Address) []byte {
 	return util.PrefixKey([]byte("nonce"), addr.Bytes())
 }
 
-func Nonce(state loomchain.ReadOnlyState, addr loom.Address) uint64 {
+func Nonce(state appstate.ReadOnlyState, addr loom.Address) uint64 {
 	return loomchain.NewSequence(nonceKey(addr)).Value(state)
 }
 
@@ -101,7 +102,7 @@ type NonceHandler struct {
 }
 
 func (n *NonceHandler) Nonce(
-	state loomchain.State,
+	state appstate.State,
 	kvStore store.KVStore,
 	txBytes []byte,
 	next loomchain.TxHandlerFunc,
@@ -163,7 +164,7 @@ func (n *NonceHandler) Nonce(
 	return next(state, tx.Inner, isCheckTx)
 }
 
-func (n *NonceHandler) IncNonce(state loomchain.State,
+func (n *NonceHandler) IncNonce(state appstate.State,
 	txBytes []byte,
 	result loomchain.TxHandlerResult,
 	postcommit loomchain.PostCommitHandler,
@@ -192,7 +193,7 @@ var NonceTxPostNonceMiddleware = loomchain.PostCommitMiddlewareFunc(NonceTxHandl
 
 var NonceTxMiddleware = func(kvStore store.KVStore) loomchain.TxMiddlewareFunc {
 	nonceTxMiddleware := func(
-		state loomchain.State,
+		state appstate.State,
 		txBytes []byte,
 		next loomchain.TxHandlerFunc,
 		isCheckTx bool,

--- a/auth/chainconfig_middleware.go
+++ b/auth/chainconfig_middleware.go
@@ -7,6 +7,7 @@ import (
 	"github.com/loomnetwork/go-loom/plugin/contractpb"
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/features"
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 // NewChainConfigMiddleware returns middleware that verifies signed txs using either
@@ -14,10 +15,10 @@ import (
 // based on the on-chain and off-chain auth config settings.
 func NewChainConfigMiddleware(
 	authConfig *Config,
-	createAddressMapperCtx func(state loomchain.State) (contractpb.StaticContext, error),
+	createAddressMapperCtx func(state appstate.State) (contractpb.StaticContext, error),
 ) loomchain.TxMiddlewareFunc {
 	return loomchain.TxMiddlewareFunc(func(
-		state loomchain.State,
+		state appstate.State,
 		txBytes []byte,
 		next loomchain.TxHandlerFunc,
 		isCheckTx bool,
@@ -33,7 +34,7 @@ func NewChainConfigMiddleware(
 }
 
 // Filters out any auth.ChainConfig(s) that haven't been enabled by the majority of validators.
-func getEnabledChains(chains map[string]ChainConfig, state loomchain.State) map[string]ChainConfig {
+func getEnabledChains(chains map[string]ChainConfig, state appstate.State) map[string]ChainConfig {
 	enabledChains := map[string]ChainConfig{}
 	for chainID, config := range chains {
 		if state.FeatureEnabled(features.AuthSigTxFeaturePrefix+chainID, false) {
@@ -57,8 +58,8 @@ func getEnabledChains(chains map[string]ChainConfig, state loomchain.State) map[
 // ResolveAccountAddress takes a local or foreign account address and returns the address used
 // to identify the account on this chain.
 func ResolveAccountAddress(
-	account loom.Address, state loomchain.State, authCfg *Config,
-	createAddressMapperCtx func(state loomchain.State) (contractpb.StaticContext, error),
+	account loom.Address, state appstate.State, authCfg *Config,
+	createAddressMapperCtx func(state appstate.State) (contractpb.StaticContext, error),
 ) (loom.Address, error) {
 	chains := getEnabledChains(authCfg.Chains, state)
 	if len(chains) > 0 {

--- a/auth/multi_chain_sigtx_middleware.go
+++ b/auth/multi_chain_sigtx_middleware.go
@@ -15,6 +15,7 @@ import (
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/builtin/plugins/address_mapper"
 	"github.com/loomnetwork/loomchain/features"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ed25519"
 )
@@ -53,10 +54,10 @@ type originRecoveryFunc func(tx SignedTx, allowedSigTypes []evmcompat.SignatureT
 // specific signing algos.
 func NewMultiChainSignatureTxMiddleware(
 	chains map[string]ChainConfig,
-	createAddressMapperCtx func(state loomchain.State) (contractpb.StaticContext, error),
+	createAddressMapperCtx func(state appstate.State) (contractpb.StaticContext, error),
 ) loomchain.TxMiddlewareFunc {
 	return loomchain.TxMiddlewareFunc(func(
-		state loomchain.State,
+		state appstate.State,
 		txBytes []byte,
 		next loomchain.TxHandlerFunc,
 		isCheckTx bool,
@@ -151,9 +152,9 @@ func NewMultiChainSignatureTxMiddleware(
 }
 
 func getMappedAccountAddress(
-	state loomchain.State,
+	state appstate.State,
 	addr loom.Address,
-	createAddressMapperCtx func(state loomchain.State) (contractpb.StaticContext, error),
+	createAddressMapperCtx func(state appstate.State) (contractpb.StaticContext, error),
 ) (loom.Address, error) {
 	ctx, err := createAddressMapperCtx(state)
 	if err != nil {
@@ -193,7 +194,7 @@ func verifyEd25519(tx SignedTx, _ []evmcompat.SignatureType) ([]byte, error) {
 	return loom.LocalAddressFromPublicKey(tx.PublicKey), nil
 }
 
-func getAllowedSignatureTypes(state loomchain.State, chainID string) []evmcompat.SignatureType {
+func getAllowedSignatureTypes(state appstate.State, chainID string) []evmcompat.SignatureType {
 	if !state.FeatureEnabled(features.MultiChainSigTxMiddlewareVersion1_1, false) {
 		return []evmcompat.SignatureType{
 			evmcompat.SignatureType_EIP712,

--- a/auth/multi_chain_sigtx_middleware_test.go
+++ b/auth/multi_chain_sigtx_middleware_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/builtin/plugins/address_mapper"
 	"github.com/loomnetwork/loomchain/features"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 )
 
@@ -172,7 +173,7 @@ func TestBinanceSigning(t *testing.T) {
 }
 
 func TestEthAddressMappingVerification(t *testing.T) {
-	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
+	state := appstate.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
 	addresMapperAddr := fakeCtx.CreateContract(address_mapper.Contract)
 	amCtx := contractpb.WrapPluginContext(fakeCtx.WithAddress(addresMapperAddr))
@@ -191,7 +192,7 @@ func TestEthAddressMappingVerification(t *testing.T) {
 	}
 	tmx := NewMultiChainSignatureTxMiddleware(
 		chains,
-		func(state loomchain.State) (contractpb.StaticContext, error) { return amCtx, nil },
+		func(state appstate.State) (contractpb.StaticContext, error) { return amCtx, nil },
 	)
 
 	// Normal loom transaction without address mapping
@@ -234,7 +235,7 @@ func TestEthAddressMappingVerification(t *testing.T) {
 }
 
 func TestBinanceAddressMappingVerification(t *testing.T) {
-	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
+	state := appstate.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
 	state.SetFeature(features.AddressMapperVersion1_1, true)
 	state.SetFeature(features.MultiChainSigTxMiddlewareVersion1_1, true)
 	state.SetFeature(features.AuthSigTxFeaturePrefix+"binance", true)
@@ -260,7 +261,7 @@ func TestBinanceAddressMappingVerification(t *testing.T) {
 	}
 	tmx := NewMultiChainSignatureTxMiddleware(
 		chains,
-		func(state loomchain.State) (contractpb.StaticContext, error) { return amCtx, nil },
+		func(state appstate.State) (contractpb.StaticContext, error) { return amCtx, nil },
 	)
 
 	// Normal loom transaction without address mapping
@@ -303,7 +304,7 @@ func TestBinanceAddressMappingVerification(t *testing.T) {
 }
 
 func TestChainIdVerification(t *testing.T) {
-	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
+	state := appstate.NewStoreState(nil, store.NewMemStore(), abci.Header{ChainID: defaultLoomChainId}, nil, nil)
 	state.SetFeature(features.AddressMapperVersion1_1, true)
 	state.SetFeature(features.MultiChainSigTxMiddlewareVersion1_1, true)
 	state.SetFeature(features.AuthSigTxFeaturePrefix+"tron", true)
@@ -338,7 +339,7 @@ func TestChainIdVerification(t *testing.T) {
 	}
 	tmx := NewMultiChainSignatureTxMiddleware(
 		chains,
-		func(state loomchain.State) (contractpb.StaticContext, error) { return amCtx, nil },
+		func(state appstate.State) (contractpb.StaticContext, error) { return amCtx, nil },
 	)
 
 	// Normal loom transaction without address mapping
@@ -378,9 +379,9 @@ func TestChainIdVerification(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func throttleMiddlewareHandler(ttm loomchain.TxMiddlewareFunc, state loomchain.State, signedTx []byte, ctx context.Context) (loomchain.TxHandlerResult, error) {
+func throttleMiddlewareHandler(ttm loomchain.TxMiddlewareFunc, state appstate.State, signedTx []byte, ctx context.Context) (loomchain.TxHandlerResult, error) {
 	return ttm.ProcessTx(state.WithContext(ctx), signedTx,
-		func(state loomchain.State, txBytes []byte, isCheckTx bool) (res loomchain.TxHandlerResult, err error) {
+		func(state appstate.State, txBytes []byte, isCheckTx bool) (res loomchain.TxHandlerResult, err error) {
 
 			var nonceTx NonceTx
 			if err := proto.Unmarshal(txBytes, &nonceTx); err != nil {

--- a/builtin/plugins/karma/karma_benchmark_test.go
+++ b/builtin/plugins/karma/karma_benchmark_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/loomnetwork/go-loom/builtin/types/karma"
 	"github.com/loomnetwork/go-loom/common"
 	"github.com/loomnetwork/go-loom/types"
-	"github.com/loomnetwork/loomchain"
-	"github.com/loomnetwork/loomchain/store"
 	abci "github.com/tendermint/tendermint/abci/types"
+
+	appstate "github.com/loomnetwork/loomchain/state"
+	"github.com/loomnetwork/loomchain/store"
 )
 
 const (
@@ -28,7 +29,7 @@ var (
 	dummyKarma int64
 )
 
-type testFunc func(state loomchain.State)
+type testFunc func(state appstate.State)
 
 func TestKarma(t *testing.T) {
 	t.Skip("use benchmark")
@@ -91,7 +92,7 @@ func benchmarkKarmaFunc(b *testing.B, name string, fn testFunc) {
 	}
 }
 
-func calculateKarma(state loomchain.State) {
+func calculateKarma(state appstate.State) {
 	const user = 0
 
 	var karmaSources karma.KarmaSources
@@ -117,7 +118,7 @@ func calculateKarma(state loomchain.State) {
 	dummyKarma = karmaValue.Int64()
 }
 
-func readKarma(state loomchain.State) {
+func readKarma(state appstate.State) {
 	var err error
 	const user = 0
 	protoAmount := state.Get(userKarmaKey(user))
@@ -127,7 +128,7 @@ func readKarma(state loomchain.State) {
 	}
 }
 
-func updateKarma(state loomchain.State) {
+func updateKarma(state appstate.State) {
 	userRange := state.Range([]byte("user."))
 	for _, userKV := range userRange {
 		var karmaStates karma.KarmaState
@@ -153,7 +154,7 @@ func updateKarma(state loomchain.State) {
 	}
 }
 
-func mockUsers(state loomchain.State, sources karma.KarmaSources, logUsers int) loomchain.State {
+func mockUsers(state appstate.State, sources karma.KarmaSources, logUsers int) appstate.State {
 	users := uint64(math.Pow(10, float64(logUsers)))
 	totalKarma := []byte(strconv.FormatInt(10, 10))
 	var userState karma.KarmaState
@@ -183,9 +184,9 @@ func userKarmaKey(user uint64) []byte {
 	return append([]byte("total-karma.user."), userKey(user)...)
 }
 
-func mockState(logSize int) loomchain.State {
+func mockState(logSize int) appstate.State {
 	header := abci.Header{}
-	state := loomchain.NewStoreState(context.Background(), store.NewMemStore(), header, nil, nil)
+	state := appstate.NewStoreState(context.Background(), store.NewMemStore(), header, nil, nil)
 	entries := uint64(math.Pow(10, float64(logSize)))
 	for i := uint64(0); i < entries; i++ {
 		strI := strconv.FormatUint(i, 10)
@@ -194,7 +195,7 @@ func mockState(logSize int) loomchain.State {
 	return state
 }
 
-func mockSources(state loomchain.State, logSize int) (loomchain.State, karma.KarmaSources) {
+func mockSources(state appstate.State, logSize int) (appstate.State, karma.KarmaSources) {
 	numStates := uint64(math.Pow(10, float64(logSize)))
 	var sources karma.KarmaSources
 	for i := uint64(0); i < numStates; i++ {

--- a/cmd/loom/db/evm.go
+++ b/cmd/loom/db/evm.go
@@ -10,6 +10,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
+	dbm "github.com/tendermint/tendermint/libs/db"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/cmd/loom/common"
 	cdb "github.com/loomnetwork/loomchain/db"
@@ -19,10 +23,8 @@ import (
 	"github.com/loomnetwork/loomchain/plugin"
 	"github.com/loomnetwork/loomchain/receipts"
 	registry "github.com/loomnetwork/loomchain/registry/factory"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
-	"github.com/spf13/cobra"
-	abci "github.com/tendermint/tendermint/abci/types"
-	dbm "github.com/tendermint/tendermint/libs/db"
 )
 
 func newDumpEVMStateCommand() *cobra.Command {
@@ -65,7 +67,7 @@ func newDumpEVMStateCommand() *cobra.Command {
 
 			// TODO: This should use snapshot obtained from appStore.ReadOnlyState()
 			storeTx := store.WrapAtomic(appStore).BeginTx()
-			state := loomchain.NewStoreState(
+			state := appstate.NewStoreState(
 				context.Background(),
 				storeTx,
 				abci.Header{
@@ -178,7 +180,7 @@ func newDumpEVMStateMultiWriterAppStoreCommand() *cobra.Command {
 
 			// TODO: This should use snapshot obtained from appStore.ReadOnlyState()
 			storeTx := store.WrapAtomic(appStore).BeginTx()
-			state := loomchain.NewStoreState(
+			state := appstate.NewStoreState(
 				context.Background(),
 				storeTx,
 				abci.Header{

--- a/cmd/loom/handler_test.go
+++ b/cmd/loom/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
 	registry "github.com/loomnetwork/loomchain/registry/factory"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	"github.com/loomnetwork/loomchain/vm"
 	"github.com/stretchr/testify/require"
@@ -35,7 +36,7 @@ func TestTxHandlerWithInvalidCaller(t *testing.T) {
 	router.HandleDeliverTx(2, loomchain.GeneratePassthroughRouteHandler(&vm.CallTxHandler{Manager: vmManager}))
 
 	kvStore := store.NewMemStore()
-	state := loomchain.NewStoreState(nil, kvStore, abci.Header{ChainID: "default"}, nil, nil)
+	state := appstate.NewStoreState(nil, kvStore, abci.Header{ChainID: "default"}, nil, nil)
 
 	txMiddleWare := []loomchain.TxMiddleware{
 		auth.SignatureTxMiddleware,

--- a/eth/polls/eth_subscribe.go
+++ b/eth/polls/eth_subscribe.go
@@ -13,6 +13,7 @@ import (
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/eth/utils"
 	"github.com/loomnetwork/loomchain/rpc/eth"
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 var (
@@ -20,9 +21,9 @@ var (
 )
 
 type EthPoll interface {
-	AllLogs(state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler) (interface{}, error)
-	Poll(state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler) (EthPoll, interface{}, error)
-	LegacyPoll(state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler) (EthPoll, []byte, error)
+	AllLogs(state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler) (interface{}, error)
+	Poll(state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler) (EthPoll, interface{}, error)
+	LegacyPoll(state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler) (EthPoll, []byte, error)
 }
 
 type EthSubscriptions struct {
@@ -111,7 +112,7 @@ func (s *EthSubscriptions) AddTxPoll(height uint64) string {
 }
 
 func (s *EthSubscriptions) AllLogs(
-	state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
+	state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
 ) (interface{}, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -124,7 +125,7 @@ func (s *EthSubscriptions) AllLogs(
 }
 
 func (s *EthSubscriptions) Poll(
-	state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
+	state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
 ) (interface{}, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -142,7 +143,7 @@ func (s *EthSubscriptions) Poll(
 }
 
 func (s *EthSubscriptions) LegacyPoll(
-	state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
+	state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
 ) ([]byte, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()

--- a/eth/polls/pollblocks.go
+++ b/eth/polls/pollblocks.go
@@ -5,8 +5,10 @@ package polls
 import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/loomnetwork/go-loom/plugin/types"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/rpc/eth"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
 )
@@ -30,7 +32,7 @@ func NewEthBlockPoll(height uint64, evmAuxStore *evmaux.EvmAuxStore, blockStore 
 }
 
 func (p *EthBlockPoll) Poll(
-	state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
+	state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
 ) (EthPoll, interface{}, error) {
 	if p.lastBlock+1 > uint64(state.Block().Height) {
 		return p, nil, nil
@@ -44,14 +46,14 @@ func (p *EthBlockPoll) Poll(
 }
 
 func (p *EthBlockPoll) AllLogs(
-	state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
+	state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
 ) (interface{}, error) {
 	_, results, err := getBlockHashes(p.blockStore, state, p.startBlock)
 	return eth.EncBytesArray(results), err
 }
 
 func getBlockHashes(
-	blockStore store.BlockStore, state loomchain.ReadOnlyState, lastBlockRead uint64,
+	blockStore store.BlockStore, state appstate.ReadOnlyState, lastBlockRead uint64,
 ) (uint64, [][]byte, error) {
 	result, err := blockStore.GetBlockRangeByHeight(int64(lastBlockRead+1), state.Block().Height)
 	if err != nil {
@@ -70,7 +72,7 @@ func getBlockHashes(
 	return lastBlockRead, blockHashes, nil
 }
 
-func (p *EthBlockPoll) LegacyPoll(state loomchain.ReadOnlyState, id string,
+func (p *EthBlockPoll) LegacyPoll(state appstate.ReadOnlyState, id string,
 	readReceipts loomchain.ReadReceiptHandler) (EthPoll, []byte, error) {
 	if p.lastBlock+1 > uint64(state.Block().Height) {
 		return p, nil, nil

--- a/eth/polls/polllogs.go
+++ b/eth/polls/polllogs.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/loomnetwork/go-loom/plugin/types"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/eth/query"
 	"github.com/loomnetwork/loomchain/eth/utils"
 	"github.com/loomnetwork/loomchain/rpc/eth"
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 type EthLogPoll struct {
@@ -40,7 +42,7 @@ func NewEthLogPoll(filter string, evmAuxStore *evmaux.EvmAuxStore, blockStore st
 }
 
 func (p *EthLogPoll) Poll(
-	state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
+	state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
 ) (EthPoll, interface{}, error) {
 	start, err := eth.DecBlockHeight(state.Block().Height, p.filter.FromBlock)
 	if err != nil {
@@ -75,7 +77,7 @@ func (p *EthLogPoll) Poll(
 	return newLogPoll, eth.EncLogs(eventLogs), nil
 }
 
-func (p *EthLogPoll) AllLogs(state loomchain.ReadOnlyState,
+func (p *EthLogPoll) AllLogs(state appstate.ReadOnlyState,
 	id string, readReceipts loomchain.ReadReceiptHandler) (interface{}, error) {
 	start, err := eth.DecBlockHeight(state.Block().Height, p.filter.FromBlock)
 	if err != nil {
@@ -98,7 +100,7 @@ func (p *EthLogPoll) AllLogs(state loomchain.ReadOnlyState,
 	return eth.EncLogs(eventLogs), nil
 }
 
-func (p *EthLogPoll) LegacyPoll(state loomchain.ReadOnlyState,
+func (p *EthLogPoll) LegacyPoll(state appstate.ReadOnlyState,
 	id string, readReceipts loomchain.ReadReceiptHandler) (EthPoll, []byte, error) {
 	start, err := eth.DecBlockHeight(state.Block().Height, p.filter.FromBlock)
 	if err != nil {

--- a/eth/polls/polls_test.go
+++ b/eth/polls/polls_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/loomnetwork/loomchain/rpc/eth"
+	appstate "github.com/loomnetwork/loomchain/state"
 
 	"github.com/loomnetwork/loomchain/events"
 	"github.com/loomnetwork/loomchain/store"
@@ -249,7 +250,7 @@ func testTimeout(t *testing.T, version handler.ReceiptHandlerVersion) {
 	require.NoError(t, receiptHandler.Close())
 }
 
-func makeMockState(t *testing.T, receiptHandler *handler.ReceiptHandler) loomchain.State {
+func makeMockState(t *testing.T, receiptHandler *handler.ReceiptHandler) appstate.State {
 	state := common.MockState(0)
 
 	mockEvent4 := []*types.EventData{

--- a/eth/polls/polltx.go
+++ b/eth/polls/polltx.go
@@ -5,11 +5,13 @@ package polls
 import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/loomnetwork/go-loom/plugin/types"
+	"github.com/pkg/errors"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/rpc/eth"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
-	"github.com/pkg/errors"
 )
 
 type EthTxPoll struct {
@@ -30,7 +32,7 @@ func NewEthTxPoll(height uint64, evmAuxStore *evmaux.EvmAuxStore, blockStore sto
 }
 
 func (p *EthTxPoll) Poll(
-	state loomchain.ReadOnlyState, id string, readReceipt loomchain.ReadReceiptHandler,
+	state appstate.ReadOnlyState, id string, readReceipt loomchain.ReadReceiptHandler,
 ) (EthPoll, interface{}, error) {
 	if p.lastBlockRead+1 > uint64(state.Block().Height) {
 		return p, nil, nil
@@ -44,13 +46,13 @@ func (p *EthTxPoll) Poll(
 }
 
 func (p *EthTxPoll) AllLogs(
-	state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
+	state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
 ) (interface{}, error) {
 	_, results, err := getTxHashes(state, p.startBlock, readReceipts, p.evmAuxStore)
 	return eth.EncBytesArray(results), err
 }
 
-func getTxHashes(state loomchain.ReadOnlyState, lastBlockRead uint64,
+func getTxHashes(state appstate.ReadOnlyState, lastBlockRead uint64,
 	readReceipts loomchain.ReadReceiptHandler, evmAuxStore *evmaux.EvmAuxStore) (uint64, [][]byte, error) {
 	var txHashes [][]byte
 	for height := lastBlockRead + 1; height < uint64(state.Block().Height); height++ {
@@ -68,7 +70,7 @@ func getTxHashes(state loomchain.ReadOnlyState, lastBlockRead uint64,
 }
 
 func (p *EthTxPoll) LegacyPoll(
-	state loomchain.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
+	state appstate.ReadOnlyState, id string, readReceipts loomchain.ReadReceiptHandler,
 ) (EthPoll, []byte, error) {
 	if p.lastBlockRead+1 > uint64(state.Block().Height) {
 		return p, nil, nil

--- a/eth/query/block.go
+++ b/eth/query/block.go
@@ -13,8 +13,10 @@ import (
 	"github.com/loomnetwork/go-loom/auth"
 	"github.com/loomnetwork/go-loom/plugin/types"
 	"github.com/loomnetwork/go-loom/vm"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/rpc/eth"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
 )
@@ -31,7 +33,7 @@ var (
 
 func GetBlockByNumber(
 	blockStore store.BlockStore,
-	state loomchain.ReadOnlyState,
+	state appstate.ReadOnlyState,
 	height int64,
 	full bool,
 	evmAuxStore *evmaux.EvmAuxStore,
@@ -210,7 +212,7 @@ func GetTxObjectFromBlockResult(
 	return txObj, contractAddress, nil
 }
 
-func GetNumTxBlock(blockStore store.BlockStore, state loomchain.ReadOnlyState, height int64) (uint64, error) {
+func GetNumTxBlock(blockStore store.BlockStore, state appstate.ReadOnlyState, height int64) (uint64, error) {
 	// todo make information about pending block available.
 	// Should be able to get transaction count from receipt object.
 	if height > state.Block().Height {
@@ -226,7 +228,7 @@ func GetNumTxBlock(blockStore store.BlockStore, state loomchain.ReadOnlyState, h
 }
 
 // todo find better method of doing this. Maybe use a blockhash index.
-func GetBlockHeightFromHash(blockStore store.BlockStore, state loomchain.ReadOnlyState, hash []byte) (int64, error) {
+func GetBlockHeightFromHash(blockStore store.BlockStore, state appstate.ReadOnlyState, hash []byte) (int64, error) {
 	start := uint64(state.Block().Height)
 	var end uint64
 	if uint64(start) > searchBlockSize {
@@ -265,7 +267,7 @@ func GetBlockHeightFromHash(blockStore store.BlockStore, state loomchain.ReadOnl
 }
 
 func DeprecatedGetBlockByNumber(
-	blockStore store.BlockStore, state loomchain.ReadOnlyState, height int64, full bool,
+	blockStore store.BlockStore, state appstate.ReadOnlyState, height int64, full bool,
 	readReceipts loomchain.ReadReceiptHandler, evmAuxStore *evmaux.EvmAuxStore,
 ) ([]byte, error) {
 	var blockresult *ctypes.ResultBlock
@@ -326,7 +328,7 @@ func GetPendingBlock(height int64, full bool, readReceipts loomchain.ReadReceipt
 }
 
 func DeprecatedGetBlockByHash(
-	blockStore store.BlockStore, state loomchain.ReadOnlyState, hash []byte, full bool,
+	blockStore store.BlockStore, state appstate.ReadOnlyState, hash []byte, full bool,
 	readReceipts loomchain.ReadReceiptHandler, evmAuxStore *evmaux.EvmAuxStore,
 ) ([]byte, error) {
 	start := uint64(state.Block().Height)

--- a/eth/query/eth.go
+++ b/eth/query/eth.go
@@ -5,22 +5,25 @@ package query
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/loomnetwork/loomchain/eth/bloom"
 	"github.com/loomnetwork/loomchain/receipts/common"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/store"
-	"github.com/pkg/errors"
 
 	"github.com/gogo/protobuf/proto"
 	ptypes "github.com/loomnetwork/go-loom/plugin/types"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/eth/utils"
+	appstate "github.com/loomnetwork/loomchain/state"
 	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
-	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
 func QueryChain(
-	blockStore store.BlockStore, state loomchain.ReadOnlyState, ethFilter eth.EthFilter,
+	blockStore store.BlockStore, state appstate.ReadOnlyState, ethFilter eth.EthFilter,
 	readReceipts loomchain.ReadReceiptHandler, evmAuxStore *evmaux.EvmAuxStore,
 ) ([]*ptypes.EthFilterLog, error) {
 	start, err := eth.DecBlockHeight(state.Block().Height, eth.BlockHeight(ethFilter.FromBlock))
@@ -36,7 +39,7 @@ func QueryChain(
 }
 
 func DeprecatedQueryChain(
-	query string, blockStore store.BlockStore, state loomchain.ReadOnlyState,
+	query string, blockStore store.BlockStore, state appstate.ReadOnlyState,
 	readReceipts loomchain.ReadReceiptHandler, evmAuxStore *evmaux.EvmAuxStore,
 ) ([]byte, error) {
 	ethFilter, err := utils.UnmarshalEthFilter([]byte(query))
@@ -62,7 +65,7 @@ func DeprecatedQueryChain(
 
 func GetBlockLogRange(
 	blockStore store.BlockStore,
-	state loomchain.ReadOnlyState,
+	state appstate.ReadOnlyState,
 	from, to uint64,
 	ethFilter eth.EthBlockFilter,
 	readReceipts loomchain.ReadReceiptHandler,
@@ -85,7 +88,7 @@ func GetBlockLogRange(
 
 func GetBlockLogs(
 	blockStore store.BlockStore,
-	state loomchain.ReadOnlyState,
+	state appstate.ReadOnlyState,
 	ethFilter eth.EthBlockFilter,
 	height uint64,
 	readReceipts loomchain.ReadReceiptHandler,

--- a/eth/query/tx.go
+++ b/eth/query/tx.go
@@ -9,13 +9,15 @@ import (
 
 	"github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/plugin/types"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/rpc/eth"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 )
 
-func GetTxByHash(state loomchain.ReadOnlyState, blockStore store.BlockStore, txHash []byte, readReceipts loomchain.ReadReceiptHandler) (eth.JsonTxObject, error) {
+func GetTxByHash(state appstate.ReadOnlyState, blockStore store.BlockStore, txHash []byte, readReceipts loomchain.ReadReceiptHandler) (eth.JsonTxObject, error) {
 	txReceipt, err := readReceipts.GetReceipt(txHash)
 	if err != nil {
 		return eth.GetEmptyTxObject(), errors.Wrap(err, "reading receipt")
@@ -49,7 +51,7 @@ func GetTxByBlockAndIndex(blockStore store.BlockStore, height, index uint64) (et
 	return txObj, nil
 }
 
-func DeprecatedGetTxByHash(state loomchain.ReadOnlyState, txHash []byte, readReceipts loomchain.ReadReceiptHandler) ([]byte, error) {
+func DeprecatedGetTxByHash(state appstate.ReadOnlyState, txHash []byte, readReceipts loomchain.ReadReceiptHandler) ([]byte, error) {
 	txReceipt, err := readReceipts.GetReceipt(txHash)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading receipt")

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -19,9 +19,10 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 
 	"github.com/loomnetwork/go-loom"
-	"github.com/loomnetwork/loomchain"
+
 	"github.com/loomnetwork/loomchain/features"
 	"github.com/loomnetwork/loomchain/log"
+	"github.com/loomnetwork/loomchain/state"
 )
 
 // EVMEnabled indicates whether or not Loom EVM integration is available
@@ -147,7 +148,7 @@ type Evm struct {
 	gasLimit        uint64
 }
 
-func NewEvm(sdb vm.StateDB, lstate loomchain.State, abm *evmAccountBalanceManager, debug bool) *Evm {
+func NewEvm(sdb vm.StateDB, lstate state.State, abm *evmAccountBalanceManager, debug bool) *Evm {
 	p := new(Evm)
 	p.sdb = sdb
 	p.gasLimit = lstate.Config().GetEvm().GetGasLimit()

--- a/evm/evm_test.go
+++ b/evm/evm_test.go
@@ -17,12 +17,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethvm "github.com/ethereum/go-ethereum/core/vm"
 	"github.com/loomnetwork/go-loom"
-	"github.com/loomnetwork/loomchain"
+	appstate "github.com/loomnetwork/loomchain/state"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	"github.com/loomnetwork/loomchain/features"
 	"github.com/loomnetwork/loomchain/store"
 	lvm "github.com/loomnetwork/loomchain/vm"
-	"github.com/stretchr/testify/require"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 const (
@@ -36,11 +37,11 @@ var (
 	blockTime            = time.Unix(123456789, 0)
 )
 
-func mockState() loomchain.State {
+func mockState() appstate.State {
 	header := abci.Header{}
 	header.Height = BlockHeight
 	header.Time = blockTime
-	return loomchain.NewStoreState(context.Background(), store.NewMemStore(), header, nil, nil)
+	return appstate.NewStoreState(context.Background(), store.NewMemStore(), header, nil, nil)
 }
 
 func TestProcessDeployTx(t *testing.T) {
@@ -174,7 +175,7 @@ func TestValue(t *testing.T) {
 
 }
 
-func testValue(t *testing.T, state loomchain.State, vm lvm.VM, caller loom.Address, checkTxValueFeature bool, value int64) {
+func testValue(t *testing.T, state appstate.State, vm lvm.VM, caller loom.Address, checkTxValueFeature bool, value int64) {
 	defer func() {
 		if r := recover(); r != nil {
 			require.True(t, !checkTxValueFeature && value < 0)

--- a/evm/loomethdb.go
+++ b/evm/loomethdb.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/loomnetwork/loomchain"
+	"github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 )
 
@@ -28,7 +28,7 @@ type LoomEthdb struct {
 	logContext *ethdbLogContext
 }
 
-func NewLoomEthdb(_state loomchain.State, logContext *ethdbLogContext) *LoomEthdb {
+func NewLoomEthdb(_state state.State, logContext *ethdbLogContext) *LoomEthdb {
 	p := new(LoomEthdb)
 	p.state = store.PrefixKVStore(vmPrefix, _state)
 	p.logContext = logContext

--- a/evm/loomevm.go
+++ b/evm/loomevm.go
@@ -15,14 +15,16 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/loomnetwork/go-loom"
 	ptypes "github.com/loomnetwork/go-loom/plugin/types"
+	"github.com/pkg/errors"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/events"
 	"github.com/loomnetwork/loomchain/features"
 	"github.com/loomnetwork/loomchain/receipts"
 	"github.com/loomnetwork/loomchain/receipts/handler"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/vm"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -52,7 +54,7 @@ type LoomEvm struct {
 
 // TODO: this doesn't need to be exported, rename to newLoomEvmWithState
 func NewLoomEvm(
-	loomState loomchain.State, accountBalanceManager AccountBalanceManager,
+	loomState appstate.State, accountBalanceManager AccountBalanceManager,
 	logContext *ethdbLogContext, debug bool,
 ) (*LoomEvm, error) {
 	p := new(LoomEvm)
@@ -100,7 +102,7 @@ func (levm LoomEvm) RawDump() []byte {
 	return output
 }
 
-var LoomVmFactory = func(state loomchain.State) (vm.VM, error) {
+var LoomVmFactory = func(state appstate.State) (vm.VM, error) {
 	//TODO , debug bool, We should be able to pass in config
 	debug := false
 	eventHandler := loomchain.NewDefaultEventHandler(events.NewLogEventDispatcher())
@@ -116,14 +118,14 @@ var LoomVmFactory = func(state loomchain.State) (vm.VM, error) {
 // LoomVm implements the loomchain/vm.VM interface using the EVM.
 // TODO: rename to LoomEVM
 type LoomVm struct {
-	state          loomchain.State
+	state          appstate.State
 	receiptHandler loomchain.WriteReceiptHandler
 	createABM      AccountBalanceManagerFactoryFunc
 	debug          bool
 }
 
 func NewLoomVm(
-	loomState loomchain.State,
+	loomState appstate.State,
 	eventHandler loomchain.EventHandler,
 	receiptHandler loomchain.WriteReceiptHandler,
 	createABM AccountBalanceManagerFactoryFunc,

--- a/evm/noevm.go
+++ b/evm/noevm.go
@@ -4,6 +4,7 @@ package evm
 
 import (
 	"github.com/loomnetwork/loomchain"
+	"github.com/loomnetwork/loomchain/state"
 	lvm "github.com/loomnetwork/loomchain/vm"
 )
 
@@ -15,7 +16,7 @@ var (
 const EVMEnabled = false
 
 func NewLoomVm(
-	loomState loomchain.State,
+	loomState state.State,
 	eventHandler loomchain.EventHandler,
 	receiptHandler loomchain.WriteReceiptHandler,
 	createABM AccountBalanceManagerFactoryFunc,

--- a/evm/test_cryptozombies.go
+++ b/evm/test_cryptozombies.go
@@ -11,10 +11,11 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gogo/protobuf/proto"
-	loom "github.com/loomnetwork/go-loom"
-	"github.com/loomnetwork/loomchain"
-	lvm "github.com/loomnetwork/loomchain/vm"
+	"github.com/loomnetwork/go-loom"
 	"github.com/stretchr/testify/require"
+
+	appstate "github.com/loomnetwork/loomchain/state"
+	lvm "github.com/loomnetwork/loomchain/vm"
 )
 
 func testCryptoZombies(t *testing.T, vm lvm.VM, caller loom.Address) {
@@ -69,7 +70,7 @@ func testCryptoZombies(t *testing.T, vm lvm.VM, caller loom.Address) {
 
 }
 
-func testCryptoZombiesUpdateState(t *testing.T, state loomchain.State, caller loom.Address) {
+func testCryptoZombiesUpdateState(t *testing.T, state appstate.State, caller loom.Address) {
 	motherKat := loom.Address{
 		ChainID: "AChainID",
 		Local:   []byte("myMotherKat"),

--- a/fork.go
+++ b/fork.go
@@ -2,6 +2,8 @@ package loomchain
 
 import (
 	"sort"
+
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 type forkRoute struct {
@@ -50,7 +52,7 @@ func (r *ForkRouter) Handle(chainID string, height int64, handler TxHandler) {
 	r.routes[chainID] = routes
 }
 
-func (r *ForkRouter) ProcessTx(state State, txBytes []byte, isCheckTx bool) (TxHandlerResult, error) {
+func (r *ForkRouter) ProcessTx(state appstate.State, txBytes []byte, isCheckTx bool) (TxHandlerResult, error) {
 	block := state.Block()
 	routes := r.routes[block.ChainID]
 

--- a/karma/karma_benchmark_test.go
+++ b/karma/karma_benchmark_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/loomnetwork/loomchain/builtin/plugins/karma"
 	"github.com/loomnetwork/loomchain/plugin"
 	"github.com/loomnetwork/loomchain/registry"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/db"
 )
@@ -29,7 +30,7 @@ const (
 	pcentDeactivateTicks = 1
 )
 
-type benchmarkFunc func(state loomchain.State) error
+type benchmarkFunc func(state appstate.State) error
 
 func BenchmarkUpkeep(b *testing.B) {
 	//kh2 := NewKarmaHandler(factory.RegistryV2, true, true)
@@ -79,7 +80,7 @@ func benchmarkKarmaFunc(b *testing.B, name string, fn benchmarkFunc) {
 	}
 }
 
-func addMockUsersWithContracts(b *testing.B, karmaState loomchain.State, reg registry.Registry, logUsers float64, pctUsersHaveKarma int, logContracts int) {
+func addMockUsersWithContracts(b *testing.B, karmaState appstate.State, reg registry.Registry, logUsers float64, pctUsersHaveKarma int, logContracts int) {
 	users := uint64(math.Pow(10, float64(logUsers)))
 	usersWith := uint64(float64(users) * float64(pctUsersHaveKarma) / 100)
 	numContracts := uint64(math.Pow(10, float64(logContracts)))
@@ -126,7 +127,7 @@ func userAddr(user uint64) loom.Address {
 	return loom.MustParseAddress("chain:0x" + hex.EncodeToString([]byte(tail)))
 }
 
-func MockDeployEvmContract(b *testing.B, karmaState loomchain.State, owner loom.Address, nonce uint64, reg registry.Registry) loom.Address {
+func MockDeployEvmContract(b *testing.B, karmaState appstate.State, owner loom.Address, nonce uint64, reg registry.Registry) loom.Address {
 	contractAddr := plugin.CreateAddress(owner, nonce)
 	err := reg.Register("", contractAddr, owner)
 	require.NoError(b, err)
@@ -189,7 +190,7 @@ func testUpkeepFunc(t *testing.T, name string, fn benchmarkFunc) {
 	}
 }
 
-func MockDeployEvmContractT(t *testing.T, karmaState loomchain.State, owner loom.Address, nonce uint64, reg registry.Registry) loom.Address {
+func MockDeployEvmContractT(t *testing.T, karmaState appstate.State, owner loom.Address, nonce uint64, reg registry.Registry) loom.Address {
 	contractAddr := plugin.CreateAddress(owner, nonce)
 	err := reg.Register("", contractAddr, owner)
 	require.NoError(t, err)
@@ -198,7 +199,7 @@ func MockDeployEvmContractT(t *testing.T, karmaState loomchain.State, owner loom
 	return contractAddr
 }
 
-func addMockUsersWithContractsT(t *testing.T, karmaState loomchain.State, reg registry.Registry, logUsers float64, pctUsersHaveKarma int, logContracts int) {
+func addMockUsersWithContractsT(t *testing.T, karmaState appstate.State, reg registry.Registry, logUsers float64, pctUsersHaveKarma int, logContracts int) {
 	users := uint64(math.Pow(10, float64(logUsers)))
 	usersWith := uint64(float64(users) * float64(pctUsersHaveKarma) / 100)
 	numContracts := uint64(math.Pow(10, float64(logContracts)))
@@ -239,7 +240,7 @@ func addMockUsersWithContractsT(t *testing.T, karmaState loomchain.State, reg re
 	}
 }
 
-func addUsers(state loomchain.State, logSize int) loomchain.State {
+func addUsers(state appstate.State, logSize int) appstate.State {
 	entries := uint64(math.Pow(10, float64(logSize)))
 	for i := uint64(0); i < entries; i++ {
 		strI := strconv.FormatUint(i, 10)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -3,6 +3,7 @@ package loomchain
 import (
 	"testing"
 
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/stretchr/testify/require"
 	common "github.com/tendermint/tendermint/libs/common"
 )
@@ -13,7 +14,7 @@ type appHandler struct {
 
 var appTag = common.KVPair{Key: []byte("AppKey"), Value: []byte("AppValue")}
 
-func (a *appHandler) ProcessTx(state State, txBytes []byte, isCheckTx bool) (TxHandlerResult, error) {
+func (a *appHandler) ProcessTx(state appstate.State, txBytes []byte, isCheckTx bool) (TxHandlerResult, error) {
 	require.Equal(a.t, txBytes, []byte("AppData"))
 	return TxHandlerResult{
 		Tags: []common.KVPair{appTag},
@@ -25,7 +26,7 @@ func TestMiddlewareTxHandler(t *testing.T) {
 	allBytes := []byte("FirstMW/SecondMW/AppData")
 	mw1Tag := common.KVPair{Key: []byte("MW1Key"), Value: []byte("MW1Value")}
 	mw1Func := TxMiddlewareFunc(
-		func(state State, txBytes []byte, next TxHandlerFunc, isCheckTx bool) (TxHandlerResult, error) {
+		func(state appstate.State, txBytes []byte, next TxHandlerFunc, isCheckTx bool) (TxHandlerResult, error) {
 			require.Equal(t, txBytes, allBytes)
 			r, err := next(state, txBytes[len("FirstMW/"):], false)
 			if err != nil {
@@ -38,7 +39,7 @@ func TestMiddlewareTxHandler(t *testing.T) {
 
 	mw2Tag := common.KVPair{Key: []byte("MW2Key"), Value: []byte("MW2Value")}
 	mw2Func := TxMiddlewareFunc(
-		func(state State, txBytes []byte, next TxHandlerFunc, isCheckTx bool) (TxHandlerResult, error) {
+		func(state appstate.State, txBytes []byte, next TxHandlerFunc, isCheckTx bool) (TxHandlerResult, error) {
 			require.Equal(t, txBytes, []byte("SecondMW/AppData"))
 			r, err := next(state, txBytes[len("SecondMW/"):], false)
 			if err != nil {

--- a/migrations/migration_context.go
+++ b/migrations/migration_context.go
@@ -5,11 +5,11 @@ import (
 
 	loom "github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/plugin/contractpb"
-	"github.com/loomnetwork/loomchain"
 	genesiscfg "github.com/loomnetwork/loomchain/config/genesis"
 	"github.com/loomnetwork/loomchain/core"
 	"github.com/loomnetwork/loomchain/plugin"
 	registry "github.com/loomnetwork/loomchain/registry/factory"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/vm"
 )
 
@@ -23,14 +23,14 @@ type MigrationContext struct {
 	manager        *vm.Manager
 	createRegistry registry.RegistryFactoryFunc
 	caller         loom.Address
-	state          loomchain.State
+	state          appstate.State
 	codeLoaders    map[string]core.ContractCodeLoader
 }
 
 func NewMigrationContext(
 	manager *vm.Manager,
 	createRegistry registry.RegistryFactoryFunc,
-	state loomchain.State,
+	state appstate.State,
 	caller loom.Address,
 ) *MigrationContext {
 	return &MigrationContext{
@@ -43,7 +43,7 @@ func NewMigrationContext(
 }
 
 // State returns the app state.
-func (mc *MigrationContext) State() loomchain.State {
+func (mc *MigrationContext) State() appstate.State {
 	return mc.state
 }
 

--- a/plugin/chainconfig_manager.go
+++ b/plugin/chainconfig_manager.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/loomnetwork/go-loom"
 	contract "github.com/loomnetwork/go-loom/plugin/contractpb"
+	"github.com/pkg/errors"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/builtin/plugins/chainconfig"
 	"github.com/loomnetwork/loomchain/features"
 	regcommon "github.com/loomnetwork/loomchain/registry"
-	"github.com/pkg/errors"
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 var (
@@ -20,12 +22,12 @@ var (
 // ChainConfigManager implements loomchain.ChainConfigManager interface
 type ChainConfigManager struct {
 	ctx   contract.Context
-	state loomchain.State
+	state appstate.State
 	build uint64
 }
 
 // NewChainConfigManager attempts to create an instance of ChainConfigManager.
-func NewChainConfigManager(pvm *PluginVM, state loomchain.State) (*ChainConfigManager, error) {
+func NewChainConfigManager(pvm *PluginVM, state appstate.State) (*ChainConfigManager, error) {
 	caller := loom.RootAddress(pvm.State.Block().ChainID)
 	contractAddr, err := pvm.Registry.Resolve("chainconfig")
 	if err != nil {

--- a/plugin/fake_context.go
+++ b/plugin/fake_context.go
@@ -9,15 +9,15 @@ import (
 	loom "github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/plugin"
 	"github.com/loomnetwork/go-loom/types"
-	"github.com/loomnetwork/loomchain"
 	levm "github.com/loomnetwork/loomchain/evm"
+	appstate "github.com/loomnetwork/loomchain/state"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 // Contract context for tests that need both Go & EVM contracts.
 type FakeContextWithEVM struct {
 	*plugin.FakeContext
-	State                    loomchain.State
+	State                    appstate.State
 	useAccountBalanceManager bool
 }
 
@@ -34,7 +34,7 @@ func CreateFakeContextWithEVM(caller, address loom.Address) *FakeContextWithEVM 
 			Time:    block.Time.Unix(),
 		},
 	)
-	state := loomchain.NewStoreState(context.Background(), ctx, block, nil, nil)
+	state := appstate.NewStoreState(context.Background(), ctx, block, nil, nil)
 	return &FakeContextWithEVM{
 		FakeContext: ctx,
 		State:       state,

--- a/plugin/vm.go
+++ b/plugin/vm.go
@@ -19,6 +19,7 @@ import (
 	"github.com/loomnetwork/loomchain/auth"
 	levm "github.com/loomnetwork/loomchain/evm"
 	"github.com/loomnetwork/loomchain/registry"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/vm"
 	"github.com/pkg/errors"
 )
@@ -35,7 +36,7 @@ var (
 
 type PluginVM struct {
 	Loader       Loader
-	State        loomchain.State
+	State        appstate.State
 	Registry     registry.Registry
 	EventHandler loomchain.EventHandler
 	logger       *loom.Logger
@@ -47,7 +48,7 @@ type PluginVM struct {
 
 func NewPluginVM(
 	loader Loader,
-	state loomchain.State,
+	state appstate.State,
 	registry registry.Registry,
 	eventHandler loomchain.EventHandler,
 	logger *loom.Logger,
@@ -225,7 +226,7 @@ func (vm *PluginVM) GetStorageAt(addr loom.Address, key []byte) ([]byte, error) 
 type contractContext struct {
 	caller  loom.Address
 	address loom.Address
-	loomchain.State
+	appstate.State
 	VM *PluginVM
 	registry.Registry
 	eventHandler loomchain.EventHandler

--- a/plugin/vm_test.go
+++ b/plugin/vm_test.go
@@ -25,6 +25,7 @@ import (
 	rcommon "github.com/loomnetwork/loomchain/receipts/common"
 	"github.com/loomnetwork/loomchain/receipts/handler"
 	registry "github.com/loomnetwork/loomchain/registry/factory"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	lvm "github.com/loomnetwork/loomchain/vm"
 	"github.com/stretchr/testify/require"
@@ -137,7 +138,7 @@ func TestPluginVMContractContextCaller(t *testing.T) {
 		Height:  int64(34),
 		Time:    time.Unix(123456789, 0),
 	}
-	state := loomchain.NewStoreState(context.Background(), store.NewMemStore(), block, nil, nil)
+	state := appstate.NewStoreState(context.Background(), store.NewMemStore(), block, nil, nil)
 	createRegistry, err := registry.NewRegistryFactory(registry.LatestRegistryVersion)
 	require.NoError(t, err)
 

--- a/receipt_writer.go
+++ b/receipt_writer.go
@@ -6,6 +6,8 @@ import (
 	eth_types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/plugin/types"
+
+	"github.com/loomnetwork/loomchain/state"
 )
 
 type WriteReceiptHandler interface {
@@ -13,6 +15,6 @@ type WriteReceiptHandler interface {
 		logs []*eth_types.Log, blockHeight int64, caller, contract loom.Address, input []byte,
 	) []*types.EventData
 	CacheReceipt(
-		state State, caller, addr loom.Address, events []*types.EventData, err error, txHash []byte,
+		_ state.State, caller, addr loom.Address, events []*types.EventData, err error, txHash []byte,
 	) ([]byte, error)
 }

--- a/receipts/common/test_helper.go
+++ b/receipts/common/test_helper.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/loomnetwork/go-loom/plugin/types"
-	"github.com/loomnetwork/loomchain"
-	"github.com/loomnetwork/loomchain/store"
-	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
 	"github.com/stretchr/testify/require"
 	goleveldb "github.com/syndtr/goleveldb/leveldb"
 	abci "github.com/tendermint/tendermint/abci/types"
+
+	appstate "github.com/loomnetwork/loomchain/state"
+	"github.com/loomnetwork/loomchain/store"
+	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
 )
 
 func MakeDummyReceipts(t *testing.T, num, block uint64) []*types.EvmTxReceipt {
@@ -51,23 +52,23 @@ func MakeDummyReceipt(t *testing.T, block, txNum uint64, events []*types.EventDa
 	return &dummy
 }
 
-func MockState(height uint64) loomchain.State {
+func MockState(height uint64) appstate.State {
 	header := abci.Header{}
 	header.Height = int64(height)
-	return loomchain.NewStoreState(context.Background(), store.NewMemStore(), header, nil, nil)
+	return appstate.NewStoreState(context.Background(), store.NewMemStore(), header, nil, nil)
 }
 
-func MockStateTx(state loomchain.State, height, TxNum uint64) loomchain.State {
+func MockStateTx(state appstate.State, height, TxNum uint64) appstate.State {
 	header := abci.Header{}
 	header.Height = int64(height)
 	header.NumTxs = int64(TxNum)
-	return loomchain.NewStoreState(context.Background(), state, header, nil, nil)
+	return appstate.NewStoreState(context.Background(), state, header, nil, nil)
 }
 
-func MockStateAt(state loomchain.State, newHeight uint64) loomchain.State {
+func MockStateAt(state appstate.State, newHeight uint64) appstate.State {
 	header := abci.Header{}
 	header.Height = int64(newHeight)
-	return loomchain.NewStoreState(context.Background(), state, header, nil, nil)
+	return appstate.NewStoreState(context.Background(), state, header, nil, nil)
 }
 
 func NewMockEvmAuxStore() (*evmaux.EvmAuxStore, error) {

--- a/receipts/handler/handler.go
+++ b/receipts/handler/handler.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/plugin/types"
+	"github.com/pkg/errors"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/receipts/common"
 	"github.com/loomnetwork/loomchain/receipts/leveldb"
+	appstate "github.com/loomnetwork/loomchain/state"
 	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
-	"github.com/pkg/errors"
 )
 
 type ReceiptHandlerVersion int32
@@ -137,7 +139,7 @@ func (r *ReceiptHandler) CommitBlock(height int64) error {
 
 // TODO: this doesn't need the entire state passed in, just the block header
 func (r *ReceiptHandler) CacheReceipt(
-	state loomchain.State, caller, addr loom.Address, events []*types.EventData, txErr error, txHash []byte,
+	state appstate.State, caller, addr loom.Address, events []*types.EventData, txErr error, txHash []byte,
 ) ([]byte, error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()

--- a/registry/factory/registry_factory.go
+++ b/registry/factory/registry_factory.go
@@ -1,10 +1,10 @@
 package factory
 
 import (
-	"github.com/loomnetwork/loomchain"
 	common "github.com/loomnetwork/loomchain/registry"
 	registry_v1 "github.com/loomnetwork/loomchain/registry/v1"
 	registry_v2 "github.com/loomnetwork/loomchain/registry/v2"
+	"github.com/loomnetwork/loomchain/state"
 )
 
 type RegistryVersion int32
@@ -26,18 +26,18 @@ func RegistryVersionFromInt(v int32) (RegistryVersion, error) {
 	return RegistryVersion(v), nil
 }
 
-type RegistryFactoryFunc func(loomchain.State) common.Registry
+type RegistryFactoryFunc func(state.State) common.Registry
 
 // NewRegistryFactory returns a factory function that can be used to create a Registry instance
 // matching the specified version.
 func NewRegistryFactory(v RegistryVersion) (RegistryFactoryFunc, error) {
 	switch v {
 	case RegistryV1:
-		return func(s loomchain.State) common.Registry {
+		return func(s state.State) common.Registry {
 			return &registry_v1.StateRegistry{State: s}
 		}, nil
 	case RegistryV2:
-		return func(s loomchain.State) common.Registry {
+		return func(s state.State) common.Registry {
 			return &registry_v2.StateRegistry{State: s}
 		}, nil
 	}

--- a/registry/v1/registry.go
+++ b/registry/v1/registry.go
@@ -4,11 +4,12 @@ import (
 	"errors"
 	"regexp"
 
-	proto "github.com/gogo/protobuf/proto"
-	loom "github.com/loomnetwork/go-loom"
+	"github.com/gogo/protobuf/proto"
+	"github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/util"
-	"github.com/loomnetwork/loomchain"
+
 	common "github.com/loomnetwork/loomchain/registry"
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 const (
@@ -26,7 +27,7 @@ func recordKey(name string) []byte {
 
 // StateRegistry stores contract meta data for named contracts only, and allows lookup by contract name.
 type StateRegistry struct {
-	State loomchain.State
+	State appstate.State
 }
 
 var _ common.Registry = &StateRegistry{}

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -4,12 +4,13 @@ import (
 	"errors"
 	"regexp"
 
-	proto "github.com/gogo/protobuf/proto"
-	loom "github.com/loomnetwork/go-loom"
+	"github.com/gogo/protobuf/proto"
+	"github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/types"
 	"github.com/loomnetwork/go-loom/util"
-	"github.com/loomnetwork/loomchain"
+
 	common "github.com/loomnetwork/loomchain/registry"
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 const (
@@ -36,7 +37,7 @@ func contractRecordKey(contractAddr loom.Address) []byte {
 // StateRegistry stores contract meta data for named & unnamed contracts, and allows lookup by
 // contract name or contract address.
 type StateRegistry struct {
-	State loomchain.State
+	State appstate.State
 }
 
 var _ common.Registry = &StateRegistry{}

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/loomnetwork/go-loom/plugin/contractpb"
 	"github.com/loomnetwork/go-loom/plugin/types"
 	"github.com/loomnetwork/go-loom/vm"
+
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/builtin/plugins/ethcoin"
@@ -39,6 +40,7 @@ import (
 	"github.com/loomnetwork/loomchain/registry"
 	registryFac "github.com/loomnetwork/loomchain/registry/factory"
 	"github.com/loomnetwork/loomchain/rpc/eth"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	blockindex "github.com/loomnetwork/loomchain/store/block_index"
 	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
@@ -58,7 +60,7 @@ const (
 
 // StateProvider interface is used by QueryServer to access the read-only application state
 type StateProvider interface {
-	ReadOnlyState() loomchain.State
+	ReadOnlyState() appstate.State
 }
 
 // QueryServer provides the ability to query the current state of the DAppChain via RPC.
@@ -343,11 +345,11 @@ func (s *QueryServer) EthGetCode(address eth.Data, block eth.BlockHeight) (eth.D
 }
 
 // Attempts to construct the context of the Address Mapper contract.
-func (s *QueryServer) createAddressMapperCtx(state loomchain.State) (contractpb.StaticContext, error) {
+func (s *QueryServer) createAddressMapperCtx(state appstate.State) (contractpb.StaticContext, error) {
 	return s.createStaticContractCtx(state, "addressmapper")
 }
 
-func (s *QueryServer) createStaticContractCtx(state loomchain.State, name string) (contractpb.StaticContext, error) {
+func (s *QueryServer) createStaticContractCtx(state appstate.State, name string) (contractpb.StaticContext, error) {
 	ctx, err := lcp.NewInternalContractContext(
 		name,
 		lcp.NewPluginVM(
@@ -1117,7 +1119,7 @@ func (s *QueryServer) getBlockHeightFromHash(hash []byte) (uint64, error) {
 	}
 }
 
-func getReceiptByTendermintHash(state loomchain.State, blockStore store.BlockStore, rh loomchain.ReadReceiptHandler, hash []byte) (*eth.JsonTxReceipt, error) {
+func getReceiptByTendermintHash(state appstate.State, blockStore store.BlockStore, rh loomchain.ReadReceiptHandler, hash []byte) (*eth.JsonTxReceipt, error) {
 	txResults, err := blockStore.GetTxResult(hash)
 	if err != nil {
 		return nil, err

--- a/rpc/query_server_test.go
+++ b/rpc/query_server_test.go
@@ -19,6 +19,7 @@ import (
 	llog "github.com/loomnetwork/loomchain/log"
 	"github.com/loomnetwork/loomchain/plugin"
 	registry "github.com/loomnetwork/loomchain/registry/factory"
+	"github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -89,8 +90,8 @@ type stateProvider struct {
 	ChainID string
 }
 
-func (s *stateProvider) ReadOnlyState() loomchain.State {
-	return loomchain.NewStoreState(
+func (s *stateProvider) ReadOnlyState() state.State {
+	return state.NewStoreState(
 		nil,
 		store.NewMemStore(),
 		abci.Header{

--- a/state/state.go
+++ b/state/state.go
@@ -1,0 +1,266 @@
+package state
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/loomnetwork/go-loom"
+	cctypes "github.com/loomnetwork/go-loom/builtin/types/chainconfig"
+	"github.com/loomnetwork/go-loom/config"
+	"github.com/loomnetwork/go-loom/plugin"
+	"github.com/loomnetwork/go-loom/types"
+	"github.com/loomnetwork/go-loom/util"
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/loomnetwork/loomchain/store"
+)
+
+type GetValidatorSet func(state State) (loom.ValidatorSet, error)
+type ReadOnlyState interface {
+	store.KVReader
+	Validators() []*loom.Validator
+	Block() types.BlockHeader
+	// Release should free up any underlying system resources. Must be safe to invoke multiple times.
+	Release()
+	FeatureEnabled(string, bool) bool
+	Config() *cctypes.Config
+	EnabledFeatures() []string
+}
+
+type State interface {
+	ReadOnlyState
+	store.KVWriter
+	Context() context.Context
+	WithContext(ctx context.Context) State
+	WithPrefix(prefix []byte) State
+	SetFeature(string, bool)
+	ChangeConfigSetting(name, value string) error
+}
+
+type StoreState struct {
+	ctx             context.Context
+	store           store.KVStore
+	block           types.BlockHeader
+	validators      loom.ValidatorSet
+	getValidatorSet GetValidatorSet
+	config          *cctypes.Config
+}
+
+var _ = State(&StoreState{})
+
+func NewStoreState(
+	ctx context.Context,
+	store store.KVStore,
+	block abci.Header,
+	curBlockHash []byte,
+	getValidatorSet GetValidatorSet,
+) *StoreState {
+	blockHeader := blockHeaderFromAbciHeader(&block)
+	blockHeader.CurrentHash = curBlockHash
+	return &StoreState{
+		ctx:             ctx,
+		store:           store,
+		block:           blockHeader,
+		validators:      loom.NewValidatorSet(),
+		getValidatorSet: getValidatorSet,
+	}
+}
+
+func (s *StoreState) WithOnChainConfig(config *cctypes.Config) *StoreState {
+	s.config = config
+	return s
+}
+
+func (s *StoreState) Range(prefix []byte) plugin.RangeData {
+	return s.store.Range(prefix)
+}
+
+func (s *StoreState) Get(key []byte) []byte {
+	return s.store.Get(key)
+}
+
+func (s *StoreState) Has(key []byte) bool {
+	return s.store.Has(key)
+}
+
+func (s *StoreState) Validators() []*loom.Validator {
+	if (len(s.validators) == 0) && (s.getValidatorSet != nil) {
+		validatorSet, err := s.getValidatorSet(s)
+		if err != nil {
+			panic(err)
+		}
+		// cache the validator set for the current state
+		s.validators = validatorSet
+	}
+	return s.validators.Slice()
+}
+
+func (s *StoreState) Set(key, value []byte) {
+	s.store.Set(key, value)
+}
+
+func (s *StoreState) Delete(key []byte) {
+	s.store.Delete(key)
+}
+
+func (s *StoreState) Block() types.BlockHeader {
+	return s.block
+}
+
+func (s *StoreState) Context() context.Context {
+	return s.ctx
+}
+
+const (
+	featurePrefix = "feature"
+)
+
+func (s *StoreState) EnabledFeatures() []string {
+	featuresFromState := s.Range([]byte(featurePrefix))
+	enabledFeatures := make([]string, 0, len(featuresFromState))
+	for _, m := range featuresFromState {
+		if bytes.Equal(m.Value, []byte{1}) {
+			enabledFeatures = append(enabledFeatures, string(m.Key))
+		}
+	}
+	return enabledFeatures
+}
+
+func (s *StoreState) FeatureEnabled(name string, val bool) bool {
+	data := s.store.Get(featureKey(name))
+	if len(data) == 0 {
+		return val
+	}
+	if bytes.Equal(data, []byte{1}) {
+		return true
+	}
+	return false
+}
+
+func (s *StoreState) SetFeature(name string, val bool) {
+	data := []byte{0}
+	if val {
+		data = []byte{1}
+	}
+	s.store.Set(featureKey(name), data)
+}
+
+// ChangeConfigSetting updates the value of the given on-chain config setting.
+// If an error occurs while trying to update the config the change is rolled back, if the rollback
+// itself fails this function will panic.
+func (s *StoreState) ChangeConfigSetting(name, value string) error {
+	cfg, err := store.LoadOnChainConfig(s.store)
+	if err != nil {
+		panic(err)
+	}
+	if err := config.SetConfigSetting(cfg, name, value); err != nil {
+		return err
+	}
+	if err := store.SaveOnChainConfig(s.store, cfg); err != nil {
+		return err
+	}
+	// invalidate cached config so it's reloaded next time it's accessed
+	s.config = nil
+	return nil
+}
+
+// Config returns the current on-chain config.
+func (s *StoreState) Config() *cctypes.Config {
+	if s.config == nil {
+		var err error
+		s.config, err = store.LoadOnChainConfig(s.store)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return s.config
+}
+
+func (s *StoreState) WithContext(ctx context.Context) State {
+	return &StoreState{
+		store:           s.store,
+		block:           s.block,
+		ctx:             ctx,
+		validators:      s.validators,
+		getValidatorSet: s.getValidatorSet,
+	}
+}
+
+func (s *StoreState) WithPrefix(prefix []byte) State {
+	return &StoreState{
+		store:           store.PrefixKVStore(prefix, s.store),
+		block:           s.block,
+		ctx:             s.ctx,
+		validators:      s.validators,
+		getValidatorSet: s.getValidatorSet,
+	}
+}
+
+func (s *StoreState) Release() {
+	// noop
+}
+
+// StoreStateSnapshot is a read-only snapshot of the app state at particular point in time,
+// it's unaffected by any changes to the app state. Multiple snapshots can exist at any one
+// time, but each snapshot should only be accessed from one thread at a time. After a snapshot
+// is no longer needed call Release() to free up underlying resources. Live snapshots may prevent
+// the underlying DB from writing new data in the most space efficient manner, so aim to minimize
+// their lifetime.
+type StoreStateSnapshot struct {
+	*StoreState
+	storeSnapshot store.Snapshot
+}
+
+// TODO: Ideally StoreStateSnapshot should only implement ReadOnlyState interface, but that will
+//       require updating a bunch of the existing State consumers to also handle ReadOnlyState.
+var _ = State(&StoreStateSnapshot{})
+
+// NewStoreStateSnapshot creates a new snapshot of the app state.
+func NewStoreStateSnapshot(
+	ctx context.Context, snap store.Snapshot, block abci.Header, curBlockHash []byte,
+	getValidatorSet GetValidatorSet,
+) *StoreStateSnapshot {
+	return &StoreStateSnapshot{
+		StoreState:    NewStoreState(ctx, &readOnlyKVStoreAdapter{snap}, block, curBlockHash, getValidatorSet),
+		storeSnapshot: snap,
+	}
+}
+
+// Release releases the underlying store snapshot, safe to call multiple times.
+func (s *StoreStateSnapshot) Release() {
+	if s.storeSnapshot != nil {
+		s.storeSnapshot.Release()
+		s.storeSnapshot = nil
+	}
+}
+
+// For all the times you need a read-only store.KVStore but you only have a store.KVReader.
+type readOnlyKVStoreAdapter struct {
+	store.KVReader
+}
+
+func (s *readOnlyKVStoreAdapter) Set(key, value []byte) {
+	panic("kvStoreSnapshotAdapter.Set not implemented")
+}
+
+func (s *readOnlyKVStoreAdapter) Delete(key []byte) {
+	panic("kvStoreSnapshotAdapter.Delete not implemented")
+}
+
+func featureKey(featureName string) []byte {
+	return util.PrefixKey([]byte(featurePrefix), []byte(featureName))
+}
+
+func blockHeaderFromAbciHeader(header *abci.Header) types.BlockHeader {
+	return types.BlockHeader{
+		ChainID: header.ChainID,
+		Height:  header.Height,
+		Time:    header.Time.Unix(),
+		NumTxs:  int32(header.NumTxs), //TODO this cast doesnt look right
+		LastBlockID: types.BlockID{
+			Hash: header.LastBlockId.Hash,
+		},
+		ValidatorsHash: header.ValidatorsHash,
+		AppHash:        header.AppHash,
+	}
+}

--- a/throttle/contract_tx_limiter_middleware.go
+++ b/throttle/contract_tx_limiter_middleware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
 	udw "github.com/loomnetwork/loomchain/builtin/plugins/user_deployer_whitelist"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/vm"
 	"github.com/pkg/errors"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
@@ -142,13 +143,13 @@ func loadTierMap(ctx contractpb.StaticContext) (map[udwtypes.TierID]udwtypes.Tie
 // NewContractTxLimiterMiddleware creates a middleware function that limits how many call txs can be
 // sent to an EVM contract within a pre-configured block range.
 func NewContractTxLimiterMiddleware(cfg *ContractTxLimiterConfig,
-	createUserDeployerWhitelistCtx func(state loomchain.State) (contractpb.Context, error),
+	createUserDeployerWhitelistCtx func(state appstate.State) (contractpb.Context, error),
 ) loomchain.TxMiddlewareFunc {
 	txl := &contractTxLimiter{
 		contractStatsMap: make(map[string]*contractStats),
 	}
 	return loomchain.TxMiddlewareFunc(func(
-		state loomchain.State,
+		state appstate.State,
 		txBytes []byte,
 		next loomchain.TxHandlerFunc,
 		isCheckTx bool,

--- a/throttle/deployer-middleware.go
+++ b/throttle/deployer-middleware.go
@@ -10,6 +10,7 @@ import (
 	udw "github.com/loomnetwork/loomchain/builtin/plugins/user_deployer_whitelist"
 	"github.com/loomnetwork/loomchain/eth/utils"
 	"github.com/loomnetwork/loomchain/features"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/vm"
 	"github.com/pkg/errors"
 )
@@ -25,10 +26,10 @@ var (
 // NewEVMDeployRecorderPostCommitMiddleware returns post-commit middleware that
 // Records deploymentAddress and vmType
 func NewEVMDeployRecorderPostCommitMiddleware(
-	createDeployerWhitelistCtx func(state loomchain.State) (contractpb.Context, error),
+	createDeployerWhitelistCtx func(state appstate.State) (contractpb.Context, error),
 ) (loomchain.PostCommitMiddleware, error) {
 	return loomchain.PostCommitMiddlewareFunc(func(
-		state loomchain.State,
+		state appstate.State,
 		txBytes []byte,
 		res loomchain.TxHandlerResult,
 		next loomchain.PostCommitHandler,
@@ -68,10 +69,10 @@ func NewEVMDeployRecorderPostCommitMiddleware(
 }
 
 func NewDeployerWhitelistMiddleware(
-	createDeployerWhitelistCtx func(state loomchain.State) (contractpb.Context, error),
+	createDeployerWhitelistCtx func(state appstate.State) (contractpb.Context, error),
 ) (loomchain.TxMiddlewareFunc, error) {
 	return loomchain.TxMiddlewareFunc(func(
-		state loomchain.State,
+		state appstate.State,
 		txBytes []byte,
 		next loomchain.TxHandlerFunc,
 		isCheckTx bool,

--- a/throttle/deployer-middleware_test.go
+++ b/throttle/deployer-middleware_test.go
@@ -8,14 +8,15 @@ import (
 	dwtypes "github.com/loomnetwork/go-loom/builtin/types/deployer_whitelist"
 	goloomplugin "github.com/loomnetwork/go-loom/plugin"
 	"github.com/loomnetwork/go-loom/plugin/contractpb"
-	"github.com/loomnetwork/loomchain"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	loomAuth "github.com/loomnetwork/loomchain/auth"
 	dw "github.com/loomnetwork/loomchain/builtin/plugins/deployer_whitelist"
 	"github.com/loomnetwork/loomchain/features"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	"github.com/loomnetwork/loomchain/vm"
-	"github.com/stretchr/testify/require"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 var (
@@ -24,7 +25,7 @@ var (
 )
 
 func TestDeployerWhitelistMiddleware(t *testing.T) {
-	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
+	state := appstate.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
 	state.SetFeature(features.DeployerWhitelistFeature, true)
 
 	txSignedPlugin := mockSignedTx(t, uint64(1), deployId, vm.VMType_PLUGIN, contract)
@@ -44,7 +45,7 @@ func TestDeployerWhitelistMiddleware(t *testing.T) {
 	ownerCtx := context.WithValue(state.Context(), loomAuth.ContextKeyOrigin, owner)
 
 	dwMiddleware, err := NewDeployerWhitelistMiddleware(
-		func(state loomchain.State) (contractpb.Context, error) {
+		func(_ appstate.State) (contractpb.Context, error) {
 			return contractContext, nil
 		},
 	)

--- a/throttle/karma-middleware.go
+++ b/throttle/karma-middleware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/builtin/plugins/karma"
 	"github.com/loomnetwork/loomchain/eth/utils"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/vm"
 	"github.com/pkg/errors"
 )
@@ -23,11 +24,11 @@ func GetKarmaMiddleWare(
 	karmaEnabled bool,
 	maxCallCount int64,
 	sessionDuration int64,
-	createKarmaContractCtx func(state loomchain.State) (contractpb.Context, error),
+	createKarmaContractCtx func(state appstate.State) (contractpb.Context, error),
 ) loomchain.TxMiddlewareFunc {
 	th := NewThrottle(sessionDuration, maxCallCount)
 	return loomchain.TxMiddlewareFunc(func(
-		state loomchain.State,
+		state appstate.State,
 		txBytes []byte,
 		next loomchain.TxHandlerFunc,
 		isCheckTx bool,

--- a/throttle/karma-middleware_test.go
+++ b/throttle/karma-middleware_test.go
@@ -9,10 +9,10 @@ import (
 	goloomplugin "github.com/loomnetwork/go-loom/plugin"
 	"github.com/loomnetwork/go-loom/plugin/contractpb"
 	"github.com/loomnetwork/go-loom/types"
-	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/builtin/plugins/karma"
 	"github.com/loomnetwork/loomchain/log"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	"github.com/loomnetwork/loomchain/vm"
 	"github.com/stretchr/testify/require"
@@ -39,7 +39,7 @@ func TestKarmaMiddleWare(t *testing.T) {
 	log.Setup("debug", "file://-")
 	log.Root.With("module", "throttle-middleware")
 
-	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
+	state := appstate.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
 
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
 	karmaAddr := fakeCtx.CreateContract(karma.Contract)
@@ -60,7 +60,7 @@ func TestKarmaMiddleWare(t *testing.T) {
 		true,
 		maxCallCount,
 		sessionDuration,
-		func(state loomchain.State) (contractpb.Context, error) {
+		func(state appstate.State) (contractpb.Context, error) {
 			return contractContext, nil
 		},
 	)
@@ -95,7 +95,7 @@ func TestMinKarmaToDeploy(t *testing.T) {
 	log.Setup("debug", "file://-")
 	log.Root.With("module", "throttle-middleware")
 
-	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
+	state := appstate.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
 
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
 	karmaAddr := fakeCtx.CreateContract(karma.Contract)
@@ -119,7 +119,7 @@ func TestMinKarmaToDeploy(t *testing.T) {
 		true,
 		maxCallCount,
 		sessionDuration,
-		func(state loomchain.State) (contractpb.Context, error) {
+		func(_ appstate.State) (contractpb.Context, error) {
 			return contractContext, nil
 		},
 	)

--- a/throttle/legacy_deployer_middleware.go
+++ b/throttle/legacy_deployer_middleware.go
@@ -7,6 +7,7 @@ import (
 	"github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/vm"
 	"github.com/pkg/errors"
 )
@@ -16,7 +17,7 @@ import (
 // by the DeployerWhitelist contract & middleware, though it's still in use on some clusters.
 func GetGoDeployTxMiddleWare(allowedDeployers []loom.Address) loomchain.TxMiddlewareFunc {
 	return loomchain.TxMiddlewareFunc(func(
-		state loomchain.State,
+		state appstate.State,
 		txBytes []byte,
 		next loomchain.TxHandlerFunc,
 		isCheckTx bool,

--- a/throttle/middleware_test_helper.go
+++ b/throttle/middleware_test_helper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/loomnetwork/loomchain"
 	loomAuth "github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/eth/utils"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/vm"
 	"github.com/pkg/errors"
 )
@@ -17,11 +18,11 @@ var (
 	contract = loom.MustParseAddress("chain:0x9a1aC42a17AAD6Dbc6d21c162989d0f701074044")
 )
 
-func throttleMiddlewareHandler(ttm loomchain.TxMiddlewareFunc, state loomchain.State, tx auth.SignedTx, ctx context.Context) (loomchain.TxHandlerResult, error) {
+func throttleMiddlewareHandler(ttm loomchain.TxMiddlewareFunc, state appstate.State, tx auth.SignedTx, ctx context.Context) (loomchain.TxHandlerResult, error) {
 	return ttm.ProcessTx(
 		state.WithContext(ctx),
 		tx.Inner,
-		func(state loomchain.State, txBytes []byte, isCheckTx bool) (res loomchain.TxHandlerResult, err error) {
+		func(state appstate.State, txBytes []byte, isCheckTx bool) (res loomchain.TxHandlerResult, err error) {
 
 			var nonceTx loomAuth.NonceTx
 			if err := proto.Unmarshal(txBytes, &nonceTx); err != nil {

--- a/throttle/throttle.go
+++ b/throttle/throttle.go
@@ -11,11 +11,12 @@ import (
 	ktypes "github.com/loomnetwork/go-loom/builtin/types/karma"
 	"github.com/loomnetwork/go-loom/common"
 	"github.com/loomnetwork/go-loom/plugin/contractpb"
-	"github.com/loomnetwork/loomchain"
-	"github.com/loomnetwork/loomchain/auth"
-	"github.com/loomnetwork/loomchain/builtin/plugins/karma"
 	"github.com/ulule/limiter"
 	"github.com/ulule/limiter/drivers/store/memory"
+
+	"github.com/loomnetwork/loomchain/auth"
+	"github.com/loomnetwork/loomchain/builtin/plugins/karma"
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 const (
@@ -87,7 +88,7 @@ func (t *Throttle) getLimiterContext(ctx context.Context, nonce uint64, limit in
 	}
 }
 
-func (t *Throttle) runThrottle(state loomchain.State, nonce uint64, origin loom.Address, limit int64, txId uint32, key string) error {
+func (t *Throttle) runThrottle(state appstate.State, nonce uint64, origin loom.Address, limit int64, txId uint32, key string) error {
 	limitCtx, err := t.getLimiterContext(state.Context(), nonce, limit, txId, key)
 	if err != nil {
 		return errors.Wrap(err, "deploy limiter context")

--- a/throttle/throttle_test.go
+++ b/throttle/throttle_test.go
@@ -16,6 +16,7 @@ import (
 	loomAuth "github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/builtin/plugins/karma"
 	"github.com/loomnetwork/loomchain/log"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	"github.com/loomnetwork/loomchain/vm"
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,7 @@ func TestDeployThrottleTxMiddleware(t *testing.T) {
 	log.Setup("debug", "file://-")
 	log.Root.With("module", "throttle-middleware")
 
-	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
+	state := appstate.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
 
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
 	karmaAddr := fakeCtx.CreateContract(karma.Contract)
@@ -79,7 +80,7 @@ func TestDeployThrottleTxMiddleware(t *testing.T) {
 		true,
 		maxCallCount,
 		sessionDuration,
-		func(state loomchain.State) (contractpb.Context, error) {
+		func(state appstate.State) (contractpb.Context, error) {
 			return contractContext, nil
 		},
 	)
@@ -100,7 +101,7 @@ func TestCallThrottleTxMiddleware(t *testing.T) {
 	log.Setup("debug", "file://-")
 	log.Root.With("module", "throttle-middleware")
 
-	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
+	state := appstate.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
 
 	fakeCtx := goloomplugin.CreateFakeContext(addr1, addr1)
 	karmaAddr := fakeCtx.CreateContract(karma.Contract)
@@ -121,7 +122,7 @@ func TestCallThrottleTxMiddleware(t *testing.T) {
 		true,
 		maxCallCount,
 		sessionDuration,
-		func(state loomchain.State) (contractpb.Context, error) {
+		func(state appstate.State) (contractpb.Context, error) {
 			return contractContext, nil
 		},
 	)

--- a/throttle/tx_limiter_middleware.go
+++ b/throttle/tx_limiter_middleware.go
@@ -7,6 +7,7 @@ import (
 	"github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/pkg/errors"
 	"github.com/ulule/limiter"
 	"github.com/ulule/limiter/drivers/store/memory"
@@ -70,7 +71,7 @@ func (txl *txLimiter) isAccountLimitReached(account loom.Address) bool {
 func NewTxLimiterMiddleware(cfg *TxLimiterConfig) loomchain.TxMiddlewareFunc {
 	txl := newTxLimiter(cfg)
 	return loomchain.TxMiddlewareFunc(func(
-		state loomchain.State,
+		state appstate.State,
 		txBytes []byte,
 		next loomchain.TxHandlerFunc,
 		isCheckTx bool,

--- a/tx_handler/migration_tx_handler.go
+++ b/tx_handler/migration_tx_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/loomnetwork/loomchain/features"
 	"github.com/loomnetwork/loomchain/migrations"
 	registry "github.com/loomnetwork/loomchain/registry/factory"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/vm"
 )
 
@@ -44,7 +45,7 @@ type MigrationTxHandler struct {
 }
 
 func (h *MigrationTxHandler) ProcessTx(
-	state loomchain.State,
+	state appstate.State,
 	txBytes []byte,
 	isCheckTx bool,
 ) (loomchain.TxHandlerResult, error) {

--- a/tx_handler/migration_tx_handler_test.go
+++ b/tx_handler/migration_tx_handler_test.go
@@ -8,10 +8,10 @@ import (
 	loom "github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/types"
 	"github.com/loomnetwork/go-loom/vm"
-	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/features"
 	"github.com/loomnetwork/loomchain/migrations"
+	appstate "github.com/loomnetwork/loomchain/state"
 	"github.com/loomnetwork/loomchain/store"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -20,7 +20,7 @@ import (
 
 func TestMigrationTxHandler(t *testing.T) {
 	origin := loom.MustParseAddress("chain:0x5cecd1f7261e1f4c684e297be3edf03b825e01c4")
-	state := loomchain.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
+	state := appstate.NewStoreState(nil, store.NewMemStore(), abci.Header{}, nil, nil)
 	state.SetFeature(features.MigrationTxFeature, true)
 
 	ctx := context.WithValue(state.Context(), auth.ContextKeyOrigin, origin)

--- a/vm/handler.go
+++ b/vm/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/loomnetwork/loomchain/eth/utils"
 	"github.com/loomnetwork/loomchain/features"
 	registry "github.com/loomnetwork/loomchain/registry/factory"
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 type DeployTxHandler struct {
@@ -22,7 +23,7 @@ type DeployTxHandler struct {
 }
 
 func (h *DeployTxHandler) ProcessTx(
-	state loomchain.State,
+	state appstate.State,
 	txBytes []byte,
 	isCheckTx bool,
 ) (loomchain.TxHandlerResult, error) {
@@ -103,7 +104,7 @@ type CallTxHandler struct {
 }
 
 func (h *CallTxHandler) ProcessTx(
-	state loomchain.State,
+	state appstate.State,
 	txBytes []byte,
 	isCheckTx bool,
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	loom "github.com/loomnetwork/go-loom"
-	"github.com/loomnetwork/loomchain"
+	appstate "github.com/loomnetwork/loomchain/state"
 )
 
 type VM interface {
@@ -15,7 +15,7 @@ type VM interface {
 	GetStorageAt(addr loom.Address, hash []byte) ([]byte, error)
 }
 
-type Factory func(loomchain.State) (VM, error)
+type Factory func(appstate.State) (VM, error)
 
 type Manager struct {
 	vms map[VMType]Factory
@@ -31,7 +31,7 @@ func (m *Manager) Register(typ VMType, fac Factory) {
 	m.vms[typ] = fac
 }
 
-func (m *Manager) InitVM(typ VMType, state loomchain.State) (VM, error) {
+func (m *Manager) InitVM(typ VMType, state appstate.State) (VM, error) {
 	fac, ok := m.vms[typ]
 	if !ok {
 		return nil, errors.New("vm type not found")


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request

Having the State object in the main loomchain object can make it difficult to avoid cyclic dependencies. Hence putting it in a separate package.
Should not change any functionality