### PR TITLE
Quick fix for Dpos UnbondAll 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = fix-unbond-all-req
+GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = fix-unbond-all-req
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -745,7 +745,7 @@ func (c *DPOS) UnbondAll(ctx contract.Context, req *UnbondAllRequest) error {
 	}
 
 	if req.ValidatorAddress == nil {
-		return logDposError(ctx, errors.New("UnbondAll called with req.ValidatorAddress == nil"), req.String())
+		return errors.New("validator address must be specified")
 	}
 
 	sender := ctx.Message().Sender
@@ -763,9 +763,9 @@ func (c *DPOS) UnbondAll(ctx contract.Context, req *UnbondAllRequest) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to load delegations")
 	}
-
+	validatorAddress := loom.UnmarshalAddressPB(req.ValidatorAddress)
 	for _, di := range delegationIndexes {
-		if loom.UnmarshalAddressPB(req.ValidatorAddress).Compare(loom.UnmarshalAddressPB(di.Validator)) != 0 {
+		if validatorAddress.Compare(loom.UnmarshalAddressPB(di.Validator)) != 0 {
 			continue
 		}
 		delegation, err := GetDelegation(ctx, di.Index, *di.Validator, *di.Delegator)

--- a/builtin/plugins/dposv3/dpos.go
+++ b/builtin/plugins/dposv3/dpos.go
@@ -744,6 +744,10 @@ func (c *DPOS) UnbondAll(ctx contract.Context, req *UnbondAllRequest) error {
 		return errors.New("DPOS v3.7 is not enabled")
 	}
 
+	if req.ValidatorAddress == nil {
+		return logDposError(ctx, errors.New("UnbondAll called with req.ValidatorAddress == nil"), req.String())
+	}
+
 	sender := ctx.Message().Sender
 	state, err := LoadState(ctx)
 	if err != nil {
@@ -761,6 +765,9 @@ func (c *DPOS) UnbondAll(ctx contract.Context, req *UnbondAllRequest) error {
 	}
 
 	for _, di := range delegationIndexes {
+		if loom.UnmarshalAddressPB(req.ValidatorAddress).Compare(loom.UnmarshalAddressPB(di.Validator)) != 0 {
+			continue
+		}
 		delegation, err := GetDelegation(ctx, di.Index, *di.Validator, *di.Delegator)
 		if err == contract.ErrNotFound {
 			validator := loom.UnmarshalAddressPB(di.Validator)

--- a/builtin/plugins/dposv3/dpos_test.go
+++ b/builtin/plugins/dposv3/dpos_test.go
@@ -505,6 +505,8 @@ func TestUnbondAll(t *testing.T) {
 		Local: loom.LocalAddressFromPublicKey(oraclePubKey),
 	}
 
+	valAddr1 := addr1
+
 	// Deploy the coin contract (DPOS Init() will attempt to resolve it)
 	coinContract := &coin.Coin{}
 	coinAddr := pctx.CreateContract(coin.Contract)
@@ -514,8 +516,8 @@ func TestUnbondAll(t *testing.T) {
 			makeAccount(delegatorAddress1, 1000000000000000000),
 			makeAccount(delegatorAddress2, 2000000000000000000),
 			makeAccount(delegatorAddress3, 1000000000000000000),
-			makeAccount(addr1, 1000000000000000000),
-			makeAccount(addr2, 1000000000000000000),
+			makeAccount(valAddr1, 1000000000000000000),
+			makeAccount(valAddr2, 1000000000000000000),
 		},
 	})
 
@@ -540,17 +542,17 @@ func TestUnbondAll(t *testing.T) {
 	// register a candidate with the DPOS contract
 
 	whitelistAmount := big.NewInt(1000000000000)
-	err = dpos.WhitelistCandidate(pctx.WithSender(oracleAddr), addr1, whitelistAmount, 0)
+	err = dpos.WhitelistCandidate(pctx.WithSender(oracleAddr), valAddr1, whitelistAmount, 0)
 	require.NoError(t, err)
 
-	err = dpos.RegisterCandidate(pctx.WithSender(addr1), pubKey1, nil, nil, nil, nil, nil, nil)
+	err = dpos.RegisterCandidate(pctx.WithSender(valAddr1), pubKey1, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// make two self-delegations to the registered candidate
 
 	delegationAmount := big.NewInt(1e18)
 	err = coinContract.Approve(
-		contractpb.WrapPluginContext(coinCtx.WithSender(addr1)),
+		contractpb.WrapPluginContext(coinCtx.WithSender(valAddr1)),
 		&coin.ApproveRequest{
 			Spender: dpos.Address.MarshalPB(),
 			Amount:  &types.BigUInt{Value: *loom.NewBigUInt(delegationAmount)},
@@ -558,11 +560,11 @@ func TestUnbondAll(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = dpos.Delegate(pctx.WithSender(addr1), &addr1, delegationAmount, nil, nil)
+	err = dpos.Delegate(pctx.WithSender(valAddr1), &valAddr1, delegationAmount, nil, nil)
 	require.NoError(t, err)
 
 	err = coinContract.Approve(
-		contractpb.WrapPluginContext(coinCtx.WithSender(addr1)),
+		contractpb.WrapPluginContext(coinCtx.WithSender(valAddr1)),
 		&coin.ApproveRequest{
 			Spender: dpos.Address.MarshalPB(),
 			Amount:  &types.BigUInt{Value: *loom.NewBigUInt(delegationAmount)},
@@ -570,7 +572,7 @@ func TestUnbondAll(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = dpos.Delegate(pctx.WithSender(addr1), &addr1, delegationAmount, nil, nil)
+	err = dpos.Delegate(pctx.WithSender(valAddr1), &valAddr1, delegationAmount, nil, nil)
 	require.NoError(t, err)
 
 	// get the candidate elected into the active validator set
@@ -586,7 +588,7 @@ func TestUnbondAll(t *testing.T) {
 	)
 	require.NoError(t, err)
 	tierThree := uint64(3)
-	err = dpos.Delegate(pctx.WithSender(delegatorAddress2), &addr1, delegationAmount, &tierThree, nil)
+	err = dpos.Delegate(pctx.WithSender(delegatorAddress2), &valAddr1, delegationAmount, &tierThree, nil)
 	require.NoError(t, err)
 
 	err = coinContract.Approve(
@@ -598,7 +600,7 @@ func TestUnbondAll(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = dpos.Delegate(pctx.WithSender(delegatorAddress1), &addr1, delegationAmount, &tierThree, nil)
+	err = dpos.Delegate(pctx.WithSender(delegatorAddress1), &valAddr1, delegationAmount, &tierThree, nil)
 	require.NoError(t, err)
 
 	// advance time by 60s and run another election, all delegations will remain locked since they're
@@ -607,7 +609,7 @@ func TestUnbondAll(t *testing.T) {
 	require.NoError(t, elect(pctx, dpos.Address))
 
 	// figure out how much everyone has delegated & their current LOOM balance
-	_, del1Amount, _, err := dpos.CheckDelegation(pctx, &addr1, &delegatorAddress1)
+	_, del1Amount, _, err := dpos.CheckDelegation(pctx, &valAddr1, &delegatorAddress1)
 	require.NoError(t, err)
 	del1Balance, err := coinContract.BalanceOf(
 		contractpb.WrapPluginContext(coinCtx),
@@ -615,7 +617,7 @@ func TestUnbondAll(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, del2Amount, _, err := dpos.CheckDelegation(pctx, &addr1, &delegatorAddress2)
+	_, del2Amount, _, err := dpos.CheckDelegation(pctx, &valAddr1, &delegatorAddress2)
 	require.NoError(t, err)
 	del2Balance, err := coinContract.BalanceOf(
 		contractpb.WrapPluginContext(coinCtx),
@@ -623,11 +625,11 @@ func TestUnbondAll(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, valAmount, _, err := dpos.CheckDelegation(pctx, &addr1, &addr1)
+	_, valAmount, _, err := dpos.CheckDelegation(pctx, &valAddr1, &valAddr1)
 	require.NoError(t, err)
 	valBalance, err := coinContract.BalanceOf(
 		contractpb.WrapPluginContext(coinCtx),
-		&coin.BalanceOfRequest{Owner: addr1.MarshalPB()},
+		&coin.BalanceOfRequest{Owner: valAddr1.MarshalPB()},
 	)
 	require.NoError(t, err)
 
@@ -643,7 +645,7 @@ func TestUnbondAll(t *testing.T) {
 
 	// check that everyone's LOOM balance has increased by the previously obtained delegation amount
 	// as would be expected if the delegations were unbonded successfully
-	_, delegatedAmount, _, err := dpos.CheckDelegation(pctx, &addr1, &delegatorAddress1)
+	_, delegatedAmount, _, err := dpos.CheckDelegation(pctx, &valAddr1, &delegatorAddress1)
 	balance, err := coinContract.BalanceOf(
 		contractpb.WrapPluginContext(coinCtx),
 		&coin.BalanceOfRequest{Owner: delegatorAddress1.MarshalPB()},
@@ -652,7 +654,7 @@ func TestUnbondAll(t *testing.T) {
 	assert.True(t, delegatedAmount.Cmp(del1Amount) < 0)
 	assert.Equal(t, new(big.Int).Sub(balance.GetBalance().Value.Int, del1Balance.GetBalance().Value.Int), del1Amount)
 
-	_, delegatedAmount, _, err = dpos.CheckDelegation(pctx, &addr1, &delegatorAddress2)
+	_, delegatedAmount, _, err = dpos.CheckDelegation(pctx, &valAddr1, &delegatorAddress2)
 	require.NoError(t, err)
 	balance, err = coinContract.BalanceOf(
 		contractpb.WrapPluginContext(coinCtx),
@@ -662,7 +664,7 @@ func TestUnbondAll(t *testing.T) {
 	assert.True(t, delegatedAmount.Cmp(del2Amount) < 0)
 	assert.Equal(t, new(big.Int).Sub(balance.GetBalance().Value.Int, del2Balance.GetBalance().Value.Int), del2Amount)
 
-	_, delegatedAmount, _, err = dpos.CheckDelegation(pctx, &addr1, &addr1)
+	_, delegatedAmount, _, err = dpos.CheckDelegation(pctx, &valAddr1, &valAddr1)
 	require.NoError(t, err)
 	balance, err = coinContract.BalanceOf(
 		contractpb.WrapPluginContext(coinCtx),

--- a/builtin/plugins/dposv3/dpos_test.go
+++ b/builtin/plugins/dposv3/dpos_test.go
@@ -506,7 +506,7 @@ func TestUnbondAll(t *testing.T) {
 	}
 
 	valAddr1 := addr1
-
+	valAddr2 := addr2
 	// Deploy the coin contract (DPOS Init() will attempt to resolve it)
 	coinContract := &coin.Coin{}
 	coinAddr := pctx.CreateContract(coin.Contract)
@@ -635,7 +635,9 @@ func TestUnbondAll(t *testing.T) {
 
 	err = dpos.Contract.UnbondAll(
 		contractpb.WrapPluginContext(pctx.WithAddress(dpos.Address).WithSender(oracleAddr)),
-		&UnbondAllRequest{},
+		&UnbondAllRequest{
+			ValidatorAddress: valAddr1.MarshalPB(),
+		},
 	)
 	require.NoError(t, err)
 

--- a/cmd/loom/dposV3_commands.go
+++ b/cmd/loom/dposV3_commands.go
@@ -758,19 +758,24 @@ func UnbondCmdV3() *cobra.Command {
 }
 
 const unbondAllCmdExample = `
-loom dpos3 unbond-all -k path/to/private_key
+loom dpos3 unbond-all 0x7262d4c97c7B93937E4810D289b7320e9dA82857 -k path/to/private_key
 `
 
 func UnbondAllDelegationsCmdV3() *cobra.Command {
 	var flags cli.ContractCallFlags
 	cmd := &cobra.Command{
-		Use:     "unbond-all",
-		Short:   "unbond all delegations",
+		Use:     "unbond-all [validator address]",
+		Short:   "unbond all delegations of a target validator",
 		Example: unbondAllCmdExample,
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			addr, err := cli.ResolveAccountAddress(args[0], &flags)
+			if err != nil {
+				return err
+			}
 			return cli.CallContractWithFlags(
 				&flags, DPOSV3ContractName, "UnbondAll",
-				&dposv3.UnbondAllRequest{}, nil,
+				&dposv3.UnbondAllRequest{ValidatorAddress: addr.MarshalPB()}, nil,
 			)
 		},
 	}

--- a/e2e/dposv3-unbond-all.toml
+++ b/e2e/dposv3-unbond-all.toml
@@ -120,7 +120,10 @@
   Expected = [ 'dpos:v3.7' ]
 
 [[TestCases]]
-  RunCmd = "{{ $.LoomPath }} dpos3 unbond-all -k {{index $.NodePrivKeyPathList 0}}"
+  RunCmd = "{{ $.LoomPath }} dpos3 unbond-all {{index $.NodeAddressList 2}} -k {{index $.NodePrivKeyPathList 0}}"
+
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} dpos3 unbond-all {{index $.NodeAddressList 1}} -k {{index $.NodePrivKeyPathList 0}}"
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 check-delegation {{index $.NodeAddressList 1}} {{index $.NodeAddressList 2}}"
@@ -134,6 +137,16 @@
 
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} dpos3 list-delegations {{index $.NodeAddressList 1}}"
+  Condition = "excludes"
+  Excluded = ["\"index\": \"1\""]
+
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} dpos3 list-delegations {{index $.NodeAddressList 2}}"
+  Condition = "contains"
+  Expected = ["\"index\": \"0\""]
+
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} dpos3 list-delegations {{index $.NodeAddressList 2}}"
   Condition = "excludes"
   Excluded = ["\"index\": \"1\""]
 


### PR DESCRIPTION
Add Validator Address as a target validator that the user need to unbond all of the delegations.

go-loom PR : https://github.com/loomnetwork/go-loom/pull/468
- [ ] I added unit tests for any code that added
- [ ] I updated the CHANGELOG.md 
- [ ] All IP is original and not copied from another source
- [ ] I assign all copyright to Loom Network for the code in the pull request