### PR TITLE
Emit tx events after block commit

### DIFF
--- a/app.go
+++ b/app.go
@@ -818,18 +818,6 @@ func (a *Application) deliverTx2(storeTx store.KVStoreTx, txBytes []byte) abci.R
 		txHash: receiptTxHash,
 	})
 
-	// FIXME: Really shouldn't be sending out events until the whole block is committed because
-	//        the state changes from the tx won't be visible to queries until after Application.Commit()
-	// if err := a.EventHandler.LegacyEthSubscriptionSet().EmitTxEvent(r.Data, r.Info); err != nil {
-	// 	log.Error("Emit Tx Event error", "err", err)
-	// }
-
-	// if len(receiptTxHash) > 0 {
-	// 	if err := a.EventHandler.EthSubscriptionSet().EmitTxEvent(receiptTxHash); err != nil {
-	// 		log.Error("failed to emit tx event to subscribers", "err", err)
-	// 	}
-	// }
-
 	return abci.ResponseDeliverTx{Code: abci.CodeTypeOK, Data: r.Data, Tags: r.Tags, Info: r.Info}
 }
 


### PR DESCRIPTION
Currently, events are emitted immediately after tx is processed successfully. We should delay it since the state won't be available until the block is committed.

Issue: https://github.com/loomnetwork/loomchain/issues/1561

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [x] All IP is original and not copied from another source
- [x] I assign all copyright to Loom Network for the code in the pull request