### PR TITLE
Lock down Prometheus golang client to v1.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,9 +206,13 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR) $(SSHA3_DIR)
 	cd $(PROMETHEUS_PROCFS_DIR) && git checkout master && git pull && git checkout d3b299e382e6acf1baa852560d862eca4ff643c8
 	# Lock down Prometheus golang client to v1.2.1 (newer versions use a different protobuf version)
 	git clone -q git@github.com:prometheus/client_golang $(GOPATH)/src/github.com/prometheus/client_golang
-	cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout master && git pull && git checkout v1.2.1 && git rev-parse HEAD
+	cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout master && git pull && git checkout v1.2.1
+	# prometheus/client_model is pulled by prometheus/client_golang so lock it down as well
 	git clone -q git@github.com:prometheus/client_model $(GOPATH)/src/github.com/prometheus/client_model
 	cd $(GOPATH)/src/github.com/prometheus/client_model && git checkout master && git pull && git checkout 14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016
+	# prometheus/common is pulled by prometheus/client_golang so lock it down as well
+	git clone -q git@github.com:prometheus/common $(GOPATH)/src/github.com/prometheus/common
+	cd $(GOPATH)/src/github.com/prometheus/common && git checkout master && git pull && git checkout v0.7.0
 	
 	go get \
 		golang.org/x/crypto/ed25519 \
@@ -233,8 +237,6 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR) $(SSHA3_DIR)
 		github.com/posener/wstest \
 		github.com/btcsuite/btcd
 
-	cd $(GOPATH)/src/github.com/prometheus/client_golang && git rev-parse HEAD
-	cd $(GOPATH)/src/github.com/prometheus/client_model && git rev-parse HEAD
 	# When you want to reference a different branch of go-loom change GO_LOOM_GIT_REV above
 	cd $(PLUGIN_DIR) && git checkout master && git pull && git checkout $(GO_LOOM_GIT_REV)
 	cd $(GOLANG_PROTOBUF_DIR) && git checkout v1.1.0

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR) $(SSHA3_DIR)
 	git clone -q git@github.com:prometheus/procfs $(PROMETHEUS_PROCFS_DIR)
 	cd $(PROMETHEUS_PROCFS_DIR) && git checkout master && git pull && git checkout d3b299e382e6acf1baa852560d862eca4ff643c8
 	# Lock down Prometheus golang client to v1.2.1 (newer versions use a different protobuf version)
-	git clone -q git@github.com/prometheus/client_golang $(GOPATH)/src/github.com/prometheus/client_golang
+	git clone -q git@github.com:prometheus/client_golang $(GOPATH)/src/github.com/prometheus/client_golang
 	cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout master && git pull && git checkout v1.2.1
 
 	go get \

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,9 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR) $(SSHA3_DIR)
 	# Temp workaround for https://github.com/prometheus/procfs/issues/221
 	git clone -q git@github.com:prometheus/procfs $(PROMETHEUS_PROCFS_DIR)
 	cd $(PROMETHEUS_PROCFS_DIR) && git checkout master && git pull && git checkout d3b299e382e6acf1baa852560d862eca4ff643c8
+	# Lock down Prometheus golang client to v1.2.1 (newer versions use a different protobuf version)
+	git clone -q git@github.com/prometheus/client_golang $(GOPATH)/src/github.com/prometheus/client_golang
+	cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout master && git pull && git checkout v1.2.1
 
 	go get \
 		golang.org/x/crypto/ed25519 \

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR) $(SSHA3_DIR)
 	cd $(PROMETHEUS_PROCFS_DIR) && git checkout master && git pull && git checkout d3b299e382e6acf1baa852560d862eca4ff643c8
 	# Lock down Prometheus golang client to v1.2.1 (newer versions use a different protobuf version)
 	git clone -q git@github.com:prometheus/client_golang $(GOPATH)/src/github.com/prometheus/client_golang
-	cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout master && git pull && git checkout v1.2.1
+	cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout master && git pull && git checkout v1.2.1 && git rev-parse HEAD
 
 	go get \
 		golang.org/x/crypto/ed25519 \
@@ -231,6 +231,7 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR) $(SSHA3_DIR)
 		github.com/posener/wstest \
 		github.com/btcsuite/btcd
 
+	cd $(GOPATH)/src/github.com/prometheus/client_golang && git rev-parse HEAD
 	# When you want to reference a different branch of go-loom change GO_LOOM_GIT_REV above
 	cd $(PLUGIN_DIR) && git checkout master && git pull && git checkout $(GO_LOOM_GIT_REV)
 	cd $(GOLANG_PROTOBUF_DIR) && git checkout v1.1.0

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,9 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR) $(SSHA3_DIR)
 	# Lock down Prometheus golang client to v1.2.1 (newer versions use a different protobuf version)
 	git clone -q git@github.com:prometheus/client_golang $(GOPATH)/src/github.com/prometheus/client_golang
 	cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout master && git pull && git checkout v1.2.1 && git rev-parse HEAD
-
+	git clone -q git@github.com:prometheus/client_model $(GOPATH)/src/github.com/prometheus/client_model
+	cd $(GOPATH)/src/github.com/prometheus/client_model && git checkout master && git pull && git checkout 14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016
+	
 	go get \
 		golang.org/x/crypto/ed25519 \
 		google.golang.org/grpc \
@@ -232,6 +234,7 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR) $(SSHA3_DIR)
 		github.com/btcsuite/btcd
 
 	cd $(GOPATH)/src/github.com/prometheus/client_golang && git rev-parse HEAD
+	cd $(GOPATH)/src/github.com/prometheus/client_model && git rev-parse HEAD
 	# When you want to reference a different branch of go-loom change GO_LOOM_GIT_REV above
 	cd $(PLUGIN_DIR) && git checkout master && git pull && git checkout $(GO_LOOM_GIT_REV)
 	cd $(GOLANG_PROTOBUF_DIR) && git checkout v1.1.0


### PR DESCRIPTION
Newer versions use a different protobuf version that's not compatible with ours.