### PR TITLE
Fix non-unique EVM Tx hash

### DIFF
--- a/eth/query/block.go
+++ b/eth/query/block.go
@@ -137,7 +137,6 @@ func GetTxObjectFromBlockResult(
 		Hash:             eth.EncBytes(tx.Hash()),
 	}
 
-	var evmTxHash []byte
 	var signedTx auth.SignedTx
 	if err := proto.Unmarshal([]byte(tx), &signedTx); err != nil {
 		return eth.GetEmptyTxObject(), nil, err
@@ -182,7 +181,6 @@ func GetTxObjectFromBlockResult(
 				contractAddress = eth.EncPtrAddress(resp.Contract)
 				if len(respData.TxHash) > 0 {
 					txObj.Hash = eth.EncBytes(respData.TxHash)
-					evmTxHash = respData.TxHash
 				}
 			}
 			if deployTx.Value != nil {
@@ -200,7 +198,6 @@ func GetTxObjectFromBlockResult(
 			txObj.To = &to
 			if callTx.VmType == vm.VMType_EVM && len(txResultData) > 0 {
 				txObj.Hash = eth.EncBytes(txResultData)
-				evmTxHash = txResultData
 			}
 			if callTx.Value != nil {
 				txObj.Value = eth.EncBigInt(*callTx.Value.Value.Int)
@@ -215,6 +212,10 @@ func GetTxObjectFromBlockResult(
 	}
 	txObj.Input = eth.EncBytes(input)
 
+	evmTxHash, err := eth.DecDataToBytes(txObj.Hash)
+	if err != nil {
+		return eth.GetEmptyTxObject(), nil, err
+	}
 	if evmAuxStore.IsDupEVMTxHash(evmTxHash) {
 		txObj.Hash = eth.EncBytes(tx.Hash())
 	}

--- a/eth/query/block.go
+++ b/eth/query/block.go
@@ -181,7 +181,7 @@ func GetTxObjectFromBlockResult(
 				contractAddress = eth.EncPtrAddress(resp.Contract)
 				if len(respData.TxHash) > 0 {
 					// Check duplicate EVM tx hash before using it
-					if evmAuxStore.IsDupEVMTxHash(respData.TxHash) {
+					if !evmAuxStore.IsDupEVMTxHash(respData.TxHash) {
 						txObj.Hash = eth.EncBytes(respData.TxHash)
 					}
 				}
@@ -201,7 +201,7 @@ func GetTxObjectFromBlockResult(
 			txObj.To = &to
 			if callTx.VmType == vm.VMType_EVM && len(txResultData) > 0 {
 				// Check duplicate EVM tx hash before using it
-				if evmAuxStore.IsDupEVMTxHash(txResultData) {
+				if !evmAuxStore.IsDupEVMTxHash(txResultData) {
 					txObj.Hash = eth.EncBytes(txResultData)
 				}
 			}

--- a/eth/query/noevm.go
+++ b/eth/query/noevm.go
@@ -20,7 +20,7 @@ func GetBlockByNumber(_ store.BlockStore, _ loomchain.ReadOnlyState, _ int64, _ 
 	return eth.JsonBlockObject{}, nil
 }
 
-func GetTxObjectFromBlockResult(_ *ctypes.ResultBlock, _ []byte, _ int64) (eth.JsonTxObject, *eth.Data, error) {
+func GetTxObjectFromBlockResult(_ *ctypes.ResultBlock, _ []byte, _ int64, _ *evmaux.EvmAuxStore) (eth.JsonTxObject, *eth.Data, error) {
 	return eth.JsonTxObject{}, nil, nil
 }
 
@@ -52,7 +52,7 @@ func GetTxByHash(_ loomchain.ReadOnlyState, _ store.BlockStore, _ []byte, _ loom
 	return eth.JsonTxObject{}, nil
 }
 
-func GetTxByBlockAndIndex(_ store.BlockStore, _, _ uint64) (txObj eth.JsonTxObject, err error) {
+func GetTxByBlockAndIndex(_ store.BlockStore, _, _ uint64, _ *evmaux.EvmAuxStore) (txObj eth.JsonTxObject, err error) {
 	return eth.JsonTxObject{}, nil
 }
 

--- a/eth/query/query_test.go
+++ b/eth/query/query_test.go
@@ -244,7 +244,7 @@ func TestDupEvmTxHash(t *testing.T) {
 	deployTx, err := proto.Marshal(&vm.DeployTx{
 		VmType: vm.VMType_EVM,
 	})
-	callTx, err := proto.Marshal(&vm.DeployTx{
+	callTx, err := proto.Marshal(&vm.CallTx{
 		VmType: vm.VMType_EVM,
 	})
 
@@ -294,11 +294,13 @@ func TestDupEvmTxHash(t *testing.T) {
 	txObj, _, err := GetTxObjectFromBlockResult(blockResultDeployTx, txResultData1, int64(0), evmAuxStore)
 	require.NoError(t, err)
 	require.NotEqual(t, string(txObj.Hash), string(eth.EncBytes(txHash1)))
+	require.Equal(t, string(txObj.Hash), string(eth.EncBytes(ttypes.Tx(signedDeployTxBytes).Hash())))
 
-	// txhash3 is dup, so the returned hash must not be equal
+	// txhash2 is dup, so the returned hash must not be equal
 	txObj, _, err = GetTxObjectFromBlockResult(blockResultCallTx, txResultData2, int64(0), evmAuxStore)
 	require.NoError(t, err)
 	require.NotEqual(t, string(txObj.Hash), string(eth.EncBytes(txHash2)))
+	require.Equal(t, string(txObj.Hash), string(eth.EncBytes(ttypes.Tx(signedCallTxBytes).Hash())))
 
 	// txhash3 is unique, so the returned hash must be equal
 	txObj, _, err = GetTxObjectFromBlockResult(blockResultDeployTx, txResultData3, int64(0), evmAuxStore)

--- a/eth/query/query_test.go
+++ b/eth/query/query_test.go
@@ -234,10 +234,10 @@ func TestGetLogs(t *testing.T) {
 
 func TestDupEvmTxHash(t *testing.T) {
 	blockTxHash := getRandomTxHash()
-	txHash1 := getRandomTxHash()
-	txHash2 := getRandomTxHash()
-	txHash3 := getRandomTxHash()
-	txHash4 := getRandomTxHash()
+	txHash1 := getRandomTxHash() // DeployEVMTx that has dup EVM Tx Hash
+	txHash2 := getRandomTxHash() // CallEVMTx that has dup EVM Tx Hash
+	txHash3 := getRandomTxHash() // DeploEVMTx that has unique EVM Tx Hash
+	txHash4 := getRandomTxHash() // CallEVMTx that has unique EVM Tx Hash
 	from := loom.MustParseAddress("default:0x7262d4c97c7B93937E4810D289b7320e9dA82857")
 	to := loom.MustParseAddress("default:0x7262d4c97c7B93937E4810D289b7320e9dA82857")
 
@@ -290,22 +290,22 @@ func TestDupEvmTxHash(t *testing.T) {
 	txResultData3 := mockDeployResponse(txHash3)
 	txResultData4 := txHash4
 
-	// EVM txhash1 is dup, so the return hash must not be equal
+	// txhash1 is dup, so the returned hash must not be equal
 	txObj, _, err := GetTxObjectFromBlockResult(blockResultDeployTx, txResultData1, int64(0), evmAuxStore)
 	require.NoError(t, err)
 	require.NotEqual(t, string(txObj.Hash), string(eth.EncBytes(txHash1)))
 
-	// EVM txhash3 is dup, so the return hash must not be equal
+	// txhash3 is dup, so the returned hash must not be equal
 	txObj, _, err = GetTxObjectFromBlockResult(blockResultCallTx, txResultData2, int64(0), evmAuxStore)
 	require.NoError(t, err)
 	require.NotEqual(t, string(txObj.Hash), string(eth.EncBytes(txHash2)))
 
-	// EVM txhash3 is unique, so the return hash must be equal
+	// txhash3 is unique, so the returned hash must be equal
 	txObj, _, err = GetTxObjectFromBlockResult(blockResultDeployTx, txResultData3, int64(0), evmAuxStore)
 	require.NoError(t, err)
 	require.Equal(t, string(txObj.Hash), string(eth.EncBytes(txHash3)))
 
-	// EVM txhash4 is unique, so the return hash must be equal
+	// txhash4 is unique, so the returned hash must be equal
 	txObj, _, err = GetTxObjectFromBlockResult(blockResultCallTx, txResultData4, int64(0), evmAuxStore)
 	require.NoError(t, err)
 	require.Equal(t, string(txObj.Hash), string(eth.EncBytes(txHash4)))

--- a/eth/query/query_test.go
+++ b/eth/query/query_test.go
@@ -4,23 +4,29 @@ package query
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
 	"testing"
 
 	"github.com/loomnetwork/loomchain/events"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/store"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 
 	"github.com/loomnetwork/loomchain/receipts/common"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/loomnetwork/go-loom"
+	"github.com/loomnetwork/go-loom/auth"
 	"github.com/loomnetwork/go-loom/plugin/types"
 	types1 "github.com/loomnetwork/go-loom/types"
+	"github.com/loomnetwork/go-loom/vm"
 	"github.com/loomnetwork/loomchain"
 	"github.com/loomnetwork/loomchain/eth/bloom"
 	"github.com/loomnetwork/loomchain/eth/utils"
 	"github.com/loomnetwork/loomchain/receipts/handler"
 	"github.com/stretchr/testify/require"
+	ttypes "github.com/tendermint/tendermint/types"
 )
 
 const (
@@ -33,10 +39,6 @@ var (
 )
 
 func TestQueryChain(t *testing.T) {
-	testQueryChain(t, handler.ReceiptHandlerLevelDb)
-}
-
-func testQueryChain(t *testing.T, v handler.ReceiptHandlerVersion) {
 	evmAuxStore, err := common.NewMockEvmAuxStore()
 	require.NoError(t, err)
 	eventDispatcher := events.NewLogEventDispatcher()
@@ -167,10 +169,6 @@ func TestMatchFilters(t *testing.T) {
 }
 
 func TestGetLogs(t *testing.T) {
-	testGetLogs(t, handler.ReceiptHandlerLevelDb)
-}
-
-func testGetLogs(t *testing.T, v handler.ReceiptHandlerVersion) {
 	evmAuxStore, err := common.NewMockEvmAuxStore()
 	require.NoError(t, err)
 
@@ -232,4 +230,148 @@ func testGetLogs(t *testing.T, v handler.ReceiptHandlerVersion) {
 	require.True(t, 0 == bytes.Compare(logs[0].Topics[0], []byte(testEvents[0].Topics[0])))
 
 	require.NoError(t, receiptHandler.Close())
+}
+
+func TestDupEvmTxHash(t *testing.T) {
+	blockTxHash := getRandomTxHash()
+	txHash1 := getRandomTxHash()
+	txHash2 := getRandomTxHash()
+	txHash3 := getRandomTxHash()
+	txHash4 := getRandomTxHash()
+	from := loom.MustParseAddress("default:0x7262d4c97c7B93937E4810D289b7320e9dA82857")
+	to := loom.MustParseAddress("default:0x7262d4c97c7B93937E4810D289b7320e9dA82857")
+
+	deployTx, err := proto.Marshal(&vm.DeployTx{
+		VmType: vm.VMType_EVM,
+	})
+	callTx, err := proto.Marshal(&vm.DeployTx{
+		VmType: vm.VMType_EVM,
+	})
+
+	signedDeployTxBytes := mockSignedTx(t, deployId, to, from, deployTx)
+	signedCallTxBytes := mockSignedTx(t, callId, to, from, callTx)
+
+	blockResultDeployTx := &ctypes.ResultBlock{
+		BlockMeta: &ttypes.BlockMeta{
+			BlockID: ttypes.BlockID{
+				Hash: blockTxHash,
+			},
+		},
+		Block: &ttypes.Block{
+			Data: ttypes.Data{
+				Txs: ttypes.Txs{signedDeployTxBytes},
+			},
+		},
+	}
+
+	blockResultCallTx := &ctypes.ResultBlock{
+		BlockMeta: &ttypes.BlockMeta{
+			BlockID: ttypes.BlockID{
+				Hash: blockTxHash,
+			},
+		},
+		Block: &ttypes.Block{
+			Data: ttypes.Data{
+				Txs: ttypes.Txs{signedCallTxBytes},
+			},
+		},
+	}
+
+	evmAuxStore, err := common.NewMockEvmAuxStore()
+	require.NoError(t, err)
+
+	dupEVMTxHashes := make(map[string]bool)
+	dupEVMTxHashes[string(txHash1)] = true
+	dupEVMTxHashes[string(txHash2)] = true
+	evmAuxStore.SetDupEVMTxHashes(dupEVMTxHashes)
+
+	txResultData1 := mockDeployResponse(txHash1)
+	txResultData2 := txHash2
+	txResultData3 := mockDeployResponse(txHash3)
+	txResultData4 := txHash4
+
+	// EVM txhash1 is dup, so the return hash must not be equal
+	txObj, _, err := GetTxObjectFromBlockResult(blockResultDeployTx, txResultData1, int64(0), evmAuxStore)
+	require.NoError(t, err)
+	require.NotEqual(t, string(txObj.Hash), string(eth.EncBytes(txHash1)))
+
+	// EVM txhash3 is dup, so the return hash must not be equal
+	txObj, _, err = GetTxObjectFromBlockResult(blockResultCallTx, txResultData2, int64(0), evmAuxStore)
+	require.NoError(t, err)
+	require.NotEqual(t, string(txObj.Hash), string(eth.EncBytes(txHash2)))
+
+	// EVM txhash3 is unique, so the return hash must be equal
+	txObj, _, err = GetTxObjectFromBlockResult(blockResultDeployTx, txResultData3, int64(0), evmAuxStore)
+	require.NoError(t, err)
+	require.Equal(t, string(txObj.Hash), string(eth.EncBytes(txHash3)))
+
+	// EVM txhash4 is unique, so the return hash must be equal
+	txObj, _, err = GetTxObjectFromBlockResult(blockResultCallTx, txResultData4, int64(0), evmAuxStore)
+	require.NoError(t, err)
+	require.Equal(t, string(txObj.Hash), string(eth.EncBytes(txHash4)))
+}
+
+func mockSignedTx(t *testing.T, id uint32, to loom.Address, from loom.Address, data []byte) []byte {
+	var mgsData []byte
+	var err error
+	if id == deployId {
+		mgsData, err = proto.Marshal(&vm.DeployTx{
+			VmType: vm.VMType_EVM,
+		})
+		require.NoError(t, err)
+	} else if id == callId {
+		mgsData, err = proto.Marshal(&vm.CallTx{
+			VmType: vm.VMType_EVM,
+		})
+		require.NoError(t, err)
+	}
+
+	messageTx, err := proto.Marshal(&vm.MessageTx{
+		To:   to.MarshalPB(),
+		From: from.MarshalPB(),
+		Data: mgsData,
+	})
+	require.NoError(t, err)
+
+	txTx, err := proto.Marshal(&loomchain.Transaction{
+		Data: messageTx,
+		Id:   id,
+	})
+	require.NoError(t, err)
+
+	nonceTx, err := proto.Marshal(&auth.NonceTx{
+		Sequence: 1,
+		Inner:    txTx,
+	})
+	require.NoError(t, err)
+
+	signedTx, err := proto.Marshal(&auth.SignedTx{
+		Inner: nonceTx,
+	})
+
+	return signedTx
+}
+
+func mockDeployResponse(txHash []byte) []byte {
+	deployResponseData, err := proto.Marshal(&vm.DeployResponseData{
+		TxHash: txHash,
+	})
+	if err != nil {
+		panic(err)
+	}
+	deployResponse, err := proto.Marshal(&vm.DeployResponse{
+		Output: deployResponseData,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return deployResponse
+}
+
+func getRandomTxHash() []byte {
+	token := make([]byte, 32)
+	rand.Read(token)
+	h := sha256.New()
+	h.Write(token)
+	return h.Sum(nil)
 }

--- a/eth/query/tx.go
+++ b/eth/query/tx.go
@@ -13,17 +13,26 @@ import (
 	"github.com/loomnetwork/loomchain/auth"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/store"
+	evmaux "github.com/loomnetwork/loomchain/store/evm_aux"
 )
 
-func GetTxByHash(state loomchain.ReadOnlyState, blockStore store.BlockStore, txHash []byte, readReceipts loomchain.ReadReceiptHandler) (eth.JsonTxObject, error) {
+func GetTxByHash(
+	state loomchain.ReadOnlyState, blockStore store.BlockStore, txHash []byte,
+	readReceipts loomchain.ReadReceiptHandler, evmAuxStore *evmaux.EvmAuxStore,
+) (eth.JsonTxObject, error) {
 	txReceipt, err := readReceipts.GetReceipt(txHash)
 	if err != nil {
 		return eth.GetEmptyTxObject(), errors.Wrap(err, "reading receipt")
 	}
-	return GetTxByBlockAndIndex(blockStore, uint64(txReceipt.BlockNumber), uint64(txReceipt.TransactionIndex))
+	return GetTxByBlockAndIndex(
+		blockStore, uint64(txReceipt.BlockNumber),
+		uint64(txReceipt.TransactionIndex), evmAuxStore,
+	)
 }
 
-func GetTxByBlockAndIndex(blockStore store.BlockStore, height, index uint64) (eth.JsonTxObject, error) {
+func GetTxByBlockAndIndex(
+	blockStore store.BlockStore, height, index uint64, evmAuxStore *evmaux.EvmAuxStore,
+) (eth.JsonTxObject, error) {
 	iHeight := int64(height)
 
 	blockResult, err := blockStore.GetBlockByHeight(&iHeight)
@@ -40,7 +49,7 @@ func GetTxByBlockAndIndex(blockStore store.BlockStore, height, index uint64) (et
 		return eth.GetEmptyTxObject(), errors.Wrapf(err, "failed to find result of tx %X", blockResult.Block.Data.Txs[index].Hash())
 	}
 
-	txObj, _, err := GetTxObjectFromBlockResult(blockResult, txResult.TxResult.Data, int64(index))
+	txObj, _, err := GetTxObjectFromBlockResult(blockResult, txResult.TxResult.Data, int64(index), evmAuxStore)
 	if err != nil {
 		return eth.GetEmptyTxObject(), err
 	}

--- a/receipts/common/test_helper.go
+++ b/receipts/common/test_helper.go
@@ -76,6 +76,6 @@ func NewMockEvmAuxStore() (*evmaux.EvmAuxStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	evmAuxStore := evmaux.NewEvmAuxStore(evmAuxDB, nil)
+	evmAuxStore := evmaux.NewEvmAuxStore(evmAuxDB)
 	return evmAuxStore, nil
 }

--- a/receipts/common/test_helper.go
+++ b/receipts/common/test_helper.go
@@ -76,6 +76,6 @@ func NewMockEvmAuxStore() (*evmaux.EvmAuxStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	evmAuxStore := evmaux.NewEvmAuxStore(evmAuxDB)
+	evmAuxStore := evmaux.NewEvmAuxStore(evmAuxDB, nil)
 	return evmAuxStore, nil
 }

--- a/store/evm_aux/store.go
+++ b/store/evm_aux/store.go
@@ -92,6 +92,10 @@ func (s *EvmAuxStore) SetDupEVMTxHashes(dupEVMTxHashes map[string]bool) {
 	s.dupEVMTxHashes = dupEVMTxHashes
 }
 
+func (s *EvmAuxStore) GetDupEVMTxHashes() map[string]bool {
+	return s.dupEVMTxHashes
+}
+
 func (s *EvmAuxStore) GetBloomFilter(height uint64) []byte {
 	filter, err := s.db.Get(bloomFilterKey(height), nil)
 	if err != nil && err != leveldb.ErrNotFound {

--- a/store/evm_aux/store.go
+++ b/store/evm_aux/store.go
@@ -113,10 +113,8 @@ func (s *EvmAuxStore) SetBloomFilter(tran *leveldb.Transaction, filter []byte, h
 }
 
 func (s *EvmAuxStore) IsDupEVMTxHash(txHash []byte) bool {
-	if _, ok := s.dupEVMTxHashes[string(txHash)]; ok {
-		return true
-	}
-	return false
+	_, ok := s.dupEVMTxHashes[string(txHash)]
+	return ok
 }
 
 func (s *EvmAuxStore) SetTxHashList(tran *leveldb.Transaction, txHashList [][]byte, height uint64) error {

--- a/store/evm_aux/store.go
+++ b/store/evm_aux/store.go
@@ -57,7 +57,7 @@ func LoadStore() (*EvmAuxStore, error) {
 	for iter.Next() {
 		dupTxHash, err := util.UnprefixKey(iter.Key(), dupTxHashPrefix)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 		dupEVMTxHashes[string(dupTxHash)] = true
 	}

--- a/store/evm_aux/store_test.go
+++ b/store/evm_aux/store_test.go
@@ -12,19 +12,28 @@ func TestLoadDupEvmTxHashes(t *testing.T) {
 
 	// load to set dup tx hashes
 	evmAuxStore, err := LoadStore()
-	defer evmAuxStore.ClearData()
+
 	require.NoError(t, err)
+	// add dup EVM txhash keys prefixed with dtx
 	for i := 0; i < 100; i++ {
 		evmAuxStore.db.Put(dupTxHashKey([]byte(fmt.Sprintf("hash:%d", i))), []byte{1}, nil)
 	}
+	// add 100 keys prefixed with hash
 	for i := 0; i < 100; i++ {
 		evmAuxStore.db.Put([]byte(fmt.Sprintf("hash:%d", i)), []byte{1}, nil)
 	}
+	// add another 100 keys prefixed with ahash
+	for i := 0; i < 100; i++ {
+		evmAuxStore.db.Put([]byte(fmt.Sprintf("ahash:%d", i)), []byte{1}, nil)
+	}
+	require.NoError(t, evmAuxStore.Close())
 
 	evmAuxStore2, err := LoadStore()
-	defer evmAuxStore2.ClearData()
+	require.NoError(t, err)
 	dupEvmTxHashes := evmAuxStore2.GetDupEVMTxHashes()
 	require.Equal(t, 100, len(dupEvmTxHashes))
+	evmAuxStore2.Close()
+	evmAuxStore2.ClearData()
 }
 
 func TestTxHashOperation(t *testing.T) {

--- a/store/evm_aux/store_test.go
+++ b/store/evm_aux/store_test.go
@@ -2,10 +2,30 @@ package evmaux
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoadDupEvmTxHashes(t *testing.T) {
+
+	// load to set dup tx hashes
+	evmAuxStore, err := LoadStore()
+	defer evmAuxStore.ClearData()
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		evmAuxStore.db.Put(dupTxHashKey([]byte(fmt.Sprintf("hash:%d", i))), []byte{1}, nil)
+	}
+	for i := 0; i < 100; i++ {
+		evmAuxStore.db.Put([]byte(fmt.Sprintf("hash:%d", i)), []byte{1}, nil)
+	}
+
+	evmAuxStore2, err := LoadStore()
+	defer evmAuxStore2.ClearData()
+	dupEvmTxHashes := evmAuxStore2.GetDupEVMTxHashes()
+	require.Equal(t, 100, len(dupEvmTxHashes))
+}
 
 func TestTxHashOperation(t *testing.T) {
 	txHashList1 := [][]byte{


### PR DESCRIPTION
Currently, there are some non-unique Tx hashes on test clusters due to new Tx hash generation algorithm. So we should not use EVM Tx hash generated for these Txs. This PR replaces non-unique EVM Tx hash with TM Tx hash before responding to queries.

- [x] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request