### PR TITLE
Add canonical_tx_hash RPC method on the /query interface

### DIFF
--- a/e2e/tests/truffle/test/EthFunctions.js
+++ b/e2e/tests/truffle/test/EthFunctions.js
@@ -8,11 +8,12 @@ const {
 const ethers = require('ethers').ethers
 const { getContractFuncInterface, getLatestBlock, getMappedAccount } = require('./helpers')
 const MyToken = artifacts.require('MyToken');
+const rp = require('request-promise')
 
 // web3 functions called using truffle objects use the loomProvider
-// web3 functions called uisng we3js access the loom QueryInterface directly
+// web3 functions called using we3js access the loom QueryInterface directly
 contract('MyToken', async (accounts) => {
-  let web3js, nodeAddr, alice, aliceLoomAddr, bob, bobLoomAddr
+  let web3js, nodeAddr, alice, aliceLoomAddr, bob
 
   beforeEach(async () => {
     if (!process.env.CLUSTER_DIR) {
@@ -218,4 +219,112 @@ contract('MyToken', async (accounts) => {
     result = await web3js.eth.sendSignedTransaction(payload.rawTransaction);
     assert.equal(result.status, true, 'tx submitted successfully');
   });
+
+  it('canonical_tx_hash', async () => {
+    if (process.env.TRUFFLE_PROVIDER !== 'hdwallet') {
+      return
+    }
+    const nodeAddr = fs.readFileSync(path.join(process.env.CLUSTER_DIR, '0', 'node_rpc_addr'), 'utf-8');
+    const ethAccount = await newWeb3Account(nodeAddr, web3js)
+    const tokenContract = await MyToken.deployed();
+    const mintTokenInterface = getContractFuncInterface(
+      new web3js.eth.Contract(MyToken._json.abi, tokenContract.address), 'mintToken'
+    )
+    const txCount = await web3js.eth.getTransactionCount(ethAccount.address)
+    const txParams = {
+      nonce: ethers.utils.hexlify(txCount),
+      gasPrice: '0x0', // gas price is always 0
+      gasLimit: '0xFFFFFFFFFFFFFFFF', // gas limit right now is max.Uint64
+      to: tokenContract.address,
+      value: '0x0',
+      data: web3js.eth.abi.encodeFunctionCall(mintTokenInterface, ['200']) // mintToken(200)
+    }
+        
+    const payload = await web3js.eth.accounts.signTransaction(txParams, ethAccount.privateKey);
+    const result = await web3js.eth.sendSignedTransaction(payload.rawTransaction);
+    assert.equal(result.status, true, 'tx submitted successfully');
+    let canonicalTxHash = await getCanonicalTxHashByBlockTxIndex(
+      `http://${nodeAddr}/query`, result.blockNumber, result.transactionIndex
+    )
+    assert.equal(canonicalTxHash, result.transactionHash)
+
+    const logs = await web3js.eth.getPastLogs({
+      address: tokenContract.address,
+      fromBlock: result.blockNumber,
+      toBlock: 'latest',
+    });
+    for (let i = 0 ; i < logs.length ; i++) {
+      const log = logs[i]
+      // Logs currently contain the non-canonical EVM tx hash
+      assert.notEqual(log.transactionHash, result.transactionHash)
+      canonicalTxHash = await getCanonicalTxHashByBlockTxIndex(
+        `http://${nodeAddr}/query`, log.blockNumber, log.transactionIndex
+      )
+      assert.equal(canonicalTxHash, result.transactionHash)
+      // Lookup the canonical tx hash using the EVM tx hash
+      canonicalTxHash = await getCanonicalTxHashByEvmTxHash(
+        `http://${nodeAddr}/query`, log.transactionHash
+      )
+      assert.equal(canonicalTxHash, result.transactionHash)
+    }
+  });
 });
+
+async function newWeb3Account(nodeAddr, web3js) {
+  const client = new Client('default', `ws://${nodeAddr}/websocket`, `ws://${nodeAddr}/queryws`);
+  client.on('error', msg => {
+      console.error('Error on connect to client', msg);
+      console.warn('Please verify if loom cluster is running');
+  });
+  const privKey = CryptoUtils.generatePrivateKey();
+  const pubKey = CryptoUtils.publicKeyFromPrivateKey(privKey);
+  client.txMiddleware = createDefaultTxMiddleware(client, privKey);
+  // Create a mapping between a new DAppChain account & Ethereum account, this is necessary in
+  // order to match the signer address that will be recovered from the Ethereum tx to a DAppChain
+  // account, without this mapping the Ethereum tx will be rejected.
+  const loomAddr = new Address(client.chainId, LocalAddress.fromPublicKey(pubKey));
+  const addressMapper = await Contracts.AddressMapper.createAsync(client, loomAddr);
+  const ethAccount = web3js.eth.accounts.create();
+  const ethWallet = new ethers.Wallet(ethAccount.privateKey);
+  const ethAddr = await ethWallet.getAddress();
+  await addressMapper.addIdentityMappingAsync(
+    loomAddr,
+    new Address('eth', LocalAddress.fromHexString(ethAddr)),
+    new EthersSigner(ethWallet)
+  );
+  client.disconnect();
+
+  return ethAccount
+}
+
+async function getCanonicalTxHashByBlockTxIndex(uri, blockNumber, txIndex) {
+  var options = {
+    method: 'POST',
+    uri: uri,
+    body: {
+      jsonrpc: '2.0',
+      method: 'canonical_tx_hash',
+      params: [blockNumber.toString(), txIndex.toString(), '0x0'],
+      id: 83,
+    },
+    json: true
+  };
+  const res = await rp(options)
+  return res.result
+}
+
+async function getCanonicalTxHashByEvmTxHash(uri, evmTxHash) {
+  var options = {
+    method: 'POST',
+    uri: uri,
+    body: {
+      jsonrpc: '2.0',
+      method: 'canonical_tx_hash',
+      params: ['0', '0', evmTxHash],
+      id: 83,
+    },
+    json: true
+  };
+  const res = await rp(options)
+  return res.result
+}

--- a/rpc/instrumenting.go
+++ b/rpc/instrumenting.go
@@ -139,6 +139,17 @@ func (m InstrumentingMiddleware) DPOSTotalStaked() (resp *DPOSTotalStakedRespons
 	return
 }
 
+func (m InstrumentingMiddleware) GetCanonicalTxHash(block, txIndex uint64, evmTxHash eth.Data) (resp eth.Data, err error) {
+	defer func(begin time.Time) {
+		lvs := []string{"method", "GetCanonicalTxHash", "error", fmt.Sprint(err != nil)}
+		m.requestCount.With(lvs...).Add(1)
+		m.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	resp, err = m.next.GetCanonicalTxHash(block, txIndex, evmTxHash)
+	return resp, err
+}
+
 func (m InstrumentingMiddleware) GetEvmCode(contract string) (resp []byte, err error) {
 	defer func(begin time.Time) {
 		lvs := []string{"method", "GetEvmCode", "error", fmt.Sprint(err != nil)}

--- a/rpc/mock_query_server.go
+++ b/rpc/mock_query_server.go
@@ -275,6 +275,11 @@ func (m *MockQueryService) DPOSTotalStaked() (*DPOSTotalStakedResponse, error) {
 	return nil, nil
 }
 
+func (m *MockQueryService) GetCanonicalTxHash(block, txIndex uint64, evmTxHash eth.Data) (eth.Data, error) {
+	m.MethodsCalled = append([]string{"GetCanonicalTxHash"}, m.MethodsCalled...)
+	return "", nil
+}
+
 // deprecated function
 func (m *MockQueryService) EvmTxReceipt(txHash []byte) ([]byte, error) {
 	m.mutex.Lock()

--- a/rpc/query_server.go
+++ b/rpc/query_server.go
@@ -640,6 +640,52 @@ func (s *QueryServer) DPOSTotalStaked() (*DPOSTotalStakedResponse, error) {
 	}, nil
 }
 
+// GetCanonicalTxHash returns the hash of the Tendermint tx payload within a block.
+// If the block number is specified (non-zero) then the tx payload will be found by block number & tx
+// index. Otherwise the EVM tx hash will be used to lookup the receipt for the tx and the block
+// number & tx index will be obtained from the receipt.
+//
+// Txs that call the EVM currently end up with two different hashes, one is the hash of the
+// Tendermint tx payload stored in the Tendermint blocks, the other is the hash of the tx receipt.
+// The former is the canonical hash, the latter is an abomination.
+func (s *QueryServer) GetCanonicalTxHash(block, txIndex uint64, evmTxHash eth.Data) (eth.Data, error) {
+	if block == 0 && evmTxHash == "" {
+		return "", errors.New("neither block number nor EVM tx hash was specfied")
+	}
+
+	height := int64(block)
+	index := int(txIndex)
+
+	if block == 0 {
+		txHash, err := eth.DecDataToBytes(evmTxHash)
+		if err != nil {
+			return "", err
+		}
+
+		txReceipt, err := s.ReceiptHandlerProvider.Reader().GetReceipt(txHash)
+		if err != nil {
+			return "", err
+		}
+
+		height = txReceipt.BlockNumber
+		index = int(txReceipt.TransactionIndex)
+	}
+
+	blockResult, err := s.BlockStore.GetBlockByHeight(&height)
+	if err != nil {
+		return "", err
+	}
+	if blockResult == nil || blockResult.Block == nil {
+		return "", errors.Errorf("no block results found at height %v", height)
+	}
+	if len(blockResult.Block.Data.Txs) <= index {
+		return "", errors.Errorf(
+			"tx index out of bounds (%v >= %v) at height %v", index, len(blockResult.Block.Data.Txs), height,
+		)
+	}
+	return eth.EncBytes(blockResult.Block.Data.Txs[index].Hash()), nil
+}
+
 // Takes a filter and returns a list of data relative to transactions that satisfies the filter
 // Used to support eth_getLogs
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getlogs

--- a/rpc/query_service.go
+++ b/rpc/query_service.go
@@ -64,6 +64,7 @@ type QueryService interface {
 	ContractEvents(fromBlock uint64, toBlock uint64, contract string) (*types.ContractEventsResult, error)
 	GetContractRecord(contractAddr string) (*types.ContractRecordResponse, error)
 	DPOSTotalStaked() (*DPOSTotalStakedResponse, error)
+	GetCanonicalTxHash(block, txIndex uint64, evmTxHash eth.Data) (eth.Data, error)
 
 	// deprecated function
 	EvmTxReceipt(txHash []byte) ([]byte, error)
@@ -132,6 +133,7 @@ func MakeQueryServiceHandler(svc QueryService, logger log.TMLogger, bus *QueryEv
 	routes["contractevents"] = rpcserver.NewRPCFunc(svc.ContractEvents, "fromBlock,toBlock,contract")
 	routes["contractrecord"] = rpcserver.NewRPCFunc(svc.GetContractRecord, "contract")
 	routes["dpos_total_staked"] = rpcserver.NewRPCFunc(svc.DPOSTotalStaked, "")
+	routes["canonical_tx_hash"] = rpcserver.NewRPCFunc(svc.GetCanonicalTxHash, "block,txIndex,evmTxHash")
 	rpcserver.RegisterRPCFuncs(wsmux, routes, codec, logger)
 	wm := rpcserver.NewWebsocketManager(routes, codec, rpcserver.EventSubscriber(bus))
 	wsmux.HandleFunc("/queryws", wm.WebsocketHandler)


### PR DESCRIPTION
This RPC method can be used to obtain the canonical tx hash from the EVM tx hash (which is just a hash of the tx receipt).