### PR TITLE
Fix GetBlockByNumber

### DIFF
--- a/eth/query/block.go
+++ b/eth/query/block.go
@@ -110,7 +110,15 @@ func GetBlockByNumber(
 			}
 			blockInfo.Transactions = append(blockInfo.Transactions, txObj)
 		} else {
-			blockInfo.Transactions = append(blockInfo.Transactions, eth.EncBytes(tx.Hash()))
+			txResult, err := blockStore.GetTxResult(tx.Hash())
+			if err != nil {
+				return resp, errors.Wrapf(err, "failed to load tx result, hash %X", tx.Hash())
+			}
+			txObj, _, err := GetTxObjectFromBlockResult(blockResult, txResult.TxResult.Data, int64(index))
+			if err != nil {
+				return resp, errors.Wrapf(err, "failed to decode tx, hash %X", tx.Hash())
+			}
+			blockInfo.Transactions = append(blockInfo.Transactions, txObj.Hash)
 		}
 	}
 

--- a/eth/query/block.go
+++ b/eth/query/block.go
@@ -101,6 +101,8 @@ func GetBlockByNumber(
 			txResultData = blockResults.Results.DeliverTx[index].Data
 		}
 
+		// TODO: When full is false this code ends up doing a bunch of useless encoding, should refactor
+		//       things a bit.
 		txObj, _, err := GetTxObjectFromBlockResult(blockResult, txResultData, int64(index))
 		if err != nil {
 			return resp, errors.Wrapf(err, "failed to decode tx, hash %X", tx.Hash())

--- a/eth/query/block.go
+++ b/eth/query/block.go
@@ -79,45 +79,36 @@ func GetBlockByNumber(
 	blockInfo.Number = eth.EncInt(height)
 	bloomFilter := evmAuxStore.GetBloomFilter(uint64(height))
 	blockInfo.LogsBloom = eth.EncBytes(bloomFilter)
-	var blockResults *ctypes.ResultBlockResults
-	if full {
-		// We ignore the error here becuase if the block results can't be loaded for any reason
-		// we'll try to load the data we need from tx_index.db instead.
-		// TODO: Log the error returned by GetBlockResults.
-		blockResults, _ = blockStore.GetBlockResults(&height)
-	}
-	for index, tx := range blockResult.Block.Data.Txs {
-		if full {
-			var blockResultBytes []byte
-			if blockResults == nil ||
-				len(blockResults.Results.DeliverTx) <= index ||
-				blockResults.Results.DeliverTx[index] == nil {
-				// TODO: Log an error when blockResults != nil, as it's somewhat unusual to have a
-				//       missing DeliverTx response.
-				// Retrieve tx result from tx_index.db
-				txResult, err := blockStore.GetTxResult(tx.Hash())
-				if err != nil {
-					return resp, errors.Wrapf(err, "failed to load tx result, hash %X", tx.Hash())
-				}
-				blockResultBytes = txResult.TxResult.Data
-			} else {
-				blockResultBytes = blockResults.Results.DeliverTx[index].Data
-			}
+	// We ignore the error here because if the block results can't be loaded for any reason
+	// we'll try to load the data we need from tx_index.db instead.
+	// TODO: Log the error returned by GetBlockResults.
+	blockResults, _ := blockStore.GetBlockResults(&height)
 
-			txObj, _, err := GetTxObjectFromBlockResult(blockResult, blockResultBytes, int64(index))
-			if err != nil {
-				return resp, errors.Wrapf(err, "failed to decode tx, hash %X", tx.Hash())
-			}
-			blockInfo.Transactions = append(blockInfo.Transactions, txObj)
-		} else {
+	for index, tx := range blockResult.Block.Data.Txs {
+		var txResultData []byte
+		if blockResults == nil ||
+			len(blockResults.Results.DeliverTx) <= index ||
+			blockResults.Results.DeliverTx[index] == nil {
+			// TODO: Log an error when blockResults != nil, as it's somewhat unusual to have a
+			//       missing DeliverTx response.
+			// Retrieve tx result from tx_index.db
 			txResult, err := blockStore.GetTxResult(tx.Hash())
 			if err != nil {
 				return resp, errors.Wrapf(err, "failed to load tx result, hash %X", tx.Hash())
 			}
-			txObj, _, err := GetTxObjectFromBlockResult(blockResult, txResult.TxResult.Data, int64(index))
-			if err != nil {
-				return resp, errors.Wrapf(err, "failed to decode tx, hash %X", tx.Hash())
-			}
+			txResultData = txResult.TxResult.Data
+		} else {
+			txResultData = blockResults.Results.DeliverTx[index].Data
+		}
+
+		txObj, _, err := GetTxObjectFromBlockResult(blockResult, txResultData, int64(index))
+		if err != nil {
+			return resp, errors.Wrapf(err, "failed to decode tx, hash %X", tx.Hash())
+		}
+
+		if full {
+			blockInfo.Transactions = append(blockInfo.Transactions, txObj)
+		} else {
 			blockInfo.Transactions = append(blockInfo.Transactions, txObj.Hash)
 		}
 	}
@@ -130,14 +121,14 @@ func GetBlockByNumber(
 }
 
 func GetTxObjectFromBlockResult(
-	blockResult *ctypes.ResultBlock, txResultData []byte, index int64,
+	blockResult *ctypes.ResultBlock, txResultData []byte, txIndex int64,
 ) (eth.JsonTxObject, *eth.Data, error) {
-	tx := blockResult.Block.Data.Txs[index]
+	tx := blockResult.Block.Data.Txs[txIndex]
 	var contractAddress *eth.Data
 	txObj := eth.JsonTxObject{
 		BlockHash:        eth.EncBytes(blockResult.BlockMeta.BlockID.Hash),
 		BlockNumber:      eth.EncInt(blockResult.Block.Header.Height),
-		TransactionIndex: eth.EncInt(int64(index)),
+		TransactionIndex: eth.EncInt(int64(txIndex)),
 		Value:            eth.EncInt(0),
 		GasPrice:         eth.EncInt(0),
 		Gas:              eth.EncInt(0),


### PR DESCRIPTION
Previously, `GetBlockByNumber` returns TM tx hash for EVM tx if `full` is `false`. This PR makes it return EVM tx hash for EVM tx.

Ref: https://github.com/loomnetwork/loomchain/issues/1501

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request