### PR TITLE
Add ability to override the active validator set via loom.yml

### DIFF
--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -1068,6 +1068,8 @@ func loadApp(
 			return plugin.NewValidatorsManagerV3(pvm.(*plugin.PluginVM))
 		} else if cfg.DPOSVersion == 2 {
 			return plugin.NewValidatorsManager(pvm.(*plugin.PluginVM))
+		} else if cfg.OverrideValidators.Height > 0 && cfg.OverrideValidators.Height == state.Block().Height {
+			return plugin.NewOverrideValidatorsManager(cfg.OverrideValidators.Height, cfg.OverrideValidators.Validators)
 		}
 
 		return plugin.NewNoopValidatorsManager(), nil

--- a/config/config.go
+++ b/config/config.go
@@ -14,8 +14,11 @@ import (
 	"github.com/loomnetwork/loomchain/auth"
 	plasmacfg "github.com/loomnetwork/loomchain/builtin/plugins/plasma_cash/config"
 	genesiscfg "github.com/loomnetwork/loomchain/config/genesis"
+	"github.com/loomnetwork/loomchain/db"
 	"github.com/loomnetwork/loomchain/events"
 	"github.com/loomnetwork/loomchain/evm"
+	"github.com/loomnetwork/loomchain/fnConsensus"
+	"github.com/loomnetwork/loomchain/plugin"
 	hsmpv "github.com/loomnetwork/loomchain/privval/hsm"
 	receipts "github.com/loomnetwork/loomchain/receipts/handler"
 	registry "github.com/loomnetwork/loomchain/registry/factory"
@@ -25,10 +28,6 @@ import (
 	"github.com/loomnetwork/loomchain/throttle"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-
-	"github.com/loomnetwork/loomchain/db"
-
-	"github.com/loomnetwork/loomchain/fnConsensus"
 )
 
 type (
@@ -149,9 +148,10 @@ type Config struct {
 	// Set to true to disable minimum required build number check on node startup
 	SkipMinBuildCheck bool
 
-	Web3 *eth.Web3Config
-	Geth *GethConfig
-	DPOS *DPOSConfig
+	Web3               *eth.Web3Config
+	Geth               *GethConfig
+	DPOS               *DPOSConfig
+	OverrideValidators *OverrideValidatorsConfig
 }
 
 type GethConfig struct {
@@ -258,6 +258,16 @@ type UserDeployerWhitelistConfig struct {
 	ContractEnabled bool
 }
 
+// OverrideValidatorsConfig allows the Tendermint validator set to be overriden at a specific height.
+// This config only applies when the DPOS contract is not deployed.
+type OverrideValidatorsConfig struct {
+	// Height at which the validators override should be applied.
+	// If this is zero the override will never be applied.
+	Height int64
+	// Validator powers to override.
+	Validators []plugin.OverrideValidator
+}
+
 func DefaultDBBackendConfig() *DBBackendConfig {
 	return &DBBackendConfig{
 		CacheSizeMegs:   1042, //1 Gigabyte
@@ -315,6 +325,10 @@ func DefaultUserDeployerWhitelistConfig() *UserDeployerWhitelistConfig {
 	return &UserDeployerWhitelistConfig{
 		ContractEnabled: true,
 	}
+}
+
+func DefaultOverrideValidatorsConfig() *OverrideValidatorsConfig {
+	return &OverrideValidatorsConfig{}
 }
 
 //Structure for LOOM ENV
@@ -468,10 +482,9 @@ func DefaultConfig() *Config {
 	cfg.Web3 = eth.DefaultWeb3Config()
 	cfg.Geth = DefaultGethConfig()
 	cfg.DPOS = DefaultDPOSConfig()
-
 	cfg.FnConsensus = DefaultFnConsensusConfig()
-
 	cfg.Auth = auth.DefaultConfig()
+	cfg.OverrideValidators = DefaultOverrideValidatorsConfig()
 	return cfg
 }
 
@@ -853,6 +866,19 @@ EVMDebugEnabled: {{ .EVMDebugEnabled }}
 AllowNamedEvmContracts: {{ .AllowNamedEvmContracts }}
 # Set to true to disable minimum required build number check on node startup
 SkipMinBuildCheck: {{ .SkipMinBuildCheck }}
+{{- if .OverrideValidators }}
+# Override the Tendermint validator set at a specific height.
+# Only applies if DPOS contract is not deployed.
+OverrideValidators:
+  Height: {{ .OverrideValidators.Height }}
+  {{- if .OverrideValidators.Validators }}
+  Validators:
+    {{- range $i, $v := .OverrideValidators.Validators }}
+    - PubKey: "{{ $v.PubKey }}"
+      Power: {{ $v.Power }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 
 {{if .Geth -}}
 #

--- a/config/loom.example.yaml
+++ b/config/loom.example.yaml
@@ -90,3 +90,10 @@ EventStore:
   DBName: "event"
   DBBackend: "goleveldb"
 
+OverrideValidators:
+  Height: 350000
+  Validators:
+    - PubKey: "ad1a67e16fd178476bc5ec1cb6d2069de7b3d77bdd998b7176dc06964cca9f7b"
+      Power: 100
+    - PubKey: "e536f18f57a188ea74ed4eab2a5828f78a258e0fadfc09c960974e4f28fbeac6"
+      Power: 200

--- a/plugin/override_validators_manager.go
+++ b/plugin/override_validators_manager.go
@@ -1,0 +1,63 @@
+package plugin
+
+import (
+	"encoding/hex"
+
+	"github.com/pkg/errors"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+// OverrideValidatorsManager implements loomchain.ValidatorsManager interface.
+// This manager overrides the current validator set at a certain height (specified via loom.yml).
+type OverrideValidatorsManager struct {
+	height     int64
+	validators []OverrideValidator
+}
+
+type OverrideValidator struct {
+	// Hex-encoded public key identifying the validator whose power should be overriden.
+	// Would've made more sense to encode the public key as base64 but YAML handling of base64 is
+	// hilariously WTF so the keys get mangled on their way to/from loom.yml, so best to stick to
+	// plain old hex-encoding.
+	PubKey string
+	// The power specified here will override whatever power the validator has at the height this
+	// override is applied. If the override power is zero Tendermint will remove the validator from
+	// the active validator set.
+	Power int64
+}
+
+func NewOverrideValidatorsManager(height int64, validators []OverrideValidator) (*OverrideValidatorsManager, error) {
+	return &OverrideValidatorsManager{
+		height:     height,
+		validators: validators,
+	}, nil
+}
+
+func (m *OverrideValidatorsManager) BeginBlock(_ abci.RequestBeginBlock, _ int64) error {
+	return nil
+}
+
+func (m *OverrideValidatorsManager) EndBlock(req abci.RequestEndBlock) ([]abci.ValidatorUpdate, error) {
+	if req.Height != m.height {
+		return nil, nil
+	}
+
+	var validators []abci.ValidatorUpdate
+
+	for _, validator := range m.validators {
+		pubKey, err := hex.DecodeString(validator.PubKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to decode validator pubkey")
+		}
+		validators = append(validators, abci.ValidatorUpdate{
+			PubKey: abci.PubKey{
+				Data: pubKey,
+				Type: tmtypes.ABCIPubKeyTypeEd25519,
+			},
+			Power: validator.Power,
+		})
+	}
+
+	return validators, nil
+}


### PR DESCRIPTION
The override can only be applied when the DPOS contract is not deployed on the chain.