### PR TITLE
Cleanup MultiWriterAppStore

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -61,7 +61,7 @@ func mockMultiWriterStore(flushInterval int64) (*store.MultiWriterAppStore, erro
 	}
 	memDb, _ = db.LoadMemDB()
 	evmStore := store.NewEvmStore(memDb, 100, 0)
-	multiWriterStore, err := store.NewMultiWriterAppStore(iavlStore, evmStore, false)
+	multiWriterStore, err := store.NewMultiWriterAppStore(iavlStore, evmStore)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/loom/db/evm.go
+++ b/cmd/loom/db/evm.go
@@ -53,7 +53,7 @@ func newDumpEVMStateFromEvmDB() *cobra.Command {
 
 			fmt.Printf("version: %d, root: %x\n", version, root)
 
-			srcStateDB := gstate.NewDatabase(store.NewLoomEthDB(evmStore))
+			srcStateDB := gstate.NewDatabase(store.NewLoomEthDB(evmDB))
 			srcStateDBTrie, err := srcStateDB.OpenTrie(evmRoot)
 			if err != nil {
 				fmt.Printf("cannot open trie, %s\n", evmRoot.Hex())

--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -646,7 +646,7 @@ func loadAppStore(
 		if err != nil {
 			return nil, nil, err
 		}
-		appStore, err = store.NewMultiWriterAppStore(iavlStore, evmStore, cfg.AppStore.SaveEVMStateToIAVL)
+		appStore, err = store.NewMultiWriterAppStore(iavlStore, evmStore)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -747,9 +747,6 @@ AppStore:
   PruneInterval: {{ .AppStore.PruneInterval }}
   # Number of versions to prune at a time.
   PruneBatchSize: {{ .AppStore.PruneBatchSize }}
-  # If true the app store will write EVM state to both IAVLStore and EvmStore
-  # This config works with AppStore Version 3 (MultiWriterAppStore) only
-  SaveEVMStateToIAVL: {{ .AppStore.SaveEVMStateToIAVL }}
   # Specifies the number of IAVL tree versions that should be kept in memory before writing a new
   # version to disk.
   # If set to zero every version will be written to disk unless overridden via the on-chain config.

--- a/e2e/chainconfig-loom.yaml
+++ b/e2e/chainconfig-loom.yaml
@@ -6,6 +6,5 @@ ContractLogLevel: "debug"
 LoomLogLevel: "debug"
 AppStore:
   Version: 3
-  SaveEVMStateToIAVL: false
 CachingStore:
   CachingEnabled: true

--- a/e2e/chainconfig-routine-loom.yaml
+++ b/e2e/chainconfig-routine-loom.yaml
@@ -8,6 +8,5 @@ ContractLogLevel: "debug"
 LoomLogLevel: "debug"
 AppStore:
   Version: 3
-  SaveEVMStateToIAVL: false
 CachingStore:
   CachingEnabled: true

--- a/e2e/loom-3-loom.yaml
+++ b/e2e/loom-3-loom.yaml
@@ -6,7 +6,6 @@ ContractLogLevel: "debug"
 LoomLogLevel: "debug"
 AppStore:
   Version: 3
-  SaveEVMStateToIAVL: false
 CachingStoreConfig:
   CachingEnabled: true
 

--- a/e2e/loom-4-loom.yaml
+++ b/e2e/loom-4-loom.yaml
@@ -6,7 +6,6 @@ ContractLogLevel: "debug"
 LoomLogLevel: "debug"
 AppStore:
   Version: 3
-  SaveEVMStateToIAVL: false
 CachingStoreConfig:
   CachingEnabled: true
 

--- a/e2e/loom-5-loom.yaml
+++ b/e2e/loom-5-loom.yaml
@@ -7,6 +7,5 @@ ContractLogLevel: "debug"
 LoomLogLevel: "debug"
 AppStore:
   Version: 3
-  SaveEVMStateToIAVL: false
 CachingStoreConfig:
   CachingEnabled: true

--- a/store/config.go
+++ b/store/config.go
@@ -12,8 +12,7 @@ type AppStoreConfig struct {
 	PruneInterval int64
 	// Number of versions to prune at a time.
 	PruneBatchSize int64
-	// If true the app store will write EVM state to both IAVLStore and EvmStore
-	// This config works with AppStore Version 3 (MultiWriterAppStore) only
+	// Obsolete and no longer used
 	SaveEVMStateToIAVL bool
 	// Specifies the number of IAVL tree versions that should be kept in memory before writing a new
 	// version to disk.

--- a/store/evmstore.go
+++ b/store/evmstore.go
@@ -200,14 +200,3 @@ func (s *EvmStore) GetRootAt(version int64) ([]byte, int64) {
 	}
 	return s.getLastSavedRoot(version)
 }
-
-/*
-func remove(keys []string, key string) []string {
-	for i, value := range keys {
-		if value == key {
-			return append(keys[:i], keys[i+1:]...)
-		}
-	}
-	return keys
-}
-*/

--- a/store/evmstore_test.go
+++ b/store/evmstore_test.go
@@ -2,10 +2,8 @@ package store
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
-	"github.com/loomnetwork/go-loom/util"
 	"github.com/loomnetwork/loomchain/db"
 	"github.com/stretchr/testify/suite"
 )
@@ -19,118 +17,6 @@ func (t *EvmStoreTestSuite) SetupTest() {
 
 func TestEvmStoreTestSuite(t *testing.T) {
 	suite.Run(t, new(EvmStoreTestSuite))
-}
-func (t *EvmStoreTestSuite) TestEvmStoreRangeAndCommit() {
-	require := t.Require()
-	evmDb, err := db.LoadMemDB()
-	require.NoError(err)
-	evmStore := NewEvmStore(evmDb, 100, 0)
-	for i := 0; i <= 100; i++ {
-		key := []byte(fmt.Sprintf("Key%d", i))
-		evmStore.Set(key, key)
-	}
-	evmStore.Set([]byte("hellovm"), []byte("world"))
-	evmStore.Set([]byte("hellovm"), []byte("world3"))
-	evmStore.Set([]byte("hello1"), []byte("world1"))
-	evmStore.Set([]byte("hello2"), []byte("world2"))
-	evmStore.Set([]byte("hello3"), []byte("world3"))
-	evmStore.Set([]byte("hello3"), []byte("world3"))
-	evmStore.Delete([]byte("hello2"))
-	dataRange := evmStore.Range(nil)
-	require.Equal(104, len(dataRange))
-	require.Equal(false, evmStore.Has([]byte("hello2")))
-	evmStore.Commit(1, 0)
-	evmStore.Set([]byte("SSSSS"), []byte("SSSSS"))
-	evmStore.Set([]byte("vvvvv"), []byte("vvv"))
-	dataRange = evmStore.Range(nil)
-	require.Equal(106+1, len(dataRange)) // +1 default evm root key
-	evmStore.Commit(2, 0)
-	evmStore.Set([]byte("SSSSS"), []byte("S1"))
-	ret := evmStore.Get([]byte("SSSSS"))
-	require.Equal(0, bytes.Compare(ret, []byte("S1")))
-	evmStore.Delete([]byte("SSSSS"))
-	evmStore.Delete([]byte("hello1"))
-	dataRange = evmStore.Range(nil)
-	require.Equal(104+1, len(dataRange)) // +1 default evm root key
-	evmStore.Commit(3, 0)
-	evmStore.Delete([]byte("SSSSS"))
-	evmStore.Delete([]byte("hello1"))
-	dataRange = evmStore.Range(nil)
-	require.Equal(104+1, len(dataRange)) // +1 default evm root key
-}
-
-func (t *EvmStoreTestSuite) TestEvmStoreBasicMethods() {
-	require := t.Require()
-	// Test Get|Set|Has|Delete methods
-	evmDb, err := db.LoadMemDB()
-	require.NoError(err)
-	evmStore := NewEvmStore(evmDb, 100, 0)
-	key1 := []byte("hello")
-	key2 := []byte("hello2")
-	value1 := []byte("world")
-	value2 := []byte("world2")
-	value3 := []byte("This is a new value")
-	evmStore.Set(key1, value1)
-	evmStore.Set(key2, value2)
-	result := evmStore.Get(key1)
-	require.Equal(0, bytes.Compare(value1, result))
-	evmStore.Set(key1, value3)
-	result = evmStore.Get(key1)
-	require.Equal(0, bytes.Compare(value3, result))
-	has := evmStore.Has(key1)
-	require.Equal(true, has)
-	evmStore.Delete(key1)
-	has = evmStore.Has(key1)
-	require.Equal(false, has)
-	result = evmStore.Get(key1)
-	fmt.Println(result)
-	require.Equal(0, len(result))
-}
-
-func (t *EvmStoreTestSuite) TestEvmStoreRangePrefix() {
-	require := t.Require()
-	// Test Range Prefix
-	evmDb, err := db.LoadMemDB()
-	require.NoError(err)
-	evmStore := NewEvmStore(evmDb, 100, 0)
-	for i := 0; i <= 100; i++ {
-		key := []byte(fmt.Sprintf("Key%d", i))
-		evmStore.Set(key, key)
-	}
-	for i := 0; i <= 100; i++ {
-		key := []byte(fmt.Sprintf("vv%dKey", i))
-		evmStore.Set(key, key)
-	}
-	dataRange := evmStore.Range(nil)
-	require.Equal(202, len(dataRange))
-
-	dataRange = evmStore.Range([]byte("Key"))
-	require.Equal(0, len(dataRange))
-
-	for i := 0; i <= 100; i++ {
-		key := util.PrefixKey([]byte("Key"), []byte(fmt.Sprintf("%d", i)))
-		evmStore.Set(key, key)
-		key = util.PrefixKey([]byte("vv"), []byte(fmt.Sprintf("%d", i)))
-		evmStore.Set(key, key)
-	}
-
-	dataRange = evmStore.Range([]byte("Key"))
-	require.Equal(101, len(dataRange))
-
-	dataRange = evmStore.Range([]byte("vv"))
-	require.Equal(101, len(dataRange))
-
-	evmStore.Commit(1, 0)
-	dataRange = evmStore.Range([]byte("Key"))
-	require.Equal(101, len(dataRange))
-
-	dataRange = evmStore.Range([]byte("vv"))
-	require.Equal(101, len(dataRange))
-
-	evmStore.Commit(2, 0)
-	evmStore.Delete(util.PrefixKey([]byte("vv"), []byte(fmt.Sprintf("%d", 10))))
-	dataRange = evmStore.Range([]byte("vv"))
-	require.Equal(100, len(dataRange))
 }
 
 func (t *EvmStoreTestSuite) TestLoadVersionEvmStore() {

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -11,8 +11,6 @@ import (
 	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
 	"github.com/loomnetwork/go-loom/plugin"
 	"github.com/loomnetwork/go-loom/util"
-	"github.com/loomnetwork/loomchain/db"
-	"github.com/loomnetwork/loomchain/features"
 	"github.com/loomnetwork/loomchain/log"
 	"github.com/pkg/errors"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
@@ -25,14 +23,6 @@ var (
 	vmPrefix = []byte("vm")
 	// This is the same key as rootKey in evm/loomevm.go
 	rootKey = []byte("vmroot")
-	// This is the same key as featurePrefix in app.go
-	featurePrefix = []byte("feature")
-	// Using the same featurePrefix as in app.go, and the same EvmDBFeature name as in features.go
-	evmDBFeatureKey = util.PrefixKey(featurePrefix, []byte(features.EvmDBFeature))
-	// Using the same featurePrefix as in app.go, and the same AppStoreVersion3_1 name as in features.go
-	appStoreVersion3_1 = util.PrefixKey(featurePrefix, []byte(features.AppStoreVersion3_1))
-	// This is the prefix of versioning Patricia roots
-	evmRootPrefix = []byte("evmroot")
 
 	saveVersionDuration  metrics.Histogram
 	getSnapshotDuration  metrics.Histogram
@@ -90,23 +80,23 @@ func GetEVMRootFromAppStore(s KVReader) []byte {
 	return evmRoot
 }
 
-// MultiWriterAppStore reads & writes keys that have the "vm" prefix via both the IAVLStore and the EvmStore,
-// or just the EvmStore, depending on the evmStoreEnabled flag.
+// MultiWriterAppStore keeps the EVM Patricia tree and IAVL tree roots in sync for each version so
+// that all on-chain state can be consistently persisted & loaded at any height.
+//
+// A previous version of this store used to handle EVM state keys (denoted by the "vm" prefix) but
+// the current version is only capable of pruning old EVM state keys from the IAVLStore, the EVM
+// state keys are now handled by the EVMState.
 type MultiWriterAppStore struct {
-	appStore                   *IAVLStore
-	evmStore                   *EvmStore
-	lastSavedTree              unsafe.Pointer // *iavl.ImmutableTree
-	onlySaveEvmStateToEvmStore bool
+	appStore      *IAVLStore
+	evmStore      *EvmStore
+	lastSavedTree unsafe.Pointer // *iavl.ImmutableTree
 }
 
 // NewMultiWriterAppStore creates a new MultiWriterAppStore.
-func NewMultiWriterAppStore(
-	appStore *IAVLStore, evmStore *EvmStore, saveEVMStateToIAVL bool,
-) (*MultiWriterAppStore, error) {
+func NewMultiWriterAppStore(appStore *IAVLStore, evmStore *EvmStore) (*MultiWriterAppStore, error) {
 	store := &MultiWriterAppStore{
-		appStore:                   appStore,
-		evmStore:                   evmStore,
-		onlySaveEvmStateToEvmStore: !saveEVMStateToIAVL,
+		appStore: appStore,
+		evmStore: evmStore,
 	}
 	appStoreEvmRoot := store.appStore.Get(rootKey)
 	// if root is nil, this is the first run after migration, so get evmroot from vmvmroot
@@ -123,11 +113,6 @@ func NewMultiWriterAppStore(
 			version, evmStoreEvmRoot, appStore.Version(), appStoreEvmRoot)
 	}
 
-	// feature flag overrides SaveEVMStateToIAVL
-	if !store.onlySaveEvmStateToEvmStore {
-		store.onlySaveEvmStateToEvmStore = bytes.Equal(store.appStore.Get(evmDBFeatureKey), []byte{1})
-	}
-
 	if err := store.setLastSavedTreeToVersion(appStore.Version()); err != nil {
 		return nil, err
 	}
@@ -135,41 +120,18 @@ func NewMultiWriterAppStore(
 }
 
 func (s *MultiWriterAppStore) Delete(key []byte) {
-	if util.HasPrefix(key, vmPrefix) {
-		s.evmStore.Delete(key)
-		if !s.onlySaveEvmStateToEvmStore {
-			s.appStore.Delete(key)
-		}
-	} else {
-		s.appStore.Delete(key)
-	}
+	s.appStore.Delete(key)
 }
 
 func (s *MultiWriterAppStore) Set(key, val []byte) {
-	if !s.onlySaveEvmStateToEvmStore && bytes.Equal(key, evmDBFeatureKey) {
-		s.onlySaveEvmStateToEvmStore = bytes.Equal(val, []byte{1})
-	}
-	if util.HasPrefix(key, vmPrefix) {
-		s.evmStore.Set(key, val)
-		if !s.onlySaveEvmStateToEvmStore {
-			s.appStore.Set(key, val)
-		}
-	} else {
-		s.appStore.Set(key, val)
-	}
+	s.appStore.Set(key, val)
 }
 
 func (s *MultiWriterAppStore) Has(key []byte) bool {
-	if util.HasPrefix(key, vmPrefix) {
-		return s.evmStore.Has(key)
-	}
 	return s.appStore.Has(key)
 }
 
 func (s *MultiWriterAppStore) Get(key []byte) []byte {
-	if util.HasPrefix(key, vmPrefix) {
-		return s.evmStore.Get(key)
-	}
 	return s.appStore.Get(key)
 }
 
@@ -179,9 +141,6 @@ func (s *MultiWriterAppStore) Range(prefix []byte) plugin.RangeData {
 		panic(errors.New("Range over nil prefix not implemented"))
 	}
 
-	if bytes.Equal(prefix, vmPrefix) || util.HasPrefix(prefix, vmPrefix) {
-		return s.evmStore.Range(prefix)
-	}
 	return s.appStore.Range(prefix)
 }
 
@@ -204,24 +163,19 @@ func (s *MultiWriterAppStore) SaveVersion(opts *VersionedKVStoreSaveOptions) ([]
 		flushInterval = opts.FlushInterval
 	}
 	currentRoot := s.evmStore.Commit(s.Version()+1, flushInterval)
-	if s.onlySaveEvmStateToEvmStore {
-		// Tie up Patricia tree with IAVL tree.
-		// Do this after the feature flag is enabled so that we can detect
-		// inconsistency in evm.db across the cluster
-		// AppStore 3.1 writes EVM root to app.db only if it changes
-		if bytes.Equal(s.appStore.Get(appStoreVersion3_1), []byte{1}) {
-			oldRoot := s.appStore.Get(rootKey)
-			if !bytes.Equal(oldRoot, currentRoot) {
-				s.appStore.Set(rootKey, currentRoot)
-			}
-		} else {
-			s.appStore.Set(rootKey, currentRoot)
-		}
-
-		if err := s.pruneOldEVMKeys(); err != nil {
-			return nil, 0, err
-		}
+	// Store the root of the EVM Patricia tree in the IAVL tree.
+	// Only write the EVM root to the IAVL store if it changes, this was previously only done
+	// once the AppStoreVersion3_1 feature flag was enabled, but it's now assumed the flag is
+	// always enabled so the feature check is omitted.
+	oldRoot := s.appStore.Get(rootKey)
+	if !bytes.Equal(oldRoot, currentRoot) {
+		s.appStore.Set(rootKey, currentRoot)
 	}
+
+	if err := s.pruneOldEVMKeys(); err != nil {
+		return nil, 0, err
+	}
+
 	hash, version, err := s.appStore.SaveVersion(opts)
 	s.setLastSavedTreeToVersion(version)
 	return hash, version, err
@@ -291,40 +245,28 @@ func (s *MultiWriterAppStore) GetSnapshotAt(version int64) (Snapshot, error) {
 			return nil, errors.Wrapf(err, "failed to load immutable tree for version %v", version)
 		}
 	}
-	// TODO: It's no longer necessary to acquire a snapshot from the EvmStore since it's now provided
-	//       by the EVMState.
-	evmDbSnapshot := s.evmStore.GetSnapshot(appStoreTree.Version())
-	return newMultiWriterStoreSnapshot(evmDbSnapshot, appStoreTree), nil
+	return newMultiWriterStoreSnapshot(appStoreTree), nil
 }
 
 type multiWriterStoreSnapshot struct {
-	evmDbSnapshot db.Snapshot
-	appStoreTree  *iavl.ImmutableTree
+	appStoreTree *iavl.ImmutableTree
 }
 
-func newMultiWriterStoreSnapshot(evmDbSnapshot db.Snapshot, appStoreTree *iavl.ImmutableTree) *multiWriterStoreSnapshot {
+func newMultiWriterStoreSnapshot(appStoreTree *iavl.ImmutableTree) *multiWriterStoreSnapshot {
 	return &multiWriterStoreSnapshot{
-		evmDbSnapshot: evmDbSnapshot,
-		appStoreTree:  appStoreTree,
+		appStoreTree: appStoreTree,
 	}
 }
 
 func (s *multiWriterStoreSnapshot) Release() {
-	s.evmDbSnapshot.Release()
 	s.appStoreTree = nil
 }
 
 func (s *multiWriterStoreSnapshot) Has(key []byte) bool {
-	if util.HasPrefix(key, vmPrefix) {
-		return s.evmDbSnapshot.Has(key)
-	}
 	return s.appStoreTree.Has(key)
 }
 
 func (s *multiWriterStoreSnapshot) Get(key []byte) []byte {
-	if util.HasPrefix(key, vmPrefix) {
-		return s.evmDbSnapshot.Get(key)
-	}
 	_, val := s.appStoreTree.Get(key)
 	return val
 }
@@ -336,30 +278,6 @@ func (s *multiWriterStoreSnapshot) Range(prefix []byte) plugin.RangeData {
 	}
 
 	ret := make(plugin.RangeData, 0)
-
-	if bytes.Equal(prefix, vmPrefix) || util.HasPrefix(prefix, vmPrefix) {
-		it := s.evmDbSnapshot.NewIterator(prefix, prefixRangeEnd(prefix))
-		defer it.Close()
-
-		for ; it.Valid(); it.Next() {
-			key := it.Key()
-			if util.HasPrefix(key, prefix) {
-				var err error
-				key, err = util.UnprefixKey(key, prefix)
-				if err != nil {
-					panic(err)
-				}
-
-				ret = append(ret, &plugin.RangeEntry{
-					Key:   key,
-					Value: it.Value(),
-				})
-			}
-		}
-		return ret
-	}
-
-	// Otherwise iterate over the IAVL tree
 	keys, values, _, err := s.appStoreTree.GetRangeWithProof(prefix, prefixRangeEnd(prefix), 0)
 	if err != nil {
 		log.Error("failed to get range", "prefix", string(prefix), "err", err)


### PR DESCRIPTION
`MultiWriterAppStore` was used to migrate EVM state keys from app.db to evm.db, since all clusters have now been migrated this functionality is no longer necessary, and is in fact incompatible with the changes introduced in PR #1532.

This set of changes cleans out most of the obsolete code from that store:
- Eliminate writes to the `EvmStore` from `MultiWriterAppStore`.
- Eliminate Get/Has/Set/Delete from `EvmStore`.
- Eliminate use of `AppStore.SaveEVMStateToIAVL` config setting.