### PR TITLE
[WIP] Upgrade addressmapper contract to support multi-chain mapping

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -23,6 +23,9 @@ const (
 	// Enables support for mapping DAppChain accounts to Binance accounts
 	AddressMapperVersion1_1 = "addrmapper:v1.1"
 
+	// Enables multi-chain mappings
+	AddressMapperVersion1_2 = "addrmapper:v1.2"
+
 	// Enables processing of txs via MultiChainSignatureTxMiddleware, there's a feature flag per
 	// allowed chain ID, e.g. auth:sigtx:default, auth:sigtx:eth
 	AuthSigTxFeaturePrefix = "auth:sigtx:"


### PR DESCRIPTION
Requirement : 
- [ ] DAppChain account can be mapped to multiple foreign accounts on the same foreign chain.
- [ ] DAppChain account can be mapped to foreign accounts on multiple foreign chains.
- [ ] Remove mapped address.
- [ ] Add chainID and nonce to the hash that's signed to prove account ownership.
- [ ] Migration ?

In order to support multichain address mapper, We will need to add more complex to the key of key-value store.
`prefixKey : byteAddress : TargetchainID : sequence --> address mapping protobuf (from,to)`


ref : https://github.com/loomnetwork/loomchain/issues/1101
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request