### PR TITLE
Add some notes about how the receipts feature flags interact

### DIFF
--- a/cmd/loom/config.go
+++ b/cmd/loom/config.go
@@ -221,10 +221,6 @@ func defaultGenesis(cfg *config.Config, validator *loom.Validator) (*config.Gene
 					Status: chainconfig.FeatureWaiting,
 				},
 				&cctypes.Feature{
-					Name:   features.EvmTxReceiptsVersion3,
-					Status: chainconfig.FeatureWaiting,
-				},
-				&cctypes.Feature{
 					Name:   features.EvmTxReceiptsVersion3_4,
 					Status: chainconfig.FeatureWaiting,
 				},

--- a/features/features.go
+++ b/features/features.go
@@ -49,16 +49,20 @@ const (
 	// Enables EVM tx receipts storage in separate DB.
 	EvmTxReceiptsVersion2Feature = "receipts:v2"
 
-	// Enables saving of EVM tx receipts for EVM calls made from Go contracts
+	// Enables saving of EVM tx receipts for EVM calls made from Go contracts.
+	// NOTE: This flag will have no effect once EvmTxReceiptsVersion3_1 is activated.
 	EvmTxReceiptsVersion3 = "receipts:v3"
 
 	// Enables saving of EVM tx receipts for failed EVM calls
+	// NOTE: On new clusters this flag should only be activated after EvmTxReceiptsVersion3_4.
 	EvmTxReceiptsVersion3_1 = "receipts:v3.1"
 
 	// Enables switching to an alternative algo for EVM tx hash generation
+	// NOTE: This flag will have no effect once EvmTxReceiptsVersion3_4 is activated.
 	EvmTxReceiptsVersion3_2 = "receipts:v3.2"
 
 	// Fixes the alternative EVM tx hash generation introduced in v3.2
+	// NOTE: This flag will have no effect once EvmTxReceiptsVersion3_4 is activated.
 	EvmTxReceiptsVersion3_3 = "receipts:v3.3"
 
 	// Reverts back to the original EVM tx hash generation (prior to v3.2 & v3.3)


### PR DESCRIPTION
Also generate the default genesis with `receipts:v3` disabled since it has been superseded by `receipts:v3.1`