### PR TITLE
Fix tx hash generation algo

### DIFF
--- a/cmd/loom/config.go
+++ b/cmd/loom/config.go
@@ -233,6 +233,10 @@ func defaultGenesis(cfg *config.Config, validator *loom.Validator) (*config.Gene
 					Status: chainconfig.FeatureWaiting,
 				},
 				&cctypes.Feature{
+					Name:   features.EvmTxReceiptsVersion3_3,
+					Status: chainconfig.FeatureWaiting,
+				},
+				&cctypes.Feature{
 					Name:   features.CoinVersion1_1Feature,
 					Status: chainconfig.FeatureWaiting,
 				},

--- a/e2e/tests/receipts/genesis.json
+++ b/e2e/tests/receipts/genesis.json
@@ -87,6 +87,14 @@
                         "status": "WAITING"
                     },
                     {
+                        "name": "receipts:v3.2",
+                        "status": "WAITING"
+                    },
+                    {
+                        "name": "receipts:v3.3",
+                        "status": "WAITING"
+                    },
+                    {
                         "name": "appstore:v3.1",
                         "status": "WAITING"
                     },

--- a/e2e/tests/truffle/package.json
+++ b/e2e/tests/truffle/package.json
@@ -11,6 +11,7 @@
     "bn.js": "^4.11.8",
     "ethereumjs-tx": "^2.1.1",
     "ethereumjs-wallet": "^0.6.2",
+    "js-sha3": "^0.8.0",
     "loom-js": "1.59.1",
     "loom-truffle-provider": "0.13.0",
     "openzeppelin-solidity": "2.3.0",

--- a/e2e/tests/truffle/test/TxHash.js
+++ b/e2e/tests/truffle/test/TxHash.js
@@ -2,7 +2,7 @@ const Web3 = require('web3')
 const fs = require('fs')
 const path = require('path')
 const EthereumTx = require('ethereumjs-tx').Transaction
-const { loomTxHash } = require('./helpers')
+const { getLoomEvmTxHash } = require('./helpers')
 
 const {
     SpeculativeNonceTxMiddleware, SignedTxMiddleware, Client,
@@ -12,7 +12,7 @@ const {
 const TxHashTestContract = artifacts.require('TxHashTestContract')
 
  contract('TxHashTestContract', async (accounts) => {
-    let contract, from, nodeAddr, txHashTestContract
+    let contract, fromAddr, nodeAddr, txHashTestContract
 
     beforeEach(async () => {
         nodeAddr = fs.readFileSync(path.join(process.env.CLUSTER_DIR, '0', 'node_rpc_addr'), 'utf-8').trim()
@@ -24,7 +24,7 @@ const TxHashTestContract = artifacts.require('TxHashTestContract')
         const publicKey = CryptoUtils.publicKeyFromPrivateKey(privateKey)
 
         fromAddr = LocalAddress.fromPublicKey(publicKey)
-        from = fromAddr.toString()
+        const from = fromAddr.toString()
 
         var client = new Client(chainID, writeUrl, readUrl)
         client.on('error', msg => {
@@ -53,7 +53,7 @@ const TxHashTestContract = artifacts.require('TxHashTestContract')
         }
 
         let tx = new EthereumTx(txParams)
-        let expectedTxHash = loomTxHash(tx, fromAddr)
+        let expectedTxHash = getLoomEvmTxHash(tx, fromAddr)
        
         try {
             var txResult = await contract.methods.set(1111).send()
@@ -72,7 +72,7 @@ const TxHashTestContract = artifacts.require('TxHashTestContract')
         }
 
         tx = new EthereumTx(txParams)
-        expectedTxHash = loomTxHash(tx, fromAddr)
+        expectedTxHash = getLoomEvmTxHash(tx, fromAddr)
         
         try {
             var txResult = await contract.methods.set(2222).send()

--- a/e2e/tests/truffle/test/TxHash.js
+++ b/e2e/tests/truffle/test/TxHash.js
@@ -2,6 +2,7 @@ const Web3 = require('web3')
 const fs = require('fs')
 const path = require('path')
 const EthereumTx = require('ethereumjs-tx').Transaction
+const { loomTxHash } = require('./helpers')
 
 const {
     SpeculativeNonceTxMiddleware, SignedTxMiddleware, Client,
@@ -22,7 +23,8 @@ const TxHashTestContract = artifacts.require('TxHashTestContract')
         const privateKey = CryptoUtils.generatePrivateKey()
         const publicKey = CryptoUtils.publicKeyFromPrivateKey(privateKey)
 
-        from = LocalAddress.fromPublicKey(publicKey).toString()
+        fromAddr = LocalAddress.fromPublicKey(publicKey)
+        from = fromAddr.toString()
 
         var client = new Client(chainID, writeUrl, readUrl)
         client.on('error', msg => {
@@ -51,7 +53,7 @@ const TxHashTestContract = artifacts.require('TxHashTestContract')
         }
 
         let tx = new EthereumTx(txParams)
-        let expectedTxHash = Buffer.from(tx.hash()).toString('hex')
+        let expectedTxHash = loomTxHash(tx, fromAddr)
        
         try {
             var txResult = await contract.methods.set(1111).send()
@@ -70,7 +72,7 @@ const TxHashTestContract = artifacts.require('TxHashTestContract')
         }
 
         tx = new EthereumTx(txParams)
-        expectedTxHash = Buffer.from(tx.hash()).toString('hex')
+        expectedTxHash = loomTxHash(tx, fromAddr)
         
         try {
             var txResult = await contract.methods.set(2222).send()

--- a/e2e/tests/truffle/test/helpers.js
+++ b/e2e/tests/truffle/test/helpers.js
@@ -1,4 +1,5 @@
 const rp = require('request-promise')
+keccak256 = require('js-sha3').keccak256;
 
 async function assertRevert(promise) {
   try {
@@ -88,4 +89,12 @@ async function getLatestBlock(nodeAddr) {
   return currentBlock = Number(res.result.sync_info.latest_block_height)
 }
 
-module.exports = { assertRevert, delay, waitForXBlocks, getNonce, getStorageAt ,getLatestBlock}
+function loomTxHash(tx, fromAddr) {
+  let txHashBytes = Buffer.from(tx.hash())
+  let addrBytes = Buffer.from(fromAddr.bytes)
+  var arr = [txHashBytes, addrBytes];
+  let newTxHashBytes = Buffer.concat(arr)
+  return keccak256(newTxHashBytes).toString('hex')
+}
+
+module.exports = { assertRevert, delay, waitForXBlocks, getNonce, getStorageAt ,getLatestBlock, loomTxHash}

--- a/e2e/tests/truffle/test/helpers.js
+++ b/e2e/tests/truffle/test/helpers.js
@@ -1,5 +1,5 @@
 const rp = require('request-promise')
-keccak256 = require('js-sha3').keccak256;
+const keccak256 = require('js-sha3').keccak256
 
 async function assertRevert(promise) {
   try {
@@ -89,12 +89,19 @@ async function getLatestBlock(nodeAddr) {
   return currentBlock = Number(res.result.sync_info.latest_block_height)
 }
 
-function loomTxHash(tx, fromAddr) {
-  let txHashBytes = Buffer.from(tx.hash())
-  let addrBytes = Buffer.from(fromAddr.bytes)
-  var arr = [txHashBytes, addrBytes];
-  let newTxHashBytes = Buffer.concat(arr)
-  return keccak256(newTxHashBytes).toString('hex')
+/**
+ * Generates a hash for an EVM tx that will be executed by a Loom node.
+ * This hash can be used to lookup the corresponding tx receipt.
+ * @param {EthereumTx} ethTx Unsigned Ethereum transaction.
+ * @param {Web3Address} fromAddr Sender address.
+ */
+function getLoomEvmTxHash(ethTx, fromAddr) {
+  return keccak256(Buffer.concat([
+    Buffer.from(ethTx.hash()),
+    Buffer.from(fromAddr.bytes)
+  ])).toString('hex')
 }
 
-module.exports = { assertRevert, delay, waitForXBlocks, getNonce, getStorageAt ,getLatestBlock, loomTxHash}
+module.exports = {
+  assertRevert, delay, waitForXBlocks, getNonce, getStorageAt, getLatestBlock, getLoomEvmTxHash
+}

--- a/e2e/tests/truffle/yarn.lock
+++ b/e2e/tests/truffle/yarn.lock
@@ -1956,6 +1956,11 @@ js-sha3@^0.3.1:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.3.1.tgz#86122802142f0828502a0d1dee1d95e253bb0243"
   integrity sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM=
 
+js-sha3@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"

--- a/evm/loomevm.go
+++ b/evm/loomevm.go
@@ -3,7 +3,6 @@
 package evm
 
 import (
-	"crypto/sha256"
 	"encoding/json"
 	"math"
 	"math/big"
@@ -12,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	ethvm "github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/loomnetwork/go-loom"
@@ -278,7 +278,7 @@ func (lvm LoomVm) GetStorageAt(addr loom.Address, key []byte) ([]byte, error) {
 }
 
 func loomTxHash(txHash []byte, from loom.Address) []byte {
-	h := sha256.New()
-	h.Write(append(txHash, from.Bytes()...))
+	h := sha3.NewKeccak256()
+	h.Write(append(txHash, from.Local...))
 	return h.Sum(nil)
 }

--- a/features/features.go
+++ b/features/features.go
@@ -58,6 +58,9 @@ const (
 	// Enables switching to an alternative algo for EVM tx hash generation
 	EvmTxReceiptsVersion3_2 = "receipts:v3.2"
 
+	// Enables including sender address for EVM tx hash generation
+	EvmTxReceiptsVersion3_3 = "receipts:v3.3"
+
 	// Enables deployer whitelist middleware that only allows whitelisted accounts to
 	// deploy contracts & run migrations.
 	DeployerWhitelistFeature = "mw:deploy-wl"


### PR DESCRIPTION
Previously, TxHash generation does not include `from` to calculate tx hash. This PR fixes the issue by using `from` address for calculating tx hash.

- [x] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request