### PR TITLE
Eliminate VersionedKVStore.GetSnapshot()

### DIFF
--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -209,13 +209,6 @@ func (s *IAVLStore) Prune() error {
 	return nil
 }
 
-func (s *IAVLStore) GetSnapshot() Snapshot {
-	// This isn't an actual snapshot obviously, and never will be, but lets pretend...
-	return &iavlStoreSnapshot{
-		IAVLStore: s,
-	}
-}
-
 func (s *IAVLStore) GetSnapshotAt(version int64) (Snapshot, error) {
 	panic("not implemented")
 }

--- a/store/logstore.go
+++ b/store/logstore.go
@@ -126,10 +126,6 @@ func (s *LogStore) Prune() error {
 	return s.store.Prune()
 }
 
-func (s *LogStore) GetSnapshot() Snapshot {
-	return s.store.GetSnapshot()
-}
-
 func (s *LogStore) GetSnapshotAt(version int64) (Snapshot, error) {
 	return s.store.GetSnapshotAt(version)
 }

--- a/store/memstore.go
+++ b/store/memstore.go
@@ -76,10 +76,6 @@ func (m *MemStore) Prune() error {
 	return nil
 }
 
-func (m *MemStore) GetSnapshot() Snapshot {
-	panic("not implemented")
-}
-
 func (m *MemStore) GetSnapshotAt(version int64) (Snapshot, error) {
 	panic("not implemented")
 }

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -56,7 +56,7 @@ func init() {
 			Namespace:  "loomchain",
 			Subsystem:  "multi_writer_appstore",
 			Name:       "get_snapshot",
-			Help:       "How long MultiWriterAppStore.GetSnapshot() took to execute (in seconds)",
+			Help:       "How long MultiWriterAppStore.GetSnapshotAt() took to execute (in seconds)",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{},
 	)
@@ -270,14 +270,6 @@ func (s *MultiWriterAppStore) setLastSavedTreeToVersion(version int64) error {
 
 func (s *MultiWriterAppStore) Prune() error {
 	return s.appStore.Prune()
-}
-
-func (s *MultiWriterAppStore) GetSnapshot() Snapshot {
-	snapshot, err := s.GetSnapshotAt(0)
-	if err != nil {
-		panic(err)
-	}
-	return snapshot
 }
 
 func (s *MultiWriterAppStore) GetSnapshotAt(version int64) (Snapshot, error) {

--- a/store/multi_writer_app_store_test.go
+++ b/store/multi_writer_app_store_test.go
@@ -110,7 +110,8 @@ func (m *MultiWriterAppStoreTestSuite) TestMultiWriterAppStoreSnapshotFlushInter
 	store.Set([]byte("test2"), []byte("test2v2"))
 
 	// this snapshot is from memory
-	snapshotv1 := store.GetSnapshot()
+	snapshotv1, err := store.GetSnapshotAt(0)
+	require.NoError(err)
 	require.Equal([]byte("test1"), snapshotv1.Get([]byte("test1")))
 	require.Equal([]byte("test2"), snapshotv1.Get([]byte("test2")))
 
@@ -119,7 +120,8 @@ func (m *MultiWriterAppStoreTestSuite) TestMultiWriterAppStoreSnapshotFlushInter
 	require.NoError(err)
 
 	// get snapshotv2
-	snapshotv2 := store.GetSnapshot()
+	snapshotv2, err := store.GetSnapshotAt(0)
+	require.NoError(err)
 	require.Equal([]byte("test1v2"), snapshotv2.Get([]byte("test1")))
 	require.Equal([]byte("test2v2"), snapshotv2.Get([]byte("test2")))
 
@@ -250,6 +252,42 @@ func (m *MultiWriterAppStoreTestSuite) TestIAVLRangeWithlimit() {
 	// only 4 VM keys will be returned due to the quirkiness of RangeWithLimit
 	rangeData := iavlStore.RangeWithLimit([]byte("vm"), 5)
 	require.Equal(4, len(rangeData))
+}
+
+func (m *MultiWriterAppStoreTestSuite) TestStoreRange() {
+	require := m.Require()
+	mws, err := mockMultiWriterStore(0, 0)
+	require.NoError(err)
+	prefixes, entries := populateStore(mws)
+	verifyRange(require, "MultiWriterAppStore", mws, prefixes, entries)
+	_, _, err = mws.SaveVersion()
+	require.NoError(err)
+	verifyRange(require, "MultiWriterAppStore", mws, prefixes, entries)
+}
+
+func (m *MultiWriterAppStoreTestSuite) TestSnapshotRange() {
+	require := m.Require()
+	mws, err := mockMultiWriterStore(0, 0)
+	require.NoError(err)
+	prefixes, entries := populateStore(mws)
+	verifyRange(require, "MultiWriterAppStore", mws, prefixes, entries)
+	mws.SaveVersion()
+
+	// snapshot should see all the data that was saved to disk
+	func() {
+		snap, err := mws.GetSnapshotAt(0)
+		require.NoError(err)
+		defer snap.Release()
+
+		verifyRange(require, "MultiWriterAppStoreSnapshot", snap, prefixes, entries)
+	}()
+}
+
+func (m *MultiWriterAppStoreTestSuite) TestConcurrentSnapshots() {
+	require := m.Require()
+	mws, err := mockMultiWriterStore(0, 0)
+	require.NoError(err)
+	verifyConcurrentSnapshots(require, mws)
 }
 
 func mockMultiWriterStore(appStoreFlushInterval, evmStoreFlushInterval int64) (*MultiWriterAppStore, error) {

--- a/store/store.go
+++ b/store/store.go
@@ -53,7 +53,6 @@ type VersionedKVStore interface {
 	SaveVersion() ([]byte, int64, error)
 	// Delete old version of the store
 	Prune() error
-	GetSnapshot() Snapshot
 	GetSnapshotAt(version int64) (Snapshot, error)
 }
 

--- a/store/versioned_cachingstore_test.go
+++ b/store/versioned_cachingstore_test.go
@@ -3,153 +3,83 @@ package store
 import (
 	"testing"
 
-	"github.com/loomnetwork/go-loom/plugin"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type MockStore struct {
-	storage map[string][]byte
-	version int64
-}
-
-func NewMockStore() *MockStore {
-	return &MockStore{
-		storage: make(map[string][]byte),
-		version: 0,
-	}
-}
-
-func (m *MockStore) Get(key []byte) []byte {
-	return m.storage[string(key)]
-}
-
-func (m *MockStore) Has(key []byte) bool {
-	return m.storage[string(key)] != nil
-}
-
-func (m *MockStore) Set(key []byte, value []byte) {
-	m.storage[string(key)] = value
-}
-
-func (m *MockStore) Delete(key []byte) {
-	delete(m.storage, string(key))
-}
-
-func (m *MockStore) Range(prefix []byte) plugin.RangeData {
-	return nil
-}
-
-func (m *MockStore) Hash() []byte {
-	return nil
-}
-
-func (m *MockStore) Version() int64 {
-	return m.version
-}
-
-func (m *MockStore) SaveVersion() ([]byte, int64, error) {
-	m.version = m.version + 1
-	return nil, m.version, nil
-}
-
-func (m *MockStore) Prune() error {
-	return nil
-}
-
-func (m *MockStore) GetSnapshot() Snapshot {
-	snapshotStore := make(map[string][]byte)
-	for k, v := range m.storage {
-		snapshotStore[k] = v
-	}
-	return &mockStoreSnapshot{
-		MockStore: &MockStore{
-			storage: snapshotStore,
-		},
-	}
-}
-
-func (m *MockStore) GetSnapshotAt(version int64) (Snapshot, error) {
-	panic("not implemented")
-}
-
-type mockStoreSnapshot struct {
-	*MockStore
-}
-
-func (s *mockStoreSnapshot) Release() {
-	// noop
-}
 
 func TestCachingStoreVersion(t *testing.T) {
 	defaultConfig := DefaultCachingStoreConfig()
 	defaultConfig.CachingEnabled = true
 
-	mockStore := NewMockStore()
-
-	versionedStore, err := NewVersionedCachingStore(mockStore, defaultConfig, mockStore.Version())
-	cachingStore := versionedStore.(*versionedCachingStore)
-
+	mockStore, err := mockMultiWriterStore(0, 0)
 	require.NoError(t, err)
 
 	key1 := []byte("key1")
 	key2 := []byte("key2")
 	key3 := []byte("key3")
 
-	mockStore.Set(key1, []byte("value1"))
-	mockStore.Set(key2, []byte("value2"))
-	mockStore.Set(key3, []byte("value3"))
+	versionedStore, err := NewVersionedCachingStore(mockStore, defaultConfig, mockStore.Version())
+	require.NoError(t, err)
 
-	snapshotv0 := cachingStore.GetSnapshot()
+	versionedStore.Set(key1, []byte("value1"))
+	versionedStore.Set(key2, []byte("value2"))
+	versionedStore.Set(key3, []byte("value3"))
 
-	// cachingStoreSnapshot will cache key1 in memory as version 0
+	snapshotv0, err := versionedStore.GetSnapshotAt(0)
+	require.NoError(t, err)
+
+	// snapshot should be empty because values haven't been persisted to the underlying store
 	cachedValue := snapshotv0.Get(key1)
-	assert.Equal(t, "value1", string(cachedValue), "cachingstore read needs to be consistent with underlying store")
-	// Set data directly without update the cache, caching store should return old data
-	mockStore.Set(key2, []byte("value2"))
-	cachedValue = snapshotv0.Get([]byte("key1"))
-	assert.Equal(t, "value1", string(cachedValue), "cachingstore need to fetch key directly from the backing store")
+	assert.Equal(t, "", string(cachedValue), "snapshot should be empty")
 
-	// save to bump up version
-	_, version, _ := cachingStore.SaveVersion()
+	_, version, _ := versionedStore.SaveVersion()
 	assert.Equal(t, int64(1), version, "version must be updated to 1")
-	// save data into version 1
-	cachingStore.Set(key2, []byte("newvalue2"))
-	cachingStore.Set(key3, []byte("newvalue3"))
-	snapshotv1 := cachingStore.GetSnapshot()
-	cachedValue = snapshotv1.Get(key2)
-	assert.Equal(t, "newvalue2", string(cachedValue), "snapshotv1 should get correct value")
-	cachedValue = snapshotv1.Get(key1)
-	assert.Equal(t, "value1", string(cachedValue), "snapshotv1 should get correct value")
 
-	// snapshotv0 should not get updated
+	// previously obtained snapshot should still be empty since it shouldn't be affected by changes
+	// to the underlying store
 	cachedValue = snapshotv0.Get(key1)
-	assert.Equal(t, "value1", string(cachedValue), "snapshotv0 should get correct value")
-	cachedValue = snapshotv0.Get(key2)
-	assert.Equal(t, "value2", string(cachedValue), "snapshotv0 should get correct value")
-	cachedValue = snapshotv0.Get(key3)
-	assert.Equal(t, "value3", string(cachedValue), "snapshotv0 should get correct value")
+	assert.Equal(t, "", string(cachedValue), "snapshot should be empty")
 
-	cacheSnapshot := snapshotv0.(*versionedCachingStoreSnapshot)
-	cacheSnapshot.cache.Delete(key1, 1) // evict a key
-	cachedValue = snapshotv0.Get(key1)  // call an evicted key
-	assert.Equal(t, "value1", string(cachedValue), "snapshotv1 should get correct value, fetching from underlying snapshot")
+	snapshotv1, err := versionedStore.GetSnapshotAt(0)
+	require.NoError(t, err)
+
+	// new snapshot should contain the previously persisted values
+	cachedValue = snapshotv1.Get(key1)
+	assert.Equal(t, "value1", string(cachedValue), "value should match the one persisted to the underlying store")
+	// existing snapshot should be unaffected by unpersisted changes to the store
+	versionedStore.Set(key1, []byte("newvalue1"))
+	cachedValue = snapshotv1.Get(key1)
+	assert.Equal(t, "value1", string(cachedValue), "snapshot should not be affected by changes to the underlying store")
 
 	// save to bump up version
-	_, version, _ = cachingStore.SaveVersion()
+	_, version, _ = versionedStore.SaveVersion()
 	assert.Equal(t, int64(2), version, "version must be updated to 2")
-	snapshotv2 := cachingStore.GetSnapshot()
-	cachedValue = snapshotv2.Get(key1)
-	assert.Equal(t, "value1", string(cachedValue), "snapshotv2 should get the value from cache")
-	cachedValue = snapshotv2.Get(key2)
-	assert.Equal(t, "newvalue2", string(cachedValue), "snapshotv2 should get the value from cache")
-	cachedValue = snapshotv2.Get(key3)
-	assert.Equal(t, "newvalue3", string(cachedValue), "snapshotv2 should get the value from cache")
 
-	// evict data from key table
-	cacheSnapshot = snapshotv1.(*versionedCachingStoreSnapshot)
-	cacheSnapshot.cache.cache.Delete(string(key1)) // evict a key table
+	// existing snapshot should be unaffected by persisted changes to the store
+	cachedValue = snapshotv1.Get(key1)
+	assert.Equal(t, "value1", string(cachedValue), "snapshot should not be affected by changes to the uderlying store")
+
+	// save data into version 3
+	versionedStore.Set(key2, []byte("newvalue2"))
+	versionedStore.Set(key3, []byte("newvalue3"))
+
+	_, version, _ = versionedStore.SaveVersion()
+	assert.Equal(t, int64(3), version, "version must be updated to 3")
+
+	snapshotv2, err := versionedStore.GetSnapshotAt(0)
+	require.NoError(t, err)
 	cachedValue = snapshotv2.Get(key1)
-	assert.Equal(t, "value1", string(cachedValue), "snapshotv2 should get the value from cache")
+	assert.Equal(t, "newvalue1", string(cachedValue))
+	cachedValue = snapshotv2.Get(key2)
+	assert.Equal(t, "newvalue2", string(cachedValue))
+	cachedValue = snapshotv2.Get(key3)
+	assert.Equal(t, "newvalue3", string(cachedValue))
+
+	// snapshotv1 should remain unchanged
+	cachedValue = snapshotv1.Get(key1)
+	assert.Equal(t, "value1", string(cachedValue))
+	cachedValue = snapshotv1.Get(key2)
+	assert.Equal(t, "value2", string(cachedValue))
+	cachedValue = snapshotv1.Get(key3)
+	assert.Equal(t, "value3", string(cachedValue))
 }


### PR DESCRIPTION
This is a follow up to PR #1532, cleans up a couple of issues left over from that PR:
- Eliminate GetSnapshot() from all the stores, only GetSnapshotAt() is used now.
- Fix VersionedCachingStore.GetSnapshotAt() to be atomic.

Also cleaned up the tests a little bit so they test using real stores instead of buggy mock stores.