### PR TITLE
Prune old EVM keys every N blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = prune-evm-keys-interval
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = prune-evm-keys-interval
+GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -225,8 +225,12 @@ func (s *MultiWriterAppStore) pruneOldEVMKeys() error {
 	}
 
 	maxKeysToPrune := cfg.GetAppStore().GetNumEvmKeysToPrune()
-	pruneInterval := cfg.GetAppStore().GetPruneEvmKeysInterval() // Prune old EVM Keys every N blocks
-	if maxKeysToPrune > 0 && (pruneInterval == 0 || s.Version()%int64(pruneInterval) == 0) {
+	pruneInterval := cfg.GetAppStore().GetPruneEvmKeysInterval()
+	// If pruneInterval is set then only prune old EVM Keys every N blocks
+	if (pruneInterval != 0) && (s.Version()%int64(pruneInterval) != 0) {
+		maxKeysToPrune = 0
+	}
+	if maxKeysToPrune > 0 {
 		entriesToPrune := s.appStore.RangeWithLimit(vmPrefix, int(maxKeysToPrune))
 		for _, entry := range entriesToPrune {
 			s.appStore.Delete(util.PrefixKey(vmPrefix, entry.Key))

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -225,7 +225,8 @@ func (s *MultiWriterAppStore) pruneOldEVMKeys() error {
 	}
 
 	maxKeysToPrune := cfg.GetAppStore().GetNumEvmKeysToPrune()
-	if maxKeysToPrune > 0 {
+	pruneInterval := cfg.GetAppStore().GetPruneEvmKeysInterval()
+	if maxKeysToPrune > 0 && (pruneInterval == 0 || s.Version()%int64(pruneInterval) == 0) {
 		entriesToPrune := s.appStore.RangeWithLimit(vmPrefix, int(maxKeysToPrune))
 		for _, entry := range entriesToPrune {
 			s.appStore.Delete(util.PrefixKey(vmPrefix, entry.Key))

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -226,7 +226,7 @@ func (s *MultiWriterAppStore) pruneOldEVMKeys() error {
 
 	maxKeysToPrune := cfg.GetAppStore().GetNumEvmKeysToPrune()
 	pruneInterval := cfg.GetAppStore().GetPruneEvmKeysInterval()
-	// If pruneInterval is set then only prune old EVM Keys every N blocks
+	// If pruneInterval is set, then only prune old EVM Keys every N blocks
 	if (pruneInterval != 0) && (s.Version()%int64(pruneInterval) != 0) {
 		maxKeysToPrune = 0
 	}

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -225,7 +225,7 @@ func (s *MultiWriterAppStore) pruneOldEVMKeys() error {
 	}
 
 	maxKeysToPrune := cfg.GetAppStore().GetNumEvmKeysToPrune()
-	pruneInterval := cfg.GetAppStore().GetPruneEvmKeysInterval()
+	pruneInterval := cfg.GetAppStore().GetPruneEvmKeysInterval() // Prune old EVM Keys every N blocks
 	if maxKeysToPrune > 0 && (pruneInterval == 0 || s.Version()%int64(pruneInterval) == 0) {
 		entriesToPrune := s.appStore.RangeWithLimit(vmPrefix, int(maxKeysToPrune))
 		for _, entry := range entriesToPrune {


### PR DESCRIPTION
Currently, pruning EVM keys every block forces Tendermint to create a new block faster so Blockscout indexer cannot catch up the speed and start to fall behind. This PR adds a new on-chain config, `PruneEvmKeysInterval`, which can be used to set pruning interval.   

Issue: https://github.com/loomnetwork/ops/issues/781

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request