### PR TITLE
Add TG v1.3 feature flag for precision adjustment on transfers via Binance Gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 #       specific commit.
 GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
-TG_GIT_REV = binance-chain-loomcoin-precision-adjustment
+TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch
 ETHEREUM_GIT_REV = 1fb6138d017a4309105d91f187c126cf979c93f9
 # use go-plugin we get 'timeout waiting for connection info' error

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 #       specific commit.
 GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
-TG_GIT_REV = HEAD
+TG_GIT_REV = binance-chain-loomcoin-precision-adjustment
 # loomnetwork/go-ethereum loomchain branch
 ETHEREUM_GIT_REV = 1fb6138d017a4309105d91f187c126cf979c93f9
 # use go-plugin we get 'timeout waiting for connection info' error

--- a/features/features.go
+++ b/features/features.go
@@ -19,8 +19,8 @@ const (
 	// Enable additional validation of account & contract chain IDs to make it harder to obtain
 	// invalid withdrawal receipts.
 	TGVersion1_2 = "tg:1.2"
-	// Enable precision adjustment between Loom on BinanceChain and Loom Coin on DappChain
-	TGBinanceChainLoomCoinPrecisionAdjustment = "tg:binance-loomcoin-pa"
+	// Enable token precision adjustment for LOOM deposits & withdrawals via Binance Gateway
+	TGVersion1_3 = "tg:v1.3"
 
 	// Enables support for mapping DAppChain accounts to Binance accounts
 	AddressMapperVersion1_1 = "addrmapper:v1.1"

--- a/features/features.go
+++ b/features/features.go
@@ -19,6 +19,8 @@ const (
 	// Enable additional validation of account & contract chain IDs to make it harder to obtain
 	// invalid withdrawal receipts.
 	TGVersion1_2 = "tg:1.2"
+	// Enable precision adjustment between Loom on BinanceChain and Loom Coin on DappChain
+	TGBinanceChainLoomCoinPrecisionAdjustment = "tg:binance-loomcoin-pa"
 
 	// Enables support for mapping DAppChain accounts to Binance accounts
 	AddressMapperVersion1_1 = "addrmapper:v1.1"

--- a/features/features.go
+++ b/features/features.go
@@ -18,7 +18,7 @@ const (
 	TGVersion1_1 = "tg:v1.1"
 	// Enable additional validation of account & contract chain IDs to make it harder to obtain
 	// invalid withdrawal receipts.
-	TGVersion1_2 = "tg:1.2"
+	TGVersion1_2 = "tg:v1.2"
 	// Enable token precision adjustment for LOOM deposits & withdrawals via Binance Gateway
 	TGVersion1_3 = "tg:v1.3"
 


### PR DESCRIPTION
This PRs adds `tg:v1.3` flag for the support of Binance Chain and Loom Coin precision adjustment.

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request