### PR TITLE
[WIP] Support blockatlas with GetBlockTxs endpoint 

### DIFF
--- a/rpc/blockatlas/jsonrpc_conversion.go
+++ b/rpc/blockatlas/jsonrpc_conversion.go
@@ -1,0 +1,237 @@
+package blockatlas
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/loomnetwork/go-loom"
+	ltypes "github.com/loomnetwork/go-loom/types"
+	"github.com/pkg/errors"
+)
+
+// https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding
+// Eth JSON RPC define three types QUANTITIES, DATA and default block parameter.
+// All represented by strings.
+type Quantity string
+type Data string
+type BlockHeight string
+
+const (
+	ZeroedQuantity     Quantity = "0x0"
+	ZeroedData         Data     = "0x0"
+	ZeroedData8Bytes   Data     = "0x0000000000000000"
+	ZeroedData20Bytes  Data     = "0x0000000000000000000000000000000000000000"
+	ZeroedData32Bytes  Data     = "0x0000000000000000000000000000000000000000000000000000000000000000"
+	ZeroedData64bytes  Data     = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	ZeroedData256Bytes Data     = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+	StatusTxSuccess = "0x1"
+)
+
+type JsonTxObject struct {
+	Hash             Data     `json:"hash,omitempty"`
+	TransactionType  Data     `json:"transactionType,omitempty"`
+	ContractName     string   `json:"contractName,omitempty"`
+	ContractMethod   string   `json:"contractMethod,omitempty"`
+	Nonce            Quantity `json:"nonce,omitempty"`
+	BlockHash        Data     `json:"blockHash,omitempty"`
+	BlockNumber      Quantity `json:"blockNumber,omitempty"`
+	TransactionIndex Quantity `json:"transactionIndex,omitempty"`
+	From             string   `json:"from,omitempty"`
+	To               string   `json:"to"`
+	Value            Quantity `json:"value,omitempty"`
+	GasPrice         Quantity `json:"gasPrice,omitempty"`
+	Gas              Quantity `json:"gas,omitempty"`
+	Input            Data     `json:"input,omitempty"`
+}
+
+type JsonBlockObject struct {
+	Number           Quantity       `json:"number,omitempty"`
+	Hash             Data           `json:"hash,omitempty"`
+	ParentHash       Data           `json:"parentHash,omitempty"`
+	Nonce            Data           `json:"nonce,omitempty"`
+	TransactionsRoot Data           `json:"transactionsRoot,omitempty"`
+	Size             Quantity       `json:"size,omitempty"`
+	GasLimit         Quantity       `json:"gasLimit,omitempty"`
+	GasUsed          Quantity       `json:"gasUsed,omitempty"`
+	Timestamp        Quantity       `json:"timestamp,omitempty"`
+	Transactions     []JsonTxObject `json:"transactions"` // Data or []Data
+}
+
+func EncInt(value int64) Quantity {
+	return Quantity("0x" + strconv.FormatInt(value, 16))
+}
+
+func EncUint(value uint64) Quantity {
+	return Quantity("0x" + strconv.FormatUint(value, 16))
+}
+
+func EncBigInt(value big.Int) Quantity {
+	return Quantity("0x" + value.Text(16))
+}
+
+// Hex
+func EncBytes(value []byte) Data {
+	bytesStr := "0x" + hex.EncodeToString(value)
+	if bytesStr == "0x" {
+		bytesStr = "0x0"
+	}
+	return Data(strings.ToLower(bytesStr))
+}
+
+// Ptr to Hex
+func EncPtrBytes(value []byte) *Data {
+	if len(value) == 0 {
+		return nil
+	}
+	bytesStr := "0x" + hex.EncodeToString(value)
+	if bytesStr == "0x" {
+		bytesStr = "0x0"
+	}
+	data := Data(strings.ToLower(bytesStr))
+	return &data
+}
+
+func EncPtrData(value Data) *Data {
+	if len(value) == 0 {
+		return nil
+	}
+	return &value
+}
+
+func EncBytesArray(list [][]byte) []Data {
+	dataArray := []Data{}
+	for _, hash := range list {
+		dataArray = append(dataArray, EncBytes(hash))
+	}
+	return dataArray
+}
+
+func EncAddress(value *ltypes.Address) Data {
+	if value == nil {
+		return ZeroedData
+	} else {
+		return EncBytes([]byte(value.Local))
+	}
+}
+
+func EncPtrAddress(value *ltypes.Address) *Data {
+	if value == nil {
+		return nil
+	} else {
+		data := EncBytes([]byte(value.Local))
+		return &data
+	}
+}
+
+type EthBlockFilter struct {
+	Addresses []loom.LocalAddress
+	Topics    [][]string
+}
+
+type EthFilter struct {
+	EthBlockFilter
+	FromBlock BlockHeight
+	ToBlock   BlockHeight
+}
+
+func DecQuantityToInt(value Quantity) (int64, error) {
+	if len(value) <= 2 || value[0:2] != "0x" {
+		return 0, errors.Errorf("invalid quantity format: %v", value)
+	}
+	return strconv.ParseInt(string(value), 0, 64)
+}
+
+func DecQuantityToUint(value Quantity) (uint64, error) {
+	if len(value) <= 2 || value[0:2] != "0x" {
+		return 0, errors.Errorf("invalid quantity format: %v", value)
+	}
+	return strconv.ParseUint(string(value), 0, 64)
+}
+
+func DecDataToBytes(value Data) ([]byte, error) {
+	if len(value) <= 2 || value[0:2] != "0x" {
+		return []byte{}, errors.Errorf("invalid data format: %v", value)
+	}
+	return hex.DecodeString(string(value[2:]))
+}
+
+func DecDataToAddress(chainID string, value Data) (loom.Address, error) {
+	local, err := loom.LocalAddressFromHexString(string(value))
+	if err != nil {
+		return loom.Address{}, err
+	}
+	return loom.Address{
+		ChainID: chainID,
+		Local:   local,
+	}, nil
+}
+
+func DecBlockHeight(lastBlockHeight int64, value BlockHeight) (uint64, error) {
+	if lastBlockHeight < 1 {
+		return 0, errors.Errorf("invalid last block height %v", lastBlockHeight)
+	}
+
+	switch value {
+	case "earliest":
+		return 1, nil
+	case "genesis":
+		return 1, nil
+	case "latest":
+		if (lastBlockHeight) > 0 {
+			return uint64(lastBlockHeight), nil
+		} else {
+			return 0, errors.New("no block completed yet")
+		}
+	case "pending":
+		return uint64(lastBlockHeight + 1), nil
+	default:
+		height, err := strconv.ParseUint(string(value), 0, 64)
+		if err != nil {
+			return 0, errors.Wrap(err, "parse block height")
+		}
+		if height > uint64(lastBlockHeight+1) {
+			return 0, errors.Errorf("requested block height %v exceeds pending block height %v", height, lastBlockHeight+1)
+		}
+		if height == 0 {
+			return 0, errors.Errorf("zero block height is not valid")
+		}
+		return height, nil
+	}
+}
+
+func GetEmptyTxObject() JsonTxObject {
+	return JsonTxObject{
+		Hash:             ZeroedData64bytes,
+		Nonce:            ZeroedQuantity,
+		BlockHash:        ZeroedData64bytes,
+		BlockNumber:      ZeroedQuantity,
+		TransactionIndex: ZeroedQuantity,
+		To:               string(ZeroedData32Bytes),
+		From:             string(ZeroedData32Bytes),
+		Gas:              ZeroedQuantity,
+		Value:            ZeroedQuantity,
+		GasPrice:         ZeroedQuantity,
+		Input:            ZeroedData,
+	}
+}
+
+func GetBlockZero() *JsonBlockObject {
+	blockInfo := JsonBlockObject{
+		Number:       ZeroedQuantity,
+		Hash:         "0x0000000000000000000000000000000000000000000000000000000000000001",
+		ParentHash:   ZeroedData32Bytes,
+		Timestamp:    "0x5af97a40", // TODO get the right timestamp, maybe the timestamp for block 0x1
+		GasLimit:     ZeroedQuantity,
+		GasUsed:      ZeroedQuantity,
+		Size:         ZeroedQuantity,
+		Transactions: nil,
+		Nonce:        ZeroedData8Bytes,
+	}
+
+	blockInfo.Transactions = make([]JsonTxObject, 0)
+
+	return &blockInfo
+}

--- a/rpc/blockatlas/jsonrpc_conversion.go
+++ b/rpc/blockatlas/jsonrpc_conversion.go
@@ -31,20 +31,19 @@ const (
 )
 
 type JsonTxObject struct {
-	Hash             Data     `json:"hash,omitempty"`
-	TransactionType  Data     `json:"transactionType,omitempty"`
-	ContractName     string   `json:"contractName,omitempty"`
-	ContractMethod   string   `json:"contractMethod,omitempty"`
-	Nonce            Quantity `json:"nonce,omitempty"`
-	BlockHash        Data     `json:"blockHash,omitempty"`
-	BlockNumber      Quantity `json:"blockNumber,omitempty"`
-	TransactionIndex Quantity `json:"transactionIndex,omitempty"`
-	From             string   `json:"from,omitempty"`
-	To               string   `json:"to"`
-	Value            Quantity `json:"value,omitempty"`
-	GasPrice         Quantity `json:"gasPrice,omitempty"`
-	Gas              Quantity `json:"gas,omitempty"`
-	Input            Data     `json:"input,omitempty"`
+	Hash             Data        `json:"hash,omitempty"`
+	TransactionType  string      `json:"transactionType,omitempty"`
+	ContractName     string      `json:"contractName,omitempty"`
+	ContractMethod   string      `json:"contractMethod,omitempty"`
+	Nonce            Quantity    `json:"nonce,omitempty"`
+	BlockHash        Data        `json:"blockHash,omitempty"`
+	BlockNumber      Quantity    `json:"blockNumber,omitempty"`
+	TransactionIndex Quantity    `json:"transactionIndex,omitempty"`
+	From             string      `json:"from,omitempty"`
+	To               string      `json:"to"`
+	Value            interface{} `json:"value"`
+	GasPrice         Quantity    `json:"gasPrice,omitempty"`
+	Gas              Quantity    `json:"gas,omitempty"`
 }
 
 type JsonBlockObject struct {
@@ -57,7 +56,23 @@ type JsonBlockObject struct {
 	GasLimit         Quantity       `json:"gasLimit,omitempty"`
 	GasUsed          Quantity       `json:"gasUsed,omitempty"`
 	Timestamp        Quantity       `json:"timestamp,omitempty"`
-	Transactions     []JsonTxObject `json:"transactions"` // Data or []Data
+	Transactions     []JsonTxObject `json:"transactions,omitempty"`
+}
+
+type DelegateValue struct {
+	ValidatorAddress Data     `json:"validator_address,omitempty"`
+	Amount           Quantity `json:"amount,omitempty"`
+	LockTimeTier     Quantity `json:"lock_time_tier,omitempty"`
+	Referrer         Data     `json:"referrer,omitempty"`
+}
+
+type ReDelegateValue struct {
+	ValidatorAddress       Data     `json:"validator_address,omitempty"`
+	FormerValidatorAddress Data     `former_validator_address,omitempty`
+	Index                  Quantity `json:"index,omitempty"`
+	Amount                 Quantity `json:"amount,omitempty"`
+	NewLockTimeTier        Quantity `json:"lock_time_tier,omitempty"`
+	Referrer               Data     `json:"referrer,omitempty"`
 }
 
 func EncInt(value int64) Quantity {
@@ -214,11 +229,10 @@ func GetEmptyTxObject() JsonTxObject {
 		Gas:              ZeroedQuantity,
 		Value:            ZeroedQuantity,
 		GasPrice:         ZeroedQuantity,
-		Input:            ZeroedData,
 	}
 }
 
-func GetBlockZero() *JsonBlockObject {
+func GetBlockZero() JsonBlockObject {
 	blockInfo := JsonBlockObject{
 		Number:       ZeroedQuantity,
 		Hash:         "0x0000000000000000000000000000000000000000000000000000000000000001",
@@ -227,11 +241,9 @@ func GetBlockZero() *JsonBlockObject {
 		GasLimit:     ZeroedQuantity,
 		GasUsed:      ZeroedQuantity,
 		Size:         ZeroedQuantity,
-		Transactions: nil,
+		Transactions: make([]JsonTxObject, 0),
 		Nonce:        ZeroedData8Bytes,
 	}
 
-	blockInfo.Transactions = make([]JsonTxObject, 0)
-
-	return &blockInfo
+	return blockInfo
 }

--- a/rpc/blockatlas/jsonrpc_types.go
+++ b/rpc/blockatlas/jsonrpc_types.go
@@ -1,0 +1,70 @@
+package blockatlas
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gorilla/websocket"
+)
+
+type RPCFunc interface {
+	UnmarshalParamsAndCall(JsonRpcRequest, *websocket.Conn) (json.RawMessage, *Error)
+	GetResponse(result json.RawMessage, ID *json.RawMessage) (*JsonRpcResponse, *Error)
+}
+
+type JsonRpcRequest struct {
+	Version string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+	// The request ID can be a string, number, or may be missing entirely.
+	// We just pass it through as is in the response/error without unmarshalling.
+	// Related: https://github.com/ethereum/go-ethereum/issues/295
+	ID *json.RawMessage `json:"id"`
+}
+
+type JsonRpcResponse struct {
+	Result  json.RawMessage  `json:"result"`
+	Version string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id"`
+}
+
+type JsonRpcErrorResponse struct {
+	Version string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id"`
+	Error   Error            `json:"error"`
+}
+
+// Json2 compliant error object
+// https://www.jsonrpc.org/specification#error_object
+type ErrorCode int
+
+const (
+	EcParseError     ErrorCode = -32700 // Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.
+	EcInvalidRequest ErrorCode = -32600 // The JSON sent is not a valid Request object.
+	EcMethodNotFound ErrorCode = -32601 // The method does not exist / is not available.
+	EcInvalidParams  ErrorCode = -32602 // Invalid method parameter(s).
+	EcInternal       ErrorCode = -32603 // Internal JSON-RPC error.
+	EcServer         ErrorCode = -32000 // Reserved for implementation-defined server-errors.
+)
+
+type Error struct {
+	Code    ErrorCode   `json:"code"`    // A Number that indicates the error type that occurred.
+	Message string      `json:"message"` // A String providing a short description of the error. The message SHOULD be limited to a concise single sentence.
+	Data    interface{} `json:"data"`    // A Primitive or Structured value that contains additional information about the error.
+}
+
+func NewError(code ErrorCode, message, data string) *Error {
+	return &Error{
+		Code:    code,
+		Message: message,
+		Data:    data,
+	}
+}
+
+func NewErrorf(code ErrorCode, message, format string, args ...interface{}) *Error {
+	return NewError(code, message, fmt.Sprintf(format, args...))
+}
+
+func (e *Error) Error() string {
+	return e.Message
+}

--- a/rpc/blockatlas/query.go
+++ b/rpc/blockatlas/query.go
@@ -1,0 +1,230 @@
+package blockatlas
+
+import (
+	"fmt"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
+
+	"github.com/loomnetwork/go-loom/auth"
+	cointypes "github.com/loomnetwork/go-loom/builtin/types/coin"
+	dpos3types "github.com/loomnetwork/go-loom/builtin/types/dposv3"
+	gplugin "github.com/loomnetwork/go-loom/plugin"
+	"github.com/loomnetwork/go-loom/vm"
+	"github.com/loomnetwork/loomchain"
+	"github.com/loomnetwork/loomchain/store"
+	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
+)
+
+const (
+	deployId    = uint32(1)
+	callId      = uint32(2)
+	migrationTx = uint32(3)
+)
+
+var (
+	searchBlockSize = uint64(20)
+)
+
+func GetBlockByNumber(
+	blockStore store.BlockStore,
+	state loomchain.ReadOnlyState,
+	height int64,
+	evmAuxStore *evmaux.EvmAuxStore,
+) (resp *JsonBlockObject, err error) {
+
+	if height > state.Block().Height {
+		return resp, errors.New("get block information for pending blocks not implemented yet")
+	}
+
+	var blockResult *ctypes.ResultBlock
+	blockResult, err = blockStore.GetBlockByHeight(&height)
+	if err != nil {
+		return resp, errors.Wrapf(err, "GetBlockByNumber failed to get block %d", height)
+	}
+
+	blockInfo := &JsonBlockObject{
+		Transactions:     nil,
+		Nonce:            ZeroedData8Bytes,
+		TransactionsRoot: ZeroedData32Bytes,
+	}
+
+	// These three fields are null for pending blocks.
+	blockInfo.Hash = EncBytes(blockResult.BlockMeta.BlockID.Hash)
+	blockInfo.Number = EncInt(height)
+
+	var blockResults *ctypes.ResultBlockResults
+
+	// We ignore the error here becuase if the block results can't be loaded for any reason
+	// we'll try to load the data we need from tx_index.db instead.
+	// TODO: Log the error returned by GetBlockResults.
+	blockResults, _ = blockStore.GetBlockResults(&height)
+	for index, tx := range blockResult.Block.Data.Txs {
+		var blockResultBytes []byte
+		if blockResults == nil {
+			// Retrieve tx result from tx_index.db
+			txResult, err := blockStore.GetTxResult(tx.Hash())
+			if err != nil {
+				return resp, errors.Wrapf(err, "cant find tx details, hash %X", tx.Hash())
+			}
+			blockResultBytes = txResult.TxResult.Data
+		} else {
+			blockResultBytes = blockResults.Results.DeliverTx[index].Data
+		}
+
+		txObj, _, err := GetTxObjectFromBlockResult(blockResult, blockResultBytes, int64(index))
+		if err != nil {
+			return resp, errors.Wrapf(err, "cant resolve tx, hash %X", tx.Hash())
+		}
+		blockInfo.Transactions = append(blockInfo.Transactions, txObj)
+	}
+
+	if len(blockInfo.Transactions) == 0 {
+		blockInfo.Transactions = make([]JsonTxObject, 0)
+	}
+	return blockInfo, nil
+}
+
+func GetTxObjectFromBlockResult(
+	blockResult *ctypes.ResultBlock, txResultData []byte, index int64,
+) (JsonTxObject, *Data, error) {
+	tx := blockResult.Block.Data.Txs[index]
+	var contractAddress *Data
+	txObj := JsonTxObject{
+		BlockHash:        EncBytes(blockResult.BlockMeta.BlockID.Hash),
+		BlockNumber:      EncInt(blockResult.Block.Header.Height),
+		TransactionIndex: EncInt(int64(index)),
+		Value:            EncInt(0),
+		GasPrice:         EncInt(0),
+		Gas:              EncInt(0),
+		Hash:             EncBytes(tx.Hash()),
+	}
+
+	var signedTx auth.SignedTx
+	if err := proto.Unmarshal([]byte(tx), &signedTx); err != nil {
+		return GetEmptyTxObject(), nil, err
+	}
+
+	var nonceTx auth.NonceTx
+	if err := proto.Unmarshal(signedTx.Inner, &nonceTx); err != nil {
+		return GetEmptyTxObject(), nil, err
+	}
+	txObj.Nonce = EncInt(int64(nonceTx.Sequence))
+
+	var txTx loomchain.Transaction
+	if err := proto.Unmarshal(nonceTx.Inner, &txTx); err != nil {
+		return GetEmptyTxObject(), nil, err
+	}
+
+	var msg vm.MessageTx
+	if err := proto.Unmarshal(txTx.Data, &msg); err != nil {
+		return GetEmptyTxObject(), nil, err
+	}
+	txObj.From = msg.From.Local.String()
+
+	var input []byte
+	switch txTx.Id {
+	case deployId:
+		{
+			var deployTx vm.DeployTx
+			if err := proto.Unmarshal(msg.Data, &deployTx); err != nil {
+				return GetEmptyTxObject(), nil, err
+			}
+			fmt.Printf("DEPLOY-TX : %+v\n", deployTx)
+			input = deployTx.Code
+			if deployTx.VmType == vm.VMType_EVM {
+				var resp vm.DeployResponse
+				if err := proto.Unmarshal(txResultData, &resp); err != nil {
+					return GetEmptyTxObject(), nil, err
+				}
+				var respData vm.DeployResponseData
+				if err := proto.Unmarshal(resp.Output, &respData); err != nil {
+					return GetEmptyTxObject(), nil, err
+				}
+				contractAddress = EncPtrAddress(resp.Contract)
+				if len(respData.TxHash) > 0 {
+					txObj.Hash = EncBytes(respData.TxHash)
+				}
+			}
+			if deployTx.Value != nil {
+				txObj.Value = EncBigInt(*deployTx.Value.Value.Int)
+			}
+		}
+	case callId:
+		{
+			var callTx vm.CallTx
+			if err := proto.Unmarshal(msg.Data, &callTx); err != nil {
+				return GetEmptyTxObject(), nil, err
+			}
+
+			input = callTx.Input
+			txObj.To = msg.To.Local.String()
+			if callTx.VmType == vm.VMType_EVM && len(txResultData) > 0 {
+				txObj.Hash = EncBytes(txResultData)
+			}
+			if callTx.Value != nil {
+				txObj.Value = EncBigInt(*callTx.Value.Value.Int)
+			}
+
+			var req gplugin.Request
+			if err := proto.Unmarshal(input, &req); err != nil {
+				return GetEmptyTxObject(), nil, err
+			}
+			fmt.Printf("CALL-TX 1: %+v\n", req)
+
+			var methodcall gplugin.ContractMethodCall
+			if err := proto.Unmarshal(req.Body, &methodcall); err != nil {
+				return GetEmptyTxObject(), nil, err
+			}
+			fmt.Printf("CALL-TX 2: %+v\n", methodcall)
+
+			txObj.ContractMethod = methodcall.GetMethod()
+			switch methodcall.GetMethod() {
+			case "Transfer":
+				var transfer cointypes.TransferRequest
+				if err := proto.Unmarshal(methodcall.Args, &transfer); err != nil {
+					return GetEmptyTxObject(), nil, err
+				}
+				fmt.Printf("CALL-TX 3 transfer: %+v\n", transfer)
+			case "Delegate":
+				var delegate dpos3types.DelegateRequest
+				if err := proto.Unmarshal(methodcall.Args, &delegate); err != nil {
+					return GetEmptyTxObject(), nil, err
+				}
+				fmt.Printf("CALL-TX 3 delegate : %+v\n", delegate)
+			case "Redelegate":
+				var redelegate dpos3types.RedelegateRequest
+				if err := proto.Unmarshal(methodcall.Args, &redelegate); err != nil {
+					return GetEmptyTxObject(), nil, err
+				}
+				fmt.Printf("CALL-TX 3 redelegate : %+v\n", redelegate)
+			default:
+				fmt.Printf("Something else %s\n", methodcall.GetMethod())
+			}
+		}
+	case migrationTx:
+		txObj.To = msg.To.Local.String()
+		input = msg.Data
+	default:
+		return GetEmptyTxObject(), nil, fmt.Errorf("unrecognised tx type %v", txTx.Id)
+	}
+	txObj.Input = EncBytes(input)
+
+	return txObj, contractAddress, nil
+}
+
+func GetNumTxBlock(blockStore store.BlockStore, state loomchain.ReadOnlyState, height int64) (uint64, error) {
+	// todo make information about pending block available.
+	// Should be able to get transaction count from receipt object.
+	if height > state.Block().Height {
+		return 0, errors.New("get number of transactions for pending blocks, not implemented yet")
+	}
+
+	var blockResults *ctypes.ResultBlockResults
+	blockResults, err := blockStore.GetBlockResults(&height)
+	if err != nil {
+		return 0, errors.Wrapf(err, "results for block %v", height)
+	}
+	return uint64(len(blockResults.Results.DeliverTx)), nil
+}

--- a/rpc/instrumenting.go
+++ b/rpc/instrumenting.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/loomnetwork/go-loom/plugin/types"
 	"github.com/loomnetwork/loomchain/config"
+	"github.com/loomnetwork/loomchain/rpc/blockatlas"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/vm"
 	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
@@ -567,5 +568,18 @@ func (m InstrumentingMiddleware) EthGetTransactionCount(
 	}(time.Now())
 
 	resp, err = m.next.EthGetTransactionCount(local, block)
+	return
+}
+
+func (m InstrumentingMiddleware) GetBlockTxs(
+	height blockatlas.BlockHeight,
+) (resp *blockatlas.JsonBlockObject, err error) {
+	defer func(begin time.Time) {
+		lvs := []string{"method", "GetBlockTxs", "error", fmt.Sprint(err != nil)}
+		m.requestCount.With(lvs...).Add(1)
+		m.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	resp, err = m.next.GetBlockTxs(height)
 	return
 }

--- a/rpc/instrumenting.go
+++ b/rpc/instrumenting.go
@@ -573,7 +573,7 @@ func (m InstrumentingMiddleware) EthGetTransactionCount(
 
 func (m InstrumentingMiddleware) GetBlockTxs(
 	height blockatlas.BlockHeight,
-) (resp *blockatlas.JsonBlockObject, err error) {
+) (resp blockatlas.JsonBlockObject, err error) {
 	defer func(begin time.Time) {
 		lvs := []string{"method", "GetBlockTxs", "error", fmt.Sprint(err != nil)}
 		m.requestCount.With(lvs...).Add(1)

--- a/rpc/mock_query_server.go
+++ b/rpc/mock_query_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/loomnetwork/go-loom/plugin/types"
 
 	"github.com/loomnetwork/loomchain/config"
+	"github.com/loomnetwork/loomchain/rpc/blockatlas"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/vm"
 )
@@ -367,4 +368,11 @@ func (m *MockQueryService) EvmUnSubscribe(id string) (bool, error) {
 	defer m.mutex.Unlock()
 	m.MethodsCalled = append([]string{"EvmUnSubscribe"}, m.MethodsCalled...)
 	return true, nil
+}
+
+func (m *MockQueryService) GetBlockTxs(height blockatlas.BlockHeight) (*blockatlas.JsonBlockObject, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.MethodsCalled = append([]string{"GetBlockTxs"}, m.MethodsCalled...)
+	return nil, nil
 }

--- a/rpc/mock_query_server.go
+++ b/rpc/mock_query_server.go
@@ -374,5 +374,5 @@ func (m *MockQueryService) GetBlockTxs(height blockatlas.BlockHeight) (*blockatl
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.MethodsCalled = append([]string{"GetBlockTxs"}, m.MethodsCalled...)
-	return nil, nil
+	return &blockatlas.JsonBlockObject{}, nil
 }

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -599,7 +599,7 @@ func (s *QueryServer) GetContractRecord(contractAddrStr string) (*types.Contract
 	return k, nil
 }
 
-func (s *QueryServer) GetBlockTxs(block blockatlas.BlockHeight) (resp *blockatlas.JsonBlockObject, err error) {
+func (s *QueryServer) GetBlockTxs(block blockatlas.BlockHeight) (resp blockatlas.JsonBlockObject, err error) {
 	if block == "0x0" {
 		return blockatlas.GetBlockZero(), nil
 	}
@@ -618,8 +618,11 @@ func (s *QueryServer) GetBlockTxs(block blockatlas.BlockHeight) (resp *blockatla
 	}
 
 	reg := s.CreateRegistry(snapshot)
+
 	for i, tx := range resp.Transactions {
-		fmt.Println(s.ChainID + ":" + tx.To)
+		if tx.TransactionType != blockatlas.TransactionType[blockatlas.CallId] {
+			continue
+		}
 		contractAddr, err := loom.ParseAddress(s.ChainID + ":" + tx.To)
 		if err != nil {
 			return resp, errors.Wrapf(err, "%s", tx.To)
@@ -634,7 +637,7 @@ func (s *QueryServer) GetBlockTxs(block blockatlas.BlockHeight) (resp *blockatla
 	if block == "0x1" && resp.ParentHash == "0x0" {
 		resp.ParentHash = "0x0000000000000000000000000000000000000000000000000000000000000001"
 	}
-
+	fmt.Printf("PASS : %+v", resp)
 	return resp, nil
 }
 

--- a/rpc/query_service.go
+++ b/rpc/query_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/loomnetwork/loomchain/config"
 	"github.com/loomnetwork/loomchain/eth/subs"
 	"github.com/loomnetwork/loomchain/log"
+	"github.com/loomnetwork/loomchain/rpc/blockatlas"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/vm"
 )
@@ -64,6 +65,9 @@ type QueryService interface {
 	ContractEvents(fromBlock uint64, toBlock uint64, contract string) (*types.ContractEventsResult, error)
 
 	GetContractRecord(contractAddr string) (*types.ContractRecordResponse, error)
+
+	//blockatlas
+	GetBlockTxs(height blockatlas.BlockHeight) (*blockatlas.JsonBlockObject, error)
 
 	// deprecated function
 	EvmTxReceipt(txHash []byte) ([]byte, error)
@@ -131,6 +135,8 @@ func MakeQueryServiceHandler(svc QueryService, logger log.TMLogger, bus *QueryEv
 	routes["evmsubscribe"] = rpcserver.NewWSRPCFunc(svc.EvmSubscribe, "method,filter")
 	routes["contractevents"] = rpcserver.NewRPCFunc(svc.ContractEvents, "fromBlock,toBlock,contract")
 	routes["contractrecord"] = rpcserver.NewRPCFunc(svc.GetContractRecord, "contract")
+
+	routes["ba_block_txs"] = rpcserver.NewRPCFunc(svc.GetBlockTxs, "height")
 	rpcserver.RegisterRPCFuncs(wsmux, routes, codec, logger)
 	wm := rpcserver.NewWebsocketManager(routes, codec, rpcserver.EventSubscriber(bus))
 	wsmux.HandleFunc("/queryws", wm.WebsocketHandler)

--- a/rpc/query_service.go
+++ b/rpc/query_service.go
@@ -67,7 +67,7 @@ type QueryService interface {
 	GetContractRecord(contractAddr string) (*types.ContractRecordResponse, error)
 
 	//blockatlas
-	GetBlockTxs(height blockatlas.BlockHeight) (*blockatlas.JsonBlockObject, error)
+	GetBlockTxs(height blockatlas.BlockHeight) (blockatlas.JsonBlockObject, error)
 
 	// deprecated function
 	EvmTxReceipt(txHash []byte) ([]byte, error)
@@ -137,6 +137,7 @@ func MakeQueryServiceHandler(svc QueryService, logger log.TMLogger, bus *QueryEv
 	routes["contractrecord"] = rpcserver.NewRPCFunc(svc.GetContractRecord, "contract")
 
 	routes["ba_block_txs"] = rpcserver.NewRPCFunc(svc.GetBlockTxs, "height")
+
 	rpcserver.RegisterRPCFuncs(wsmux, routes, codec, logger)
 	wm := rpcserver.NewWebsocketManager(routes, codec, rpcserver.EventSubscriber(bus))
 	wsmux.HandleFunc("/queryws", wm.WebsocketHandler)


### PR DESCRIPTION
We need to provide these endpoints to support `blockatlas`

-  query sent/received list of transactions for an account/address
-  query transactions in a block

This PR will add `ba_block_txs` endpoint that can get block information by block height.

ref: https://developer.trustwallet.com/wallet-core/rpc-requirements#for-block-atlas
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request