### PR TITLE
Add a new evm state dump command

### DIFF
--- a/cmd/loom/db/db.go
+++ b/cmd/loom/db/db.go
@@ -16,6 +16,7 @@ func NewDBCommand() *cobra.Command {
 		newCompactDBCommand(),
 		newDumpEVMStateCommand(),
 		newDumpEVMStateMultiWriterAppStoreCommand(),
+		newDumpEVMStateFromEvmDB(),
 		newGetEvmHeightCommand(),
 		newGetAppHeightCommand(),
 	)

--- a/cmd/loom/db/evm.go
+++ b/cmd/loom/db/evm.go
@@ -269,7 +269,7 @@ func newDumpEVMStateFromEvmDB() *cobra.Command {
 			root, version := evmStore.Version()
 			evmRoot := gcommon.BytesToHash(root)
 
-			fmt.Printf("version:%d, root: %x\n", version, root)
+			fmt.Printf("version: %d, root: %x\n", version, root)
 
 			// TODO: This should use snapshot obtained from appStore.ReadOnlyState()
 			storeTx := store.WrapAtomic(evmStore).BeginTx()
@@ -309,10 +309,12 @@ func newDumpEVMStateFromEvmDB() *cobra.Command {
 					panic(err)
 				}
 
-				fmt.Printf("Account: %s\n", addr.Hex())
-				fmt.Printf("- Code: %x\n", srcState.GetCode(addr))
-				fmt.Printf("- Nonce: %d\n", srcState.GetNonce(addr))
-				fmt.Printf("- Balance: %d\n", srcState.GetBalance(addr))
+				fmt.Printf("Account: %s\n", gcommon.Bytes2Hex(addrBytes))
+				fmt.Printf("- Balance: %s\n", data.Balance.String())
+				fmt.Printf("- Nonce: %d\n", data.Nonce)
+				fmt.Printf("- Root: %s\n", gcommon.Bytes2Hex(data.Root[:]))
+				fmt.Printf("- CodeHash: %s\n", gcommon.Bytes2Hex((data.CodeHash)))
+				fmt.Printf("- Code: %x\n", gcommon.Bytes2Hex(srcState.GetCode(addr)))
 				fmt.Printf("- Storage Root: %x\n", srcState.StorageTrie(addr).Hash())
 
 				if dumpStorageTrie {

--- a/cmd/loom/db/evm.go
+++ b/cmd/loom/db/evm.go
@@ -233,7 +233,7 @@ func newDumpEVMStateMultiWriterAppStoreCommand() *cobra.Command {
 
 	cmdFlags := cmd.Flags()
 	cmdFlags.Int64Var(&appHeight, "app-height", 0, "Dump EVM state as it was the specified app height")
-	cmdFlags.StringVar(&evmDBName, "evmdb-name", "evm", "Dump EVM state as it was the specified app height")
+	cmdFlags.StringVar(&evmDBName, "evmdb-name", "evm", "Name of EVM state database")
 	return cmd
 }
 
@@ -310,7 +310,7 @@ func newDumpEVMStateFromEvmDB() *cobra.Command {
 				}
 
 				fmt.Printf("Account: %s\n", addr.Hex())
-				fmt.Printf("- Code: %x\n", srcState.GetCodeHash(addr))
+				fmt.Printf("- Code: %x\n", srcState.GetCode(addr))
 				fmt.Printf("- Nonce: %d\n", srcState.GetNonce(addr))
 				fmt.Printf("- Balance: %d\n", srcState.GetBalance(addr))
 				fmt.Printf("- Storage Root: %x\n", srcState.StorageTrie(addr).Hash())
@@ -331,7 +331,7 @@ func newDumpEVMStateFromEvmDB() *cobra.Command {
 
 	cmdFlags := cmd.Flags()
 	cmdFlags.Int64Var(&appHeight, "app-height", 0, "Dump EVM state as it was the specified app height")
-	cmdFlags.StringVar(&evmDBName, "evmdb-name", "evm", "Dump EVM state as it was the specified app height")
+	cmdFlags.StringVar(&evmDBName, "evmdb-name", "evm", "Name of EVM state database")
 	cmdFlags.BoolVar(&dumpStorageTrie, "storage-trie", false, "Dump all storage tries of accounts")
 	return cmd
 }


### PR DESCRIPTION
This PR adds a new evm state dump command which directly dump state out of evm.db
```
loom db evm-dump-3 --app-height 20  --storage-trie
```


- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request