### PR TITLE
Gas Usage Tracker

### DIFF
--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -732,6 +732,8 @@ func loadApp(
 		return nil, err
 	}
 
+	evm.GasUsageTrackerEnabled = cfg.GasUsageTrackerEnabled
+
 	if !cfg.SkipMinBuildCheck {
 		if buildBytes := appStore.Get([]byte(loomchain.MinBuildKey)); len(buildBytes) > 0 {
 			minimumBuild := binary.BigEndian.Uint64(buildBytes)

--- a/config/config.go
+++ b/config/config.go
@@ -148,6 +148,8 @@ type Config struct {
 	EVMDebugEnabled bool
 	// Set to true to disable minimum required build number check on node startup
 	SkipMinBuildCheck bool
+	// Enable tracking account/contract gas usage
+	GasUsageTrackerEnabled bool
 
 	Web3 *eth.Web3Config
 
@@ -421,6 +423,7 @@ func DefaultConfig() *Config {
 		EVMAccountsEnabled:         false,
 		EVMDebugEnabled:            false,
 		SampleGoContractEnabled:    false,
+		GasUsageTrackerEnabled:     false,
 
 		Oracle:                 "",
 		DeployEnabled:          true,
@@ -837,6 +840,7 @@ DPOS:
 # Here be dragons, don't change the defaults unless you know what you're doing
 #
 EVMDebugEnabled: {{ .EVMDebugEnabled }}
+GasUsageTrackerEnabled: {{ .GasUsageTrackerEnabled }}
 AllowNamedEvmContracts: {{ .AllowNamedEvmContracts }}
 # Set to true to disable minimum required build number check on node startup
 SkipMinBuildCheck: {{ .SkipMinBuildCheck }}

--- a/evm/noevm.go
+++ b/evm/noevm.go
@@ -8,11 +8,14 @@ import (
 )
 
 var (
-	LogEthDbBatch = true
+	LogEthDbBatch          = true
+	GasUsageTrackerEnabled = false
 )
 
 // EVMEnabled indicates whether or not EVM integration is available
-const EVMEnabled = false
+const (
+	EVMEnabled = false
+)
 
 func NewLoomVm(
 	loomState loomchain.State,
@@ -25,3 +28,5 @@ func NewLoomVm(
 }
 
 func AddLoomPrecompiles() {}
+
+func GetGasUsage(addr string) uint64 { return 0 }

--- a/registry/registry.pb.go
+++ b/registry/registry.pb.go
@@ -32,7 +32,7 @@ func (m *Record) Reset()         { *m = Record{} }
 func (m *Record) String() string { return proto.CompactTextString(m) }
 func (*Record) ProtoMessage()    {}
 func (*Record) Descriptor() ([]byte, []int) {
-	return fileDescriptor_registry_8f33b09e6c22f9ce, []int{0}
+	return fileDescriptor_registry_db594c69f58cdc2f, []int{0}
 }
 func (m *Record) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Record.Unmarshal(m, b)
@@ -78,10 +78,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("github.com/loomnetwork/loomchain/registry/registry.proto", fileDescriptor_registry_8f33b09e6c22f9ce)
+	proto.RegisterFile("github.com/loomnetwork/loomchain/registry/registry.proto", fileDescriptor_registry_db594c69f58cdc2f)
 }
 
-var fileDescriptor_registry_8f33b09e6c22f9ce = []byte{
+var fileDescriptor_registry_db594c69f58cdc2f = []byte{
 	// 163 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xb2, 0x48, 0xcf, 0x2c, 0xc9,
 	0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0xcf, 0xc9, 0xcf, 0xcf, 0xcd, 0x4b, 0x2d, 0x29, 0xcf,

--- a/rpc/instrumenting.go
+++ b/rpc/instrumenting.go
@@ -125,6 +125,20 @@ func (m InstrumentingMiddleware) GetContractRecord(contractAddr string) (resp *t
 	return
 }
 
+func (m InstrumentingMiddleware) GetGasUsage(addr string) (resp uint64, err error) {
+	defer func(begin time.Time) {
+		lvs := []string{"method", "GetContractRecord", "error", fmt.Sprint(err != nil)}
+		m.requestCount.With(lvs...).Add(1)
+		m.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	resp, err = m.next.GetGasUsage(addr)
+	if err != nil {
+		return 0, err
+	}
+	return
+}
+
 func (m InstrumentingMiddleware) DPOSTotalStaked() (resp *DPOSTotalStakedResponse, err error) {
 	defer func(begin time.Time) {
 		lvs := []string{"method", "DposTotalStaked", "error", fmt.Sprint(err != nil)}

--- a/rpc/mock_query_server.go
+++ b/rpc/mock_query_server.go
@@ -228,6 +228,13 @@ func (m *MockQueryService) EthEstimateGas(query eth.JsonTxCallObject) (eth.Quant
 	return "", nil
 }
 
+func (m *MockQueryService) EthGasUsage(address eth.Data) (eth.Quantity, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.MethodsCalled = append([]string{"EthGasUsage"}, m.MethodsCalled...)
+	return "", nil
+}
+
 func (m *MockQueryService) EthGasPrice() (eth.Quantity, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/rpc/mock_query_server.go
+++ b/rpc/mock_query_server.go
@@ -228,13 +228,6 @@ func (m *MockQueryService) EthEstimateGas(query eth.JsonTxCallObject) (eth.Quant
 	return "", nil
 }
 
-func (m *MockQueryService) EthGasUsage(address eth.Data) (eth.Quantity, error) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	m.MethodsCalled = append([]string{"EthGasUsage"}, m.MethodsCalled...)
-	return "", nil
-}
-
 func (m *MockQueryService) EthGasPrice() (eth.Quantity, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -275,6 +268,13 @@ func (m *MockQueryService) ContractEvents(
 func (m *MockQueryService) GetContractRecord(addr string) (*types.ContractRecordResponse, error) {
 	m.MethodsCalled = append([]string{"GetcontractRecord"}, m.MethodsCalled...)
 	return nil, nil
+}
+
+func (m *MockQueryService) GetGasUsage(address string) (uint64, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.MethodsCalled = append([]string{"GasUsage"}, m.MethodsCalled...)
+	return 0, nil
 }
 
 func (m *MockQueryService) DPOSTotalStaked() (*DPOSTotalStakedResponse, error) {

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -609,6 +609,17 @@ func (s *QueryServer) GetContractRecord(contractAddrStr string) (*types.Contract
 	return k, nil
 }
 
+func (s *QueryServer) GetGasUsage(addr string) (uint64, error) {
+	if !levm.GasUsageTrackerEnabled {
+		return 0, errors.New("GasUsageTracker is disabled")
+	}
+	loomAddr, err := loom.ParseAddress(addr)
+	if err != nil {
+		return 0, err
+	}
+	return levm.GetGasUsage(loomAddr.String()), nil
+}
+
 type DPOSTotalStakedResponse struct {
 	TotalStaked *gtypes.BigUInt
 }

--- a/rpc/query_service.go
+++ b/rpc/query_service.go
@@ -63,6 +63,7 @@ type QueryService interface {
 
 	ContractEvents(fromBlock uint64, toBlock uint64, contract string) (*types.ContractEventsResult, error)
 	GetContractRecord(contractAddr string) (*types.ContractRecordResponse, error)
+	GetGasUsage(addr string) (uint64, error)
 	DPOSTotalStaked() (*DPOSTotalStakedResponse, error)
 
 	// deprecated function
@@ -131,6 +132,7 @@ func MakeQueryServiceHandler(svc QueryService, logger log.TMLogger, bus *QueryEv
 	routes["evmsubscribe"] = rpcserver.NewWSRPCFunc(svc.EvmSubscribe, "method,filter")
 	routes["contractevents"] = rpcserver.NewRPCFunc(svc.ContractEvents, "fromBlock,toBlock,contract")
 	routes["contractrecord"] = rpcserver.NewRPCFunc(svc.GetContractRecord, "contract")
+	routes["gasusage"] = rpcserver.NewRPCFunc(svc.GetGasUsage, "address")
 	routes["dpos_total_staked"] = rpcserver.NewRPCFunc(svc.DPOSTotalStaked, "")
 	rpcserver.RegisterRPCFuncs(wsmux, routes, codec, logger)
 	wm := rpcserver.NewWebsocketManager(routes, codec, rpcserver.EventSubscriber(bus))


### PR DESCRIPTION
Gas Usage Tracker is used to track the total amount of gas used by each account/contract. 

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request