### PR TITLE
Add DPOS rpc endpoints 

### DIFF
--- a/app.go
+++ b/app.go
@@ -914,3 +914,19 @@ func (a *Application) ReadOnlyState() State {
 		a.GetValidatorSet,
 	)
 }
+
+func (a *Application) ReadOnlyStateAt(version int64) (State, error) {
+	readOnlySnapshot, err := a.Store.GetSnapshotAt(version)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: the store snapshot should be created atomically, otherwise the block header might
+	//       not match the state... need to figure out why this hasn't spectacularly failed already
+	return NewStoreStateSnapshot(
+		nil,
+		readOnlySnapshot,
+		a.lastBlockHeader,
+		nil, // TODO: last block hash!
+		a.GetValidatorSet,
+	), nil
+}

--- a/app.go
+++ b/app.go
@@ -829,6 +829,7 @@ func (a *Application) Commit() abci.ResponseCommit {
 		committedBlockCount.With(lvs...).Add(1)
 		commitBlockLatency.With(lvs...).Observe(time.Since(begin).Seconds())
 	}(time.Now())
+
 	appHash, _, err := a.Store.SaveVersion()
 	if err != nil {
 		panic(err)

--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -1324,7 +1324,15 @@ func (c *DPOS) ListDelegations(ctx contract.StaticContext, req *ListDelegationsR
 	if req.Candidate == nil {
 		return nil, logStaticDposError(ctx, errors.New("ListDelegations called with req.Candidate == nil"), req.String())
 	}
+	return ListDelegations(ctx, req)
+}
 
+func (c *DPOS) ListAllDelegations(ctx contract.StaticContext, req *ListAllDelegationsRequest) (*ListAllDelegationsResponse, error) {
+	ctx.Logger().Debug("DPOSv3 ListAllDelegations", "request", req)
+	return ListAllDelegations(ctx)
+}
+
+func ListDelegations(ctx contract.StaticContext, req *ListDelegationsRequest) (*ListDelegationsResponse, error) {
 	delegations, err := loadDelegationList(ctx)
 	if err != nil {
 		return nil, err
@@ -1354,9 +1362,7 @@ func (c *DPOS) ListDelegations(ctx contract.StaticContext, req *ListDelegationsR
 	}, nil
 }
 
-func (c *DPOS) ListAllDelegations(ctx contract.StaticContext, req *ListAllDelegationsRequest) (*ListAllDelegationsResponse, error) {
-	ctx.Logger().Debug("DPOSv3 ListAllDelegations", "request", req)
-
+func ListAllDelegations(ctx contract.StaticContext) (*ListAllDelegationsResponse, error) {
 	candidates, err := LoadCandidateList(ctx)
 	if err != nil {
 		return nil, err
@@ -1364,7 +1370,7 @@ func (c *DPOS) ListAllDelegations(ctx contract.StaticContext, req *ListAllDelega
 
 	responses := make([]*ListDelegationsResponse, 0)
 	for _, candidate := range candidates {
-		response, err := c.ListDelegations(ctx, &ListDelegationsRequest{Candidate: candidate.Address})
+		response, err := ListDelegations(ctx, &ListDelegationsRequest{Candidate: candidate.Address})
 		if err != nil {
 			return nil, err
 		}
@@ -2077,6 +2083,14 @@ func (c *DPOS) GetState(ctx contract.StaticContext, req *GetStateRequest) (*GetS
 	}
 
 	return &GetStateResponse{State: state}, nil
+}
+
+func GetState(ctx contract.StaticContext) (*State, error) {
+	state, err := LoadState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
 }
 
 // *************************

--- a/rpc/instrumenting.go
+++ b/rpc/instrumenting.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/gorilla/websocket"
 	"github.com/loomnetwork/go-loom/plugin/types"
+	"github.com/loomnetwork/loomchain/builtin/plugins/dposv3"
 	"github.com/loomnetwork/loomchain/config"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/vm"
@@ -133,6 +134,34 @@ func (m InstrumentingMiddleware) DPOSTotalStaked() (resp *DPOSTotalStakedRespons
 	}(time.Now())
 
 	resp, err = m.next.DPOSTotalStaked()
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+func (m InstrumentingMiddleware) DPOSState(height int64) (resp *dposv3.State, err error) {
+	defer func(begin time.Time) {
+		lvs := []string{"method", "DposTotalStaked", "error", fmt.Sprint(err != nil)}
+		m.requestCount.With(lvs...).Add(1)
+		m.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	resp, err = m.next.DPOSState(height)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+func (m InstrumentingMiddleware) DPOSListAllDelegations(height int64) (resp *dposv3.ListAllDelegationsResponse, err error) {
+	defer func(begin time.Time) {
+		lvs := []string{"method", "DposTotalStaked", "error", fmt.Sprint(err != nil)}
+		m.requestCount.With(lvs...).Add(1)
+		m.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	resp, err = m.next.DPOSListAllDelegations(height)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/mock_query_server.go
+++ b/rpc/mock_query_server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/loomnetwork/go-loom/plugin/types"
 
+	"github.com/loomnetwork/loomchain/builtin/plugins/dposv3"
 	"github.com/loomnetwork/loomchain/config"
 	"github.com/loomnetwork/loomchain/rpc/eth"
 	"github.com/loomnetwork/loomchain/vm"
@@ -272,6 +273,16 @@ func (m *MockQueryService) GetContractRecord(addr string) (*types.ContractRecord
 
 func (m *MockQueryService) DPOSTotalStaked() (*DPOSTotalStakedResponse, error) {
 	m.MethodsCalled = append([]string{"DposTotalStaked"}, m.MethodsCalled...)
+	return nil, nil
+}
+
+func (m *MockQueryService) DPOSState(height int64) (*dposv3.State, error) {
+	m.MethodsCalled = append([]string{"DPOSState"}, m.MethodsCalled...)
+	return nil, nil
+}
+
+func (m *MockQueryService) DPOSListAllDelegations(height int64) (*dposv3.State, error) {
+	m.MethodsCalled = append([]string{"DPOSState"}, m.MethodsCalled...)
 	return nil, nil
 }
 

--- a/rpc/query_service.go
+++ b/rpc/query_service.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/websocket"
+	dtypes "github.com/loomnetwork/go-loom/builtin/types/dposv3"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/tendermint/go-amino"
 	"github.com/tendermint/tendermint/libs/pubsub"
@@ -63,7 +64,10 @@ type QueryService interface {
 
 	ContractEvents(fromBlock uint64, toBlock uint64, contract string) (*types.ContractEventsResult, error)
 	GetContractRecord(contractAddr string) (*types.ContractRecordResponse, error)
+	// DPOS RPC endpoints
 	DPOSTotalStaked() (*DPOSTotalStakedResponse, error)
+	DPOSState(height int64) (*dtypes.State, error)
+	DPOSListAllDelegations(height int64) (*dtypes.ListAllDelegationsResponse, error)
 
 	// deprecated function
 	EvmTxReceipt(txHash []byte) ([]byte, error)
@@ -132,6 +136,8 @@ func MakeQueryServiceHandler(svc QueryService, logger log.TMLogger, bus *QueryEv
 	routes["contractevents"] = rpcserver.NewRPCFunc(svc.ContractEvents, "fromBlock,toBlock,contract")
 	routes["contractrecord"] = rpcserver.NewRPCFunc(svc.GetContractRecord, "contract")
 	routes["dpos_total_staked"] = rpcserver.NewRPCFunc(svc.DPOSTotalStaked, "")
+	routes["dpos_state"] = rpcserver.NewRPCFunc(svc.DPOSState, "height")
+	routes["dpos_list_all_delegations"] = rpcserver.NewRPCFunc(svc.DPOSListAllDelegations, "height")
 	rpcserver.RegisterRPCFuncs(wsmux, routes, codec, logger)
 	wm := rpcserver.NewWebsocketManager(routes, codec, rpcserver.EventSubscriber(bus))
 	wsmux.HandleFunc("/queryws", wm.WebsocketHandler)

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -216,6 +216,13 @@ func (s *IAVLStore) GetSnapshot() Snapshot {
 	}
 }
 
+func (s *IAVLStore) GetSnapshotAt(version int64) (Snapshot, error) {
+	// This isn't an actual snapshot obviously, and never will be, but lets pretend...
+	return &iavlStoreSnapshot{
+		IAVLStore: s,
+	}, nil
+}
+
 // NewIAVLStore creates a new IAVLStore.
 // maxVersions can be used to specify how many versions should be retained, if set to zero then
 // old versions will never been deleted.

--- a/store/logstore.go
+++ b/store/logstore.go
@@ -129,3 +129,7 @@ func (s *LogStore) Prune() error {
 func (s *LogStore) GetSnapshot() Snapshot {
 	return s.store.GetSnapshot()
 }
+
+func (s *LogStore) GetSnapshotAt(version int64) (Snapshot, error) {
+	return s.store.GetSnapshotAt(version)
+}

--- a/store/pruning_iavlstore.go
+++ b/store/pruning_iavlstore.go
@@ -184,6 +184,13 @@ func (s *PruningIAVLStore) GetSnapshot() Snapshot {
 	}
 }
 
+func (s *PruningIAVLStore) GetSnapshotAt(version int64) (Snapshot, error) {
+	// This isn't an actual snapshot obviously, and never will be, but lets pretend...
+	return &pruningIAVLStoreSnapshot{
+		PruningIAVLStore: s,
+	}, nil
+}
+
 func (s *PruningIAVLStore) prune() error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()

--- a/store/store.go
+++ b/store/store.go
@@ -54,6 +54,7 @@ type VersionedKVStore interface {
 	// Delete old version of the store
 	Prune() error
 	GetSnapshot() Snapshot
+	GetSnapshotAt(version int64) (Snapshot, error)
 }
 
 type cacheItem struct {


### PR DESCRIPTION
This PR implement 2 rpc endpoints, `dpos_state` and `dpos_list_all_delegations` 

These endpoints can be called to get dpos state and all delegation at a particular height
```
http://localhost:46658/query/dpos_state?height=100
http://localhost:46658/query/dpos_list_all_delegations?height=100
```

- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request