### PR TITLE
Lock down version of go-testing-interface package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ GRPC_DIR = $(GOPATH)/src/google.golang.org/grpc
 GO_ETHEREUM_DIR = $(GOPATH)/src/github.com/ethereum/go-ethereum
 SSHA3_DIR = $(GOPATH)/src/github.com/miguelmota/go-solidity-sha3
 HASHICORP_DIR = $(GOPATH)/src/github.com/hashicorp/go-plugin
+GO_TESTING_INTERFACE_DIR = $(GOPATH)/src/github.com/mitchellh/go-testing-interface
 LEVIGO_DIR = $(GOPATH)/src/github.com/jmhodges/levigo
 GAMECHAIN_DIR = $(GOPATH)/src/github.com/loomnetwork/gamechain
 BTCD_DIR = $(GOPATH)/src/github.com/btcsuite/btcd
@@ -245,6 +246,9 @@ deps: $(PLUGIN_DIR) $(GO_ETHEREUM_DIR) $(SSHA3_DIR)
 	cd $(GENPROTO_DIR) && git checkout master && git pull && git checkout $(GENPROTO_GIT_REV)
 	cd $(GO_ETHEREUM_DIR) && git checkout master && git pull && git checkout $(ETHEREUM_GIT_REV)
 	cd $(HASHICORP_DIR) && git checkout $(HASHICORP_GIT_REV)
+	# go-testing-interface is a dependency of hashicorp/go-plugin,
+	# latest version of go-testing-interface only supports Go 1.14+ so use an older version
+	cd $(GO_TESTING_INTERFACE_DIR) && git checkout v1.0.0
 	cd $(BTCD_DIR) && git checkout $(BTCD_GIT_REV)
 	cd $(YUBIHSM_DIR) && git checkout master && git pull && git checkout $(YUBIHSM_REV)
 	# fetch vendored packages


### PR DESCRIPTION
This should keep everything building properly on Go 1.13 and earlier.