### PR TITLE
Make LoomEthFilter support array of addreses

### DIFF
--- a/eth/utils/utils.go
+++ b/eth/utils/utils.go
@@ -21,7 +21,7 @@ func UnmarshalEthFilter(query []byte) (eth.EthFilter, error) {
 	var filter struct {
 		FromBlock string        `json:"fromBlock"`
 		ToBlock   string        `json:"toBlock"`
-		Address   string        `json:"address"`
+		Addresses []string      `json:"address"`
 		Topics    []interface{} `json:"topics"`
 	}
 	json.Unmarshal(query, &filter)
@@ -31,13 +31,16 @@ func UnmarshalEthFilter(query []byte) (eth.EthFilter, error) {
 		ToBlock:   eth.BlockHeight(filter.ToBlock),
 	}
 
-	if len(filter.Address) > 0 {
-		address, err := loom.LocalAddressFromHexString(filter.Address)
-		if err != nil {
-			return eth.EthFilter{}, fmt.Errorf("invalid ethfilter, address")
+	for _, address := range filter.Addresses {
+		if len(address) > 0 {
+			addr, err := loom.LocalAddressFromHexString(address)
+			if err != nil {
+				return eth.EthFilter{}, fmt.Errorf("invalid ethfilter, address")
+			}
+			rFilter.Addresses = append(rFilter.Addresses, addr)
 		}
-		rFilter.Addresses = append(rFilter.Addresses, address)
 	}
+
 	if len(filter.Topics) > SolidtyMaxTopics {
 		return eth.EthFilter{}, fmt.Errorf("invalid ethfilter, too many topics")
 	}

--- a/eth/utils/utils.go
+++ b/eth/utils/utils.go
@@ -21,7 +21,7 @@ func UnmarshalEthFilter(query []byte) (eth.EthFilter, error) {
 	var filter struct {
 		FromBlock string        `json:"fromBlock"`
 		ToBlock   string        `json:"toBlock"`
-		Addresses []string      `json:"address"`
+		Addresses []string      `json:"addresses"`
 		Topics    []interface{} `json:"topics"`
 	}
 	json.Unmarshal(query, &filter)

--- a/eth/utils/utils_test.go
+++ b/eth/utils/utils_test.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	addr       = "0x8888f1f195afa192cfee860698584c030f4c9db1"
-	testFilter = "{\"fromBlock\":\"0x1\",\"toBlock\":\"0x2\",\"address\":[\"" + addr + "\"],\"topics\":[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",null,[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",\"0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc\"]]}"
-	allFilter  = "{\"fromBlock\":\"0x0\",\"toBlock\":\"latest\",\"address\":\"\",\"topics\":[]}"
+	testFilter = "{\"fromBlock\":\"0x1\",\"toBlock\":\"0x2\",\"addresses\":[\"" + addr + "\"],\"topics\":[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",null,[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",\"0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc\"]]}"
+	allFilter  = "{\"fromBlock\":\"0x0\",\"toBlock\":\"latest\",\"addresses\":\"\",\"topics\":[]}"
 	test1      = "{\"fromBlock\":\"0x1\"}"
 )
 

--- a/eth/utils/utils_test.go
+++ b/eth/utils/utils_test.go
@@ -3,20 +3,23 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	testFilter = "{\"fromBlock\":\"0x1\",\"toBlock\":\"0x2\",\"address\":\"0x8888f1f195afa192cfee860698584c030f4c9db1\",\"topics\":[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",null,[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",\"0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc\"]]}"
+	addr       = "0x8888f1f195afa192cfee860698584c030f4c9db1"
+	testFilter = "{\"fromBlock\":\"0x1\",\"toBlock\":\"0x2\",\"address\":[\"" + addr + "\"],\"topics\":[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",null,[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",\"0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc\"]]}"
 	allFilter  = "{\"fromBlock\":\"0x0\",\"toBlock\":\"latest\",\"address\":\"\",\"topics\":[]}"
 	test1      = "{\"fromBlock\":\"0x1\"}"
 )
 
 func TestEthUnmarshal(t *testing.T) {
-	_, err := UnmarshalEthFilter([]byte(testFilter))
+	ethFilter, err := UnmarshalEthFilter([]byte(testFilter))
 	require.NoError(t, err, "un-marshalling test filter")
+	require.Equal(t, addr, strings.ToLower(ethFilter.Addresses[0].String()))
 	_, err = UnmarshalEthFilter([]byte(allFilter))
 	require.NoError(t, err, "un-marshalling test filter")
 	_, err = UnmarshalEthFilter([]byte(test1))

--- a/eth/utils/utils_test.go
+++ b/eth/utils/utils_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	addr       = "0x8888f1f195afa192cfee860698584c030f4c9db1"
-	testFilter = "{\"fromBlock\":\"0x1\",\"toBlock\":\"0x2\",\"addresses\":[\"" + addr + "\"],\"topics\":[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",null,[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",\"0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc\"]]}"
+	addr1      = "0x8888f1f195afa192cfee860698584c030f4c9db1"
+	addr2      = "0x5ea31a5614f66526b00b9858b4db079178b5aea2"
+	testFilter = "{\"fromBlock\":\"0x1\",\"toBlock\":\"0x2\",\"addresses\":[\"" + addr1 + "\",\"" + addr2 + "\"],\"topics\":[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",null,[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\",\"0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc\"]]}"
 	allFilter  = "{\"fromBlock\":\"0x0\",\"toBlock\":\"latest\",\"addresses\":\"\",\"topics\":[]}"
 	test1      = "{\"fromBlock\":\"0x1\"}"
 )
@@ -19,7 +20,8 @@ const (
 func TestEthUnmarshal(t *testing.T) {
 	ethFilter, err := UnmarshalEthFilter([]byte(testFilter))
 	require.NoError(t, err, "un-marshalling test filter")
-	require.Equal(t, addr, strings.ToLower(ethFilter.Addresses[0].String()))
+	require.Equal(t, addr1, strings.ToLower(ethFilter.Addresses[0].String()))
+	require.Equal(t, addr2, strings.ToLower(ethFilter.Addresses[1].String()))
 	_, err = UnmarshalEthFilter([]byte(allFilter))
 	require.NoError(t, err, "un-marshalling test filter")
 	_, err = UnmarshalEthFilter([]byte(test1))


### PR DESCRIPTION
Note: loom-js must be changed to support this fix.

Ref: https://github.com/loomnetwork/loomchain/issues/1531

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request