### PR TITLE
Add flag to show all validators on chainconfig command

### DIFF
--- a/cmd/loom/chainconfig/cmd.go
+++ b/cmd/loom/chainconfig/cmd.go
@@ -540,16 +540,16 @@ func ListValidatorsInfoCmd() *cobra.Command {
 				return err
 			}
 
-			var rawJson json.RawMessage
+			var rawJSON json.RawMessage
 			rpcclient := client.NewJSONRPCClient(flags.URI + "/rpc")
-			err = rpcclient.Call("validators", map[string]interface{}{}, "11", &rawJson)
+			err = rpcclient.Call("validators", map[string]interface{}{}, "11", &rawJSON)
 			if err != nil {
 				return err
 			}
 			cdc := amino.NewCodec()
 			coretypes.RegisterAmino(cdc)
 			var rpcResult coretypes.ResultValidators
-			if err := cdc.UnmarshalJSON(rawJson, &rpcResult); err != nil {
+			if err := cdc.UnmarshalJSON(rawJSON, &rpcResult); err != nil {
 				return err
 			}
 			activeValidatorList := make(map[string]bool, len(rpcResult.Validators))
@@ -654,9 +654,3 @@ type ByBuild []cctype.ValidatorInfo
 func (a ByBuild) Len() int           { return len(a) }
 func (a ByBuild) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a ByBuild) Less(i, j int) bool { return a[i].BuildNumber < a[j].BuildNumber }
-
-func getDAppChainClient(callFlags *cli.ContractCallFlags) *client.DAppChainRPCClient {
-	writeURI := callFlags.URI + "/rpc"
-	readURI := callFlags.URI + "/query"
-	return client.NewDAppChainRPCClient(callFlags.ChainID, writeURI, readURI)
-}

--- a/cmd/loom/gateway/mapping_cmds.go
+++ b/cmd/loom/gateway/mapping_cmds.go
@@ -480,7 +480,7 @@ func newListContractMappingsCommand() *cobra.Command {
 	}
 	cmdFlags := cmd.Flags()
 	cmdFlags.StringVar(&gatewayType, "gateway", "gateway", "Gateway name: gateway, loomcoin-gateway, or tron-gateway")
-	cmdFlags.BoolVar(&formatRaw, "raw", false, "Ouput raw JSON")
+	cmdFlags.BoolVar(&formatRaw, "raw", false, "Output raw JSON")
 	cmdFlags.BoolVar(&formatJson, "json", false, "Output prettified JSON")
 	return cmd
 }

--- a/e2e/engine/cmd.go
+++ b/e2e/engine/cmd.go
@@ -435,7 +435,7 @@ func checkConditions(e *engineCmd, n lib.TestCase, out []byte) error {
 			}
 		}
 	case "excludes":
-		var excludeds []string
+		var excludes []string
 		for _, excluded := range n.Excluded {
 			t, err := template.New("excluded").Parse(excluded)
 			if err != nil {
@@ -446,10 +446,10 @@ func checkConditions(e *engineCmd, n lib.TestCase, out []byte) error {
 			if err != nil {
 				return err
 			}
-			excludeds = append(excludeds, buf.String())
+			excludes = append(excludes, buf.String())
 		}
 
-		for _, excluded := range excludeds {
+		for _, excluded := range excludes {
 			if strings.Contains(string(out), excluded) {
 				return fmt.Errorf("❌ expect output to exclude '%s' got '%s'", excluded, string(out))
 			}


### PR DESCRIPTION
Previously, `chain-cfg list-validators` command always shows all validators included the inactive one.
This pull request will show the current active validator only. 
Using `--all` flag to display the inactive validators.

ref : https://github.com/loomnetwork/loomchain/issues/1528
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request