### PR TITLE
Modify eth_call to expect the From parameter to be an Ethereum address

### DIFF
--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -295,6 +295,7 @@ func (s *QueryServer) EthCall(query eth.JsonTxCallObject, block eth.BlockHeight)
 	if err != nil {
 		return resp, err
 	}
+
 	bytes, err := s.queryEvm(caller, contract, data)
 	return eth.EncBytes(bytes), err
 }

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -1016,16 +1016,16 @@ func (s *QueryServer) EthGetTransactionCount(address eth.Data, block eth.BlockHe
 
 	resolvedAddr, err := s.getEthAccount(snapshot, address)
 	if err != nil {
-		return eth.Quantity("0x0"), err
+		return eth.ZeroedQuantity, err
 	}
 
 	height, err := eth.DecBlockHeight(snapshot.Block().Height, block)
 	if err != nil {
-		return eth.Quantity("0x0"), err
+		return eth.ZeroedQuantity, err
 	}
 
 	if height != uint64(snapshot.Block().Height) {
-		return eth.Quantity("0x0"), errors.New("transaction count only available for the latest block")
+		return eth.ZeroedQuantity, errors.New("transaction count only available for the latest block")
 	}
 
 	return eth.EncUint(auth.Nonce(snapshot, resolvedAddr)), nil

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -295,7 +295,6 @@ func (s *QueryServer) EthCall(query eth.JsonTxCallObject, block eth.BlockHeight)
 	if err != nil {
 		return resp, err
 	}
-
 	bytes, err := s.queryEvm(caller, contract, data)
 	return eth.EncBytes(bytes), err
 }

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -277,9 +277,14 @@ func (s *QueryServer) queryEvm(caller, contract loom.Address, query []byte) ([]b
 
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_call
 func (s *QueryServer) EthCall(query eth.JsonTxCallObject, block eth.BlockHeight) (resp eth.Data, err error) {
-	caller, err := s.getEthAccount(query.From)
-	if err != nil {
-		return resp, err
+	var caller loom.Address
+	if len(query.From) > 0 {
+		caller, err = s.getEthAccount(query.From)
+		if err != nil {
+			return resp, err
+		}
+	} else {
+		caller = loom.RootAddress(s.ChainID)
 	}
 
 	contract, err := eth.DecDataToAddress(s.ChainID, query.To)


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request

https://github.com/loomnetwork/loomchain/issues/1540
If `from` address entered, set to use "eth" chain id or give an error if eth not supported.
If there is no `from` address, use loom.RootAddress(s.ChainID).