### PR TITLE
Disable the VersionedCachingStore by default

### DIFF
--- a/store/versioned_cachingstore.go
+++ b/store/versioned_cachingstore.go
@@ -125,7 +125,7 @@ type CachingStoreConfig struct {
 
 func DefaultCachingStoreConfig() *CachingStoreConfig {
 	return &CachingStoreConfig{
-		CachingEnabled:            true,
+		CachingEnabled:            false,
 		Shards:                    1024,
 		EvictionTimeInSeconds:     60 * 60,       // 1 hour
 		CleaningIntervalInSeconds: 10,            // Cleaning per 10 second


### PR DESCRIPTION
The caching provided by the `VersionedCachingStore` is of no benefit to nodes that aren't queried by clients because the transaction handlers bypass the cache. Since the vast majority of nodes, regardless of whether or not they're validators don't respond to client queries it makes more sense to disable the caching by default.