### PR TITLE
Skip a botched DPOS election on extdev

### DIFF
--- a/plugin/validators_manager_v3.go
+++ b/plugin/validators_manager_v3.go
@@ -107,8 +107,9 @@ func (m *ValidatorsManagerV3) EndBlock(req abci.RequestEndBlock) ([]abci.Validat
 		return nil, nil
 	}
 
-	// Skip a botched election on Extdev due to insufficient funds in the DPOS contract
-	if req.Height == 9856178 && m.ctx.Block().ChainID == "extdev-plasma-us1" {
+	// Postpone Extdev election at block 9856178 by 2000 blocks, the original election failed
+	// because the DPOS contract didn't have enough funds to honor a rewards claim.
+	if req.Height >= 9856178 && req.Height < 9858178 && m.ctx.Block().ChainID == "extdev-plasma-us1" {
 		m.ctx.Logger().Info("DPOSv3 EndBlock skipping election", "height", req.Height)
 		return nil, nil
 	}

--- a/plugin/validators_manager_v3.go
+++ b/plugin/validators_manager_v3.go
@@ -107,6 +107,12 @@ func (m *ValidatorsManagerV3) EndBlock(req abci.RequestEndBlock) ([]abci.Validat
 		return nil, nil
 	}
 
+	// Skip a botched election on Extdev due to insufficient funds in the DPOS contract
+	if req.Height == 9856178 && m.ctx.Block().ChainID == "extdev-plasma-us1" {
+		m.ctx.Logger().Info("DPOSv3 EndBlock skipping election", "height", req.Height)
+		return nil, nil
+	}
+
 	oldValidatorList, err := m.ValidatorList()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
DPOS contract had insufficient funds to process a rewards claim during the election in block `9856178` so we have to delay this election to resume the chain. Once the chain is back up and running we can transfer some funds to the DPOS contract so the next election goes through.