### PR TITLE
Add block time to events & logs retrieved via Web3 JSON-RPC on the /eth endpoint

### DIFF
--- a/rpc/eth/jsonrpc_conversion.go
+++ b/rpc/eth/jsonrpc_conversion.go
@@ -151,7 +151,6 @@ func TxObjToReceipt(txObj JsonTxObject, contractAddr *Data) JsonTxReceipt {
 }
 
 func EncEvents(logs []*types.EventData) []JsonLog {
-
 	jLogs := make([]JsonLog, 0, len(logs))
 	for i, log := range logs {
 		jLog := EncEvent(*log)
@@ -172,7 +171,6 @@ func EncEvent(log types.EventData) JsonLog {
 		data = EncBytes(log.EncodedBody)
 	}
 
-	// TODO: Copy log.BlockTime
 	jLog := JsonLog{
 		TransactionHash:  EncBytes(log.TxHash),
 		BlockNumber:      EncUint(log.BlockHeight),
@@ -180,6 +178,7 @@ func EncEvent(log types.EventData) JsonLog {
 		Data:             data,
 		TransactionIndex: EncInt(int64(log.TransactionIndex)),
 		BlockHash:        EncBytes(log.BlockHash),
+		BlockTime:        EncInt(log.BlockTime),
 	}
 	for _, topic := range log.Topics {
 		jLog.Topics = append(jLog.Topics, Data(topic))
@@ -189,15 +188,14 @@ func EncEvent(log types.EventData) JsonLog {
 }
 
 func EncLogs(logs []*types.EthFilterLog) []JsonLog {
-
 	jLogs := make([]JsonLog, 0, len(logs))
 	for _, log := range logs {
-		jLogs = append(jLogs, EncLog(*log))
+		jLogs = append(jLogs, encLog(*log))
 	}
 	return jLogs
 }
 
-func EncLog(log types.EthFilterLog) JsonLog {
+func encLog(log types.EthFilterLog) JsonLog {
 	jLog := JsonLog{
 		Removed:          log.Removed,
 		LogIndex:         EncInt(log.LogIndex),
@@ -207,6 +205,7 @@ func EncLog(log types.EthFilterLog) JsonLog {
 		BlockNumber:      EncInt(log.BlockNumber),
 		Address:          EncBytes(log.Address),
 		Data:             EncBytes(log.Data),
+		BlockTime:        EncInt(log.BlockTime),
 	}
 	for _, topic := range log.Topics {
 		jLog.Topics = append(jLog.Topics, Data(string(topic)))


### PR DESCRIPTION
This was reverted in build 1331 because it broke the Blockscout indexer, we've adapted the indexer to deal with this field now so this can go back in.