### PR TITLE
Check ResponseDeliverTx before dereferencing

### DIFF
--- a/eth/query/block.go
+++ b/eth/query/block.go
@@ -89,7 +89,9 @@ func GetBlockByNumber(
 	for index, tx := range blockResult.Block.Data.Txs {
 		if full {
 			var blockResultBytes []byte
-			if blockResults == nil {
+			if blockResults == nil ||
+				len(blockResults.Results.DeliverTx) <= index ||
+				blockResults.Results.DeliverTx[index] == nil {
 				// Retrieve tx result from tx_index.db
 				txResult, err := blockStore.GetTxResult(tx.Hash())
 				if err != nil {

--- a/eth/query/block.go
+++ b/eth/query/block.go
@@ -92,10 +92,12 @@ func GetBlockByNumber(
 			if blockResults == nil ||
 				len(blockResults.Results.DeliverTx) <= index ||
 				blockResults.Results.DeliverTx[index] == nil {
+				// TODO: Log an error when blockResults != nil, as it's somewhat unusual to have a
+				//       missing DeliverTx response.
 				// Retrieve tx result from tx_index.db
 				txResult, err := blockStore.GetTxResult(tx.Hash())
 				if err != nil {
-					return resp, errors.Wrapf(err, "cant find tx details, hash %X", tx.Hash())
+					return resp, errors.Wrapf(err, "failed to load tx result, hash %X", tx.Hash())
 				}
 				blockResultBytes = txResult.TxResult.Data
 			} else {
@@ -104,7 +106,7 @@ func GetBlockByNumber(
 
 			txObj, _, err := GetTxObjectFromBlockResult(blockResult, blockResultBytes, int64(index))
 			if err != nil {
-				return resp, errors.Wrapf(err, "cant resolve tx, hash %X", tx.Hash())
+				return resp, errors.Wrapf(err, "failed to decode tx, hash %X", tx.Hash())
 			}
 			blockInfo.Transactions = append(blockInfo.Transactions, txObj)
 		} else {


### PR DESCRIPTION
Currently, `ResponseDeliverTx` of some blocks is missing from statestore for some reason. We need to make sure that `ResponseDeliverTx` is not nil before dereferencing it or the node will panic.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request