### PR TITLE
Refactor the way the on-chain flush interval override is applied

### DIFF
--- a/app.go
+++ b/app.go
@@ -857,7 +857,10 @@ func (a *Application) Commit() abci.ResponseCommit {
 		}
 	}
 
-	appHash, _, err := a.Store.SaveVersion()
+	storeOpts := store.VersionedKVStoreSaveOptions{
+		FlushInterval: int64(a.config.GetAppStore().GetIAVLFlushInterval()),
+	}
+	appHash, _, err := a.Store.SaveVersion(&storeOpts)
 	if err != nil {
 		panic(err)
 	}

--- a/store/evmstore_test.go
+++ b/store/evmstore_test.go
@@ -39,12 +39,12 @@ func (t *EvmStoreTestSuite) TestEvmStoreRangeAndCommit() {
 	dataRange := evmStore.Range(nil)
 	require.Equal(104, len(dataRange))
 	require.Equal(false, evmStore.Has([]byte("hello2")))
-	evmStore.Commit(1)
+	evmStore.Commit(1, 0)
 	evmStore.Set([]byte("SSSSS"), []byte("SSSSS"))
 	evmStore.Set([]byte("vvvvv"), []byte("vvv"))
 	dataRange = evmStore.Range(nil)
 	require.Equal(106+1, len(dataRange)) // +1 default evm root key
-	evmStore.Commit(2)
+	evmStore.Commit(2, 0)
 	evmStore.Set([]byte("SSSSS"), []byte("S1"))
 	ret := evmStore.Get([]byte("SSSSS"))
 	require.Equal(0, bytes.Compare(ret, []byte("S1")))
@@ -52,7 +52,7 @@ func (t *EvmStoreTestSuite) TestEvmStoreRangeAndCommit() {
 	evmStore.Delete([]byte("hello1"))
 	dataRange = evmStore.Range(nil)
 	require.Equal(104+1, len(dataRange)) // +1 default evm root key
-	evmStore.Commit(3)
+	evmStore.Commit(3, 0)
 	evmStore.Delete([]byte("SSSSS"))
 	evmStore.Delete([]byte("hello1"))
 	dataRange = evmStore.Range(nil)
@@ -120,14 +120,14 @@ func (t *EvmStoreTestSuite) TestEvmStoreRangePrefix() {
 	dataRange = evmStore.Range([]byte("vv"))
 	require.Equal(101, len(dataRange))
 
-	evmStore.Commit(1)
+	evmStore.Commit(1, 0)
 	dataRange = evmStore.Range([]byte("Key"))
 	require.Equal(101, len(dataRange))
 
 	dataRange = evmStore.Range([]byte("vv"))
 	require.Equal(101, len(dataRange))
 
-	evmStore.Commit(2)
+	evmStore.Commit(2, 0)
 	evmStore.Delete(util.PrefixKey([]byte("vv"), []byte(fmt.Sprintf("%d", 10))))
 	dataRange = evmStore.Range([]byte("vv"))
 	require.Equal(100, len(dataRange))

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -140,7 +140,7 @@ func (s *IAVLStore) Version() int64 {
 	return s.tree.Version()
 }
 
-func (s *IAVLStore) SaveVersion() ([]byte, int64, error) {
+func (s *IAVLStore) SaveVersion(opts *VersionedKVStoreSaveOptions) ([]byte, int64, error) {
 	var err error
 	defer func(begin time.Time) {
 		iavlSaveVersionDuration.Observe(time.Since(begin).Seconds())
@@ -149,16 +149,8 @@ func (s *IAVLStore) SaveVersion() ([]byte, int64, error) {
 	oldVersion := s.Version()
 	flushInterval := s.flushInterval
 
-	// TODO: Rather than loading the on-chain config here the flush interval override should be passed
-	//       in as a parameter to SaveVersion().
-	if flushInterval == 0 {
-		cfg, err := LoadOnChainConfig(s)
-		if err != nil {
-			return nil, 0, errors.Wrap(err, "failed to load on-chain config")
-		}
-		if cfg.GetAppStore().GetIAVLFlushInterval() != 0 {
-			flushInterval = int64(cfg.GetAppStore().GetIAVLFlushInterval())
-		}
+	if flushInterval == 0 && opts != nil {
+		flushInterval = opts.FlushInterval
 	} else if flushInterval == -1 {
 		flushInterval = 0
 	}

--- a/store/iavlstore_test.go
+++ b/store/iavlstore_test.go
@@ -44,12 +44,12 @@ func testOrphans(t *testing.T, store *IAVLStore, diskDb db.DB, flushInterval int
 	store.Set([]byte("k1"), []byte("Fred"))
 	store.Set([]byte("k2"), []byte("John"))
 	for i := 0; i < int(flushInterval-1); i++ {
-		_, _, err := store.SaveVersion()
+		_, _, err := store.SaveVersion(nil)
 		require.NoError(t, err)
 	}
 	store.Set([]byte("k2"), []byte("Bob"))
 	store.Set([]byte("k3"), []byte("Harry"))
-	_, _, err := store.SaveVersion() // save to disk
+	_, _, err := store.SaveVersion(nil) // save to disk
 
 	require.NoError(t, err)
 
@@ -57,13 +57,13 @@ func testOrphans(t *testing.T, store *IAVLStore, diskDb db.DB, flushInterval int
 	store.Set([]byte("k2"), []byte("Sally"))
 	store.Delete([]byte("k3"))
 	for i := 0; i < int(flushInterval)-1; i++ {
-		_, _, err := store.SaveVersion()
+		_, _, err := store.SaveVersion(nil)
 		require.NoError(t, err)
 	}
 
 	store.Set([]byte("k2"), []byte("Jim"))
 	for i := 0; i < 2*int(flushInterval); i++ {
-		_, _, err := store.SaveVersion() // save to disk
+		_, _, err := store.SaveVersion(nil) // save to disk
 		require.NoError(t, err)
 	}
 	lastVersion := 3 * flushInterval
@@ -192,7 +192,7 @@ func testMaxVersions(t *testing.T) {
 func executeBlocks(t require.TestingT, blocks []*iavl.Program, store IAVLStore) {
 	for _, block := range blocks {
 		require.NoError(t, block.Execute(store.tree))
-		_, _, err := store.SaveVersion()
+		_, _, err := store.SaveVersion(nil)
 		require.NoError(t, err)
 		require.NoError(t, store.Prune())
 	}

--- a/store/logstore.go
+++ b/store/logstore.go
@@ -114,8 +114,8 @@ func (s *LogStore) Version() int64 {
 	return version
 }
 
-func (s *LogStore) SaveVersion() ([]byte, int64, error) {
-	vByte, vInt, err := s.store.SaveVersion()
+func (s *LogStore) SaveVersion(opts *VersionedKVStoreSaveOptions) ([]byte, int64, error) {
+	vByte, vInt, err := s.store.SaveVersion(opts)
 	if s.params.LogSaveVersion {
 		s.logger.Println("SaveVersion", string(vByte), " int ", vInt, " err ", err)
 	}

--- a/store/memstore.go
+++ b/store/memstore.go
@@ -68,7 +68,7 @@ func (m *MemStore) Version() int64 {
 	return 1
 }
 
-func (m *MemStore) SaveVersion() ([]byte, int64, error) {
+func (m *MemStore) SaveVersion(opts *VersionedKVStoreSaveOptions) ([]byte, int64, error) {
 	return m.Hash(), m.Version(), nil
 }
 

--- a/store/multi_writer_app_store_test.go
+++ b/store/multi_writer_app_store_test.go
@@ -102,7 +102,7 @@ func (m *MultiWriterAppStoreTestSuite) TestMultiWriterAppStoreSnapshotFlushInter
 	// the first version go to memory
 	store.Set([]byte("test1"), []byte("test1"))
 	store.Set([]byte("test2"), []byte("test2"))
-	_, version, err := store.SaveVersion()
+	_, version, err := store.SaveVersion(nil)
 	require.NoError(err)
 	require.Equal(int64(1), version)
 
@@ -116,7 +116,7 @@ func (m *MultiWriterAppStoreTestSuite) TestMultiWriterAppStoreSnapshotFlushInter
 	require.Equal([]byte("test2"), snapshotv1.Get([]byte("test2")))
 
 	// this flushes all data to disk
-	_, _, err = store.SaveVersion()
+	_, _, err = store.SaveVersion(nil)
 	require.NoError(err)
 
 	// get snapshotv2
@@ -147,7 +147,7 @@ func (m *MultiWriterAppStoreTestSuite) TestMultiWriterAppStoreSaveVersion() {
 	store.Set(vmPrefixKey("dd"), []byte("yes"))
 	store.Set(vmPrefixKey("vv"), []byte("yes"))
 
-	_, version, err := store.SaveVersion()
+	_, version, err := store.SaveVersion(nil)
 	require.Equal(int64(1), version)
 	require.NoError(err)
 
@@ -159,7 +159,7 @@ func (m *MultiWriterAppStoreTestSuite) TestMultiWriterAppStoreSaveVersion() {
 	dataRange := store.Range(vmPrefix)
 	require.Equal(6+1, len(dataRange)) // +1 is for the evm root that written by the EVM store itself
 
-	_, version, err = store.SaveVersion()
+	_, version, err = store.SaveVersion(nil)
 	require.Equal(int64(2), version)
 	require.NoError(err)
 
@@ -182,7 +182,7 @@ func (m *MultiWriterAppStoreTestSuite) TestPruningEvmKeys() {
 	iavlStore.Set(vmPrefixKey("gg"), []byte("world"))
 	iavlStore.Set(vmPrefixKey("dd"), []byte("yes"))
 	iavlStore.Set(vmPrefixKey("vv"), []byte("yes"))
-	_, version, err := store.SaveVersion()
+	_, version, err := store.SaveVersion(nil)
 	require.NoError(err)
 	require.Equal(int64(1), version)
 	require.Equal(version, iavlStore.Version())
@@ -204,7 +204,7 @@ func (m *MultiWriterAppStoreTestSuite) TestPruningEvmKeys() {
 
 	// prune VM keys
 	// NOTE: only 3 vm keys will actually get pruned due to the quirkiness of RangeWithLimit
-	_, version, err = newStore.SaveVersion()
+	_, version, err = newStore.SaveVersion(nil)
 	require.Equal(int64(2), version)
 	require.NoError(err)
 
@@ -214,7 +214,7 @@ func (m *MultiWriterAppStoreTestSuite) TestPruningEvmKeys() {
 
 	// prune VM keys
 	// NOTE: once again only 3 vm keys will get pruned
-	_, version, err = newStore.SaveVersion()
+	_, version, err = newStore.SaveVersion(nil)
 	require.Equal(int64(3), version)
 	require.NoError(err)
 
@@ -223,7 +223,7 @@ func (m *MultiWriterAppStoreTestSuite) TestPruningEvmKeys() {
 	require.Equal(1, len(rangeData))
 
 	// prune VM keys
-	_, version, err = newStore.SaveVersion()
+	_, version, err = newStore.SaveVersion(nil)
 	require.Equal(int64(4), version)
 	require.NoError(err)
 
@@ -246,7 +246,7 @@ func (m *MultiWriterAppStoreTestSuite) TestIAVLRangeWithlimit() {
 	iavlStore.Set(vmPrefixKey("gg"), []byte("world"))
 	iavlStore.Set(vmPrefixKey("dd"), []byte("yes"))
 	iavlStore.Set(vmPrefixKey("vv"), []byte("yes"))
-	_, _, err = store.SaveVersion()
+	_, _, err = store.SaveVersion(nil)
 	require.NoError(err)
 
 	// only 4 VM keys will be returned due to the quirkiness of RangeWithLimit
@@ -260,7 +260,7 @@ func (m *MultiWriterAppStoreTestSuite) TestStoreRange() {
 	require.NoError(err)
 	prefixes, entries := populateStore(mws)
 	verifyRange(require, "MultiWriterAppStore", mws, prefixes, entries)
-	_, _, err = mws.SaveVersion()
+	_, _, err = mws.SaveVersion(nil)
 	require.NoError(err)
 	verifyRange(require, "MultiWriterAppStore", mws, prefixes, entries)
 }
@@ -271,7 +271,7 @@ func (m *MultiWriterAppStoreTestSuite) TestSnapshotRange() {
 	require.NoError(err)
 	prefixes, entries := populateStore(mws)
 	verifyRange(require, "MultiWriterAppStore", mws, prefixes, entries)
-	mws.SaveVersion()
+	mws.SaveVersion(nil)
 
 	// snapshot should see all the data that was saved to disk
 	func() {

--- a/store/store.go
+++ b/store/store.go
@@ -46,11 +46,18 @@ type Snapshot interface {
 	Release()
 }
 
+// VersionedKVStoreSaveOptions contains options that can be passed into VersionedKVStore.SaveVersion()
+type VersionedKVStoreSaveOptions struct {
+	// Overrides the interval at which versions are flushed to disk, not all stores may support this.
+	FlushInterval int64
+}
+
 type VersionedKVStore interface {
 	KVStore
 	Hash() []byte
 	Version() int64
-	SaveVersion() ([]byte, int64, error)
+	// Saves changes made since the last version, the options may be nil
+	SaveVersion(options *VersionedKVStoreSaveOptions) ([]byte, int64, error)
 	// Delete old version of the store
 	Prune() error
 	GetSnapshotAt(version int64) (Snapshot, error)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -306,7 +306,7 @@ func (ts *StoreTestSuite) TestStoreRange() {
 	require := ts.Require()
 	prefixes, entries := populateStore(ts.store)
 	verifyRange(require, ts.StoreName, ts.store, prefixes, entries)
-	_, _, err := ts.store.SaveVersion()
+	_, _, err := ts.store.SaveVersion(nil)
 	require.NoError(err)
 	verifyRange(require, ts.StoreName, ts.store, prefixes, entries)
 }
@@ -324,11 +324,11 @@ func verifyConcurrentSnapshots(require *require.Assertions, s VersionedKVStore) 
 		for i := 0; i < numOps; i++ {
 			s.Set([]byte(fmt.Sprintf("key/%d", i)), []byte(fmt.Sprintf("value/%d", i)))
 			if i%10 == 0 {
-				_, _, err := s.SaveVersion()
+				_, _, err := s.SaveVersion(nil)
 				require.NoError(err)
 			}
 		}
-		_, _, err := s.SaveVersion()
+		_, _, err := s.SaveVersion(nil)
 		require.NoError(err)
 	}()
 	wg.Wait()
@@ -432,7 +432,7 @@ func TestIAVLStoreKeepsAllVersionsIfMaxVersionsIsZero(t *testing.T) {
 
 	for _, kv := range values {
 		store.Set(kv.key, kv.val)
-		_, _, err := store.SaveVersion()
+		_, _, err := store.SaveVersion(nil)
 		require.NoError(t, err)
 	}
 

--- a/store/versioned_cachingstore.go
+++ b/store/versioned_cachingstore.go
@@ -360,8 +360,8 @@ func (c *versionedCachingStore) Set(key, val []byte) {
 	c.VersionedKVStore.Set(key, val)
 }
 
-func (c *versionedCachingStore) SaveVersion() ([]byte, int64, error) {
-	hash, version, err := c.VersionedKVStore.SaveVersion()
+func (c *versionedCachingStore) SaveVersion(opts *VersionedKVStoreSaveOptions) ([]byte, int64, error) {
+	hash, version, err := c.VersionedKVStore.SaveVersion(opts)
 	if err == nil {
 		if err = c.cache.Set(rootKey, GetEVMRootFromAppStore(c.VersionedKVStore), version); err != nil {
 			// Only log error and dont error out

--- a/store/versioned_cachingstore_test.go
+++ b/store/versioned_cachingstore_test.go
@@ -32,7 +32,7 @@ func TestCachingStoreVersion(t *testing.T) {
 	cachedValue := snapshotv0.Get(key1)
 	assert.Equal(t, "", string(cachedValue), "snapshot should be empty")
 
-	_, version, _ := versionedStore.SaveVersion()
+	_, version, _ := versionedStore.SaveVersion(nil)
 	assert.Equal(t, int64(1), version, "version must be updated to 1")
 
 	// previously obtained snapshot should still be empty since it shouldn't be affected by changes
@@ -52,7 +52,7 @@ func TestCachingStoreVersion(t *testing.T) {
 	assert.Equal(t, "value1", string(cachedValue), "snapshot should not be affected by changes to the underlying store")
 
 	// save to bump up version
-	_, version, _ = versionedStore.SaveVersion()
+	_, version, _ = versionedStore.SaveVersion(nil)
 	assert.Equal(t, int64(2), version, "version must be updated to 2")
 
 	// existing snapshot should be unaffected by persisted changes to the store
@@ -63,7 +63,7 @@ func TestCachingStoreVersion(t *testing.T) {
 	versionedStore.Set(key2, []byte("newvalue2"))
 	versionedStore.Set(key3, []byte("newvalue3"))
 
-	_, version, _ = versionedStore.SaveVersion()
+	_, version, _ = versionedStore.SaveVersion(nil)
 	assert.Equal(t, int64(3), version, "version must be updated to 3")
 
 	snapshotv2, err := versionedStore.GetSnapshotAt(0)


### PR DESCRIPTION
There was a bug in `EvmStore.Commit()` where it attempted to load the on-chain config from `evm.db`, but that's not where the on-chain config gets persisted to - it's persisted to `app.db`. This meant that the
flush interval specified in the on-chain config did not override the one specified in the `EvmStore` section in `loom.yml` as was originally intended.