### PR TITLE
Add DestroyDeployedContract method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = destroy-contract-protobuf
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/cmd/loom/config.go
+++ b/cmd/loom/config.go
@@ -10,6 +10,7 @@ import (
 	dwtypes "github.com/loomnetwork/go-loom/builtin/types/deployer_whitelist"
 	ktypes "github.com/loomnetwork/go-loom/builtin/types/karma"
 	tgtypes "github.com/loomnetwork/go-loom/builtin/types/transfer_gateway"
+	udwtypes "github.com/loomnetwork/go-loom/builtin/types/user_deployer_whitelist"
 	cconfig "github.com/loomnetwork/go-loom/config"
 	"github.com/loomnetwork/go-loom/plugin/contractpb"
 	"github.com/loomnetwork/go-loom/types"
@@ -285,6 +286,34 @@ func defaultGenesis(cfg *config.Config, validator *loom.Validator) (*config.Gene
 			Name:       "deployerwhitelist",
 			Location:   "deployerwhitelist:1.0.0",
 			Init:       dwInit,
+		})
+	}
+
+	if cfg.UserDeployerWhitelist.ContractEnabled {
+		udwInitRequest := udwtypes.InitRequest{
+			Owner: contractOwner,
+			TierInfo: []*udwtypes.TierInfo{
+				&udwtypes.TierInfo{
+					TierID:     0,
+					Fee:        10,
+					Name:       "tier1",
+					BlockRange: 4,
+					MaxTxs:     1,
+				},
+			},
+		}
+
+		udwInit, err := marshalInit(&udwInitRequest)
+		if err != nil {
+			return nil, err
+		}
+
+		contracts = append(contracts, config.ContractConfig{
+			VMTypeName: "plugin",
+			Format:     "plugin",
+			Name:       "user-deployer-whitelist",
+			Location:   "user-deployer-whitelist:1.0.0",
+			Init:       udwInit,
 		})
 	}
 

--- a/cmd/loom/userdeployerwhitelist/cmd.go
+++ b/cmd/loom/userdeployerwhitelist/cmd.go
@@ -151,9 +151,7 @@ func destroyDeployedContractCmd() *cobra.Command {
 			req := &udwtypes.DestroyDeployedContractsRequest{
 				ContractAddress: contractAddr.MarshalPB(),
 			}
-			err = cli.CallContractWithFlags(&flags, dwContractName, "DestroyDeployedContract", req, nil)
-			fmt.Println(err)
-			return err
+			return cli.CallContractWithFlags(&flags, dwContractName, "DestroyDeployedContract", req, nil)
 		},
 	}
 	cli.AddContractCallFlags(cmd.Flags(), &flags)

--- a/cmd/loom/userdeployerwhitelist/cmd.go
+++ b/cmd/loom/userdeployerwhitelist/cmd.go
@@ -37,6 +37,7 @@ func NewUserDeployCommand() *cobra.Command {
 		getDeployedContractsCmd(),
 		getTierInfoCmd(),
 		setTierInfoCmd(),
+		destroyDeployedContractCmd(),
 	)
 	return cmd
 }
@@ -123,6 +124,36 @@ func swapUserDeployerCmd() *cobra.Command {
 				NewDeployerAddr: newDeployerAddr.MarshalPB(),
 			}
 			return cli.CallContractWithFlags(&flags, dwContractName, "SwapUserDeployer", req, nil)
+		},
+	}
+	cli.AddContractCallFlags(cmd.Flags(), &flags)
+	return cmd
+}
+
+const destroyDeployedContractCmdExample = `
+loom dev destroy-contract 0x7262d4c97c7B93937E4810D289b7320e9dA82857
+`
+
+func destroyDeployedContractCmd() *cobra.Command {
+	var flags cli.ContractCallFlags
+	cmd := &cobra.Command{
+		Use: "destroy-contract <contract address>",
+		// nolint:lll
+		Short:   "Destroy a deployed contract by contract address",
+		Example: destroyDeployedContractCmdExample,
+		Args:    cobra.RangeArgs(1, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			contractAddr, err := cli.ResolveAccountAddress(args[0], &flags)
+			if err != nil {
+				return err
+			}
+			fmt.Println("contractAddress", contractAddr.String())
+			req := &udwtypes.DestroyDeployedContractsRequest{
+				ContractAddress: contractAddr.MarshalPB(),
+			}
+			err = cli.CallContractWithFlags(&flags, dwContractName, "DestroyDeployedContract", req, nil)
+			fmt.Println(err)
+			return err
 		},
 	}
 	cli.AddContractCallFlags(cmd.Flags(), &flags)

--- a/e2e/middleware_test.go
+++ b/e2e/middleware_test.go
@@ -17,17 +17,17 @@ func TestMiddleware(t *testing.T) {
 		genFile  string
 		yamlFile string
 	}{
-		// {
-		// 	"deployerwhitelist", "deployerwhitelist.toml", 2, 2,
-		// 	"deployerwhitelist.genesis.json", "deployerwhitelist-loom.yaml",
-		// },
+		{
+			"deployerwhitelist", "deployerwhitelist.toml", 2, 2,
+			"deployerwhitelist.genesis.json", "deployerwhitelist-loom.yaml",
+		},
 		{
 			"userdeployerwhitelist", "userdeployerwhitelist.toml", 1, 6,
 			"userdeployerwhitelist.genesis.json", "userdeployerwhitelist-loom.yaml",
 		},
-		// {
-		// 	"tx-limiter", "tx-limiter-test.toml", 1, 4, "", "tx-limiter-loom.yaml",
-		// },
+		{
+			"tx-limiter", "tx-limiter-test.toml", 1, 4, "", "tx-limiter-loom.yaml",
+		},
 	}
 
 	for _, test := range tests {

--- a/e2e/middleware_test.go
+++ b/e2e/middleware_test.go
@@ -17,17 +17,17 @@ func TestMiddleware(t *testing.T) {
 		genFile  string
 		yamlFile string
 	}{
-		{
-			"deployerwhitelist", "deployerwhitelist.toml", 2, 2,
-			"deployerwhitelist.genesis.json", "deployerwhitelist-loom.yaml",
-		},
+		// {
+		// 	"deployerwhitelist", "deployerwhitelist.toml", 2, 2,
+		// 	"deployerwhitelist.genesis.json", "deployerwhitelist-loom.yaml",
+		// },
 		{
 			"userdeployerwhitelist", "userdeployerwhitelist.toml", 1, 6,
 			"userdeployerwhitelist.genesis.json", "userdeployerwhitelist-loom.yaml",
 		},
-		{
-			"tx-limiter", "tx-limiter-test.toml", 1, 4, "", "tx-limiter-loom.yaml",
-		},
+		// {
+		// 	"tx-limiter", "tx-limiter-test.toml", 1, 4, "", "tx-limiter-loom.yaml",
+		// },
 	}
 
 	for _, test := range tests {

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -265,7 +265,6 @@ func (e Evm) GetStorageAt(addr loom.Address, key []byte) ([]byte, error) {
 }
 
 func (e Evm) SelfDestruct(addr loom.Address) bool {
-	fmt.Println("Loom Address to destroy", addr.String())
 	return e.sdb.Suicide(common.BytesToAddress(addr.Local))
 }
 

--- a/evm/evm.go
+++ b/evm/evm.go
@@ -264,6 +264,11 @@ func (e Evm) GetStorageAt(addr loom.Address, key []byte) ([]byte, error) {
 	return result.Bytes(), nil
 }
 
+func (e Evm) SelfDestruct(addr loom.Address) bool {
+	fmt.Println("Loom Address to destroy", addr.String())
+	return e.sdb.Suicide(common.BytesToAddress(addr.Local))
+}
+
 // TODO: this doesn't need to be exported, rename to newEVM
 func (e Evm) NewEnv(origin common.Address) *vm.EVM {
 	e.context.Origin = origin

--- a/evm/loomevm.go
+++ b/evm/loomevm.go
@@ -285,6 +285,18 @@ func (lvm LoomVm) GetStorageAt(addr loom.Address, key []byte) ([]byte, error) {
 	return levm.GetStorageAt(addr, key)
 }
 
+func (lvm LoomVm) DestroyEVMContract(addr loom.Address) error {
+	levm, err := NewLoomEvm(lvm.state, nil, nil, lvm.debug)
+	if err != nil {
+		return err
+	}
+	if !levm.SelfDestruct(addr) {
+		return errors.New("Failed to destroy the contract")
+	}
+	_, err = levm.Commit()
+	return err
+}
+
 func getLoomEvmTxHash(ethTxHash []byte, from loom.LocalAddress) []byte {
 	h := sha3.NewKeccak256()
 	h.Write(append(ethTxHash, from...))

--- a/plugin/vm.go
+++ b/plugin/vm.go
@@ -213,6 +213,19 @@ func (vm *PluginVM) StaticCallEVM(caller, addr loom.Address, input []byte) ([]by
 	return evm.StaticCall(caller, addr, input)
 }
 
+func (vm *PluginVM) DestroyEVMContract(addr loom.Address) error {
+	var createABM levm.AccountBalanceManagerFactoryFunc
+	var err error
+	if vm.newABMFactory != nil {
+		createABM, err = vm.newABMFactory(vm)
+		if err != nil {
+			return err
+		}
+	}
+	evm := levm.NewLoomVm(vm.State, vm.EventHandler, vm.receiptWriter, createABM, false)
+	return evm.DestroyEVMContract(addr)
+}
+
 func (vm *PluginVM) GetCode(addr loom.Address) ([]byte, error) {
 	return []byte{}, nil
 }
@@ -243,6 +256,10 @@ func (c *contractContext) Call(addr loom.Address, input []byte) ([]byte, error) 
 
 func (c *contractContext) CallEVM(addr loom.Address, input []byte, value *loom.BigUInt) ([]byte, error) {
 	return c.VM.CallEVM(c.address, addr, input, value)
+}
+
+func (c *contractContext) DestroyEVMContract(addr loom.Address) error {
+	return c.VM.DestroyEVMContract(addr)
 }
 
 func (c *contractContext) StaticCall(addr loom.Address, input []byte) ([]byte, error) {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -13,6 +13,7 @@ type VM interface {
 	StaticCall(caller, addr loom.Address, input []byte) ([]byte, error)
 	GetCode(addr loom.Address) ([]byte, error)
 	GetStorageAt(addr loom.Address, hash []byte) ([]byte, error)
+	DestroyEVMContract(addr loom.Address) error
 }
 
 type Factory func(loomchain.State) (VM, error)


### PR DESCRIPTION
`DestroyDeployedContract` allows users to destroy their deployed contracts. In addition, UserDeployerWhitelist contract owner can use this method to destroy any contract.

TODO: need a feature flag to activate this method

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request