### PR TITLE
Add pprof profiling data http server

### DIFF
--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -1286,7 +1286,7 @@ func initQueryService(
 	}
 	var qsvc rpc.QueryService = rpc.NewInstrumentingMiddleWare(requestCount, requestLatency, qs)
 	logger := log.Root.With("module", "query-server")
-	err = rpc.RPCServer(qsvc, chainID, logger, bus, cfg.RPCBindAddress, cfg.UnsafeRPCEnabled, cfg.UnsafeRPCBindAddress)
+	err = rpc.RPCServer(qsvc, chainID, logger, bus, cfg.RPCBindAddress, cfg.UnsafeRPCEnabled, cfg.UnsafeRPCBindAddress, cfg.Debug.PprofEnabled)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -143,6 +143,12 @@ type Config struct {
 	EVMDebugEnabled bool
 	// Set to true to disable minimum required build number check on node startup
 	SkipMinBuildCheck bool
+
+	Debug *DebugConfig
+}
+
+type DebugConfig struct {
+	PprofEnabled bool
 }
 
 type Metrics struct {
@@ -222,6 +228,12 @@ func DefaultMetrics() *Metrics {
 		BlockIndexStore: false,
 		EventHandling:   true,
 		Database:        true,
+	}
+}
+
+func DefaultDebug() *DebugConfig {
+	return &DebugConfig{
+		PprofEnabled: false,
 	}
 }
 
@@ -407,6 +419,7 @@ func DefaultConfig() *Config {
 	cfg.BlockStore = store.DefaultBlockStoreConfig()
 	cfg.BlockIndexStore = blockindex.DefaultBlockIndexStoreConfig()
 	cfg.Metrics = DefaultMetrics()
+	cfg.Debug = DefaultDebug()
 	cfg.Karma = DefaultKarmaConfig()
 	cfg.ChainConfig = DefaultChainConfigConfig(cfg.RPCProxyPort)
 	cfg.DeployerWhitelist = DefaultDeployerWhitelistConfig()
@@ -569,6 +582,9 @@ Metrics:
   BlockIndexStore: {{ .Metrics.BlockIndexStore }} 
   EventHandling: {{ .Metrics.EventHandling }}
   Database: {{ .Metrics.Database }}
+Debug:
+  # Enable pprof http server runtime data
+  PprofEnabled: {{ .Debug.PprofEnabled }}
 
 #
 # ChainConfig


### PR DESCRIPTION
Currently, s304 is taking up much more memory compared to s303. We need to investigate what is wrong with it so this PR adds pprof which is a http server used for showing runtime data. 

Ref: https://golang.org/pkg/net/http/pprof/

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request