### PR TITLE
Fix tx hashes mismatch

### DIFF
--- a/eth/query/eth.go
+++ b/eth/query/eth.go
@@ -74,7 +74,7 @@ func GetBlockLogRange(
 	eventLogs := []*ptypes.EthFilterLog{}
 
 	for height := from; height <= to; height++ {
-		blockLogs, err := GetBlockLogs(blockStore, state, ethFilter, height, readReceipts, evmAuxStore)
+		blockLogs, err := getBlockLogs(blockStore, state, ethFilter, height, readReceipts, evmAuxStore)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +83,7 @@ func GetBlockLogRange(
 	return eventLogs, nil
 }
 
-func GetBlockLogs(
+func getBlockLogs(
 	blockStore store.BlockStore,
 	state loomchain.ReadOnlyState,
 	ethFilter eth.EthBlockFilter,

--- a/receipts/handler/handler.go
+++ b/receipts/handler/handler.go
@@ -53,6 +53,7 @@ func NewReceiptHandler(
 // The tx hash can either be the hash of the Tendermint tx within which the EVM tx was embedded or,
 // the hash of the embedded EVM tx itself.
 func (r *ReceiptHandler) GetReceipt(txHash []byte) (types.EvmTxReceipt, error) {
+	requestedTxHash := txHash
 	// At first assume the input hash is a Tendermint tx hash and try to resolve it to an EVM tx hash,
 	// if that fails it might be an EVM tx hash.
 	evmTxHash, err := r.evmAuxStore.GetChildTxHash(txHash)
@@ -64,6 +65,12 @@ func (r *ReceiptHandler) GetReceipt(txHash []byte) (types.EvmTxReceipt, error) {
 	if err != nil {
 		return receipt, errors.Wrapf(common.ErrTxReceiptNotFound, "GetReceipt: %v", err)
 	}
+	// Tx hash on receipt has to match the requested tx hash
+	receipt.TxHash = requestedTxHash
+	for _, eventLog := range receipt.Logs {
+		eventLog.TxHash = requestedTxHash
+	}
+
 	return receipt, nil
 }
 

--- a/rpc/eth/jsonrpc_conversion.go
+++ b/rpc/eth/jsonrpc_conversion.go
@@ -171,6 +171,7 @@ func EncEvent(log types.EventData) JsonLog {
 		data = EncBytes(log.EncodedBody)
 	}
 
+	// TODO: Copy log.BlockTime
 	jLog := JsonLog{
 		TransactionHash:  EncBytes(log.TxHash),
 		BlockNumber:      EncUint(log.BlockHeight),


### PR DESCRIPTION
Since we introduce child-tx-ref to map TM tx hash with EVM tx hash, receipts can be queried using both TM tx hash and EVM tx hash. However, Blockscout has a problem when the tx hash on receipt does not match the one it queries. This happens when it use TM tx hash to query a receipt. This PR fixes the problem by override the tx hash on receipt with the requested tx hash.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request