### PR TITLE
Websocket upgrading - checkOrigin always returns true

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -7,6 +7,7 @@ package rpc
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -33,6 +34,9 @@ var (
 	upgrader = websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
 	}
 )
 


### PR DESCRIPTION
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request

Possable fix for websocket upgrading. [Changed to match the way tendermint does it.](https://github.com/loomnetwork/tendermint/blob/loomchain/rpc/lib/server/handlers.go#L755)