### PR TITLE
Add IgnoreUnbondLocktime to DPOS params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = ignore-unbond-lock
+GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = ignore-unbond-lock
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/cmd/loom/dposV3_commands.go
+++ b/cmd/loom/dposV3_commands.go
@@ -1378,6 +1378,35 @@ func SetMinCandidateFeeCmdV3() *cobra.Command {
 	return cmd
 }
 
+const ignoreUnbondLocktimeCmdExample = `
+loom dpos3 ignore-unbond-locktime true -k path/to/private_key
+`
+
+func IgnoreUnbondLocktimeCmd() *cobra.Command {
+	var flags cli.ContractCallFlags
+	cmd := &cobra.Command{
+		Use:     "ignore-unbond-locktime [true|false]",
+		Example: ignoreUnbondLocktimeCmdExample,
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			status, err := strconv.ParseBool(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid boolean value")
+			}
+			err = cli.CallContractWithFlags(
+				&flags, DPOSV3ContractName, "IgnoreUnbondLocktime", &dposv3.IgnoreUnbondLocktimeRequest{
+					Ignore: status,
+				}, nil)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cli.AddContractCallFlags(cmd.Flags(), &flags)
+	return cmd
+}
+
 func NewDPOSV3Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dpos3 <command>",
@@ -1424,6 +1453,7 @@ func NewDPOSV3Command() *cobra.Command {
 		SetMinCandidateFeeCmdV3(),
 		UnjailValidatorCmdV3(),
 		EnableValidatorJailingCmd(),
+		IgnoreUnbondLocktimeCmd(),
 	)
 	return cmd
 }

--- a/features/features.go
+++ b/features/features.go
@@ -57,6 +57,8 @@ const (
 	DPOSVersion3_7 = "dpos:v3.7"
 	// Enables stripping of voting power from jailed validators
 	DPOSVersion3_8 = "dpos:v3.8"
+	// Enables IgnoreUnbondLocktime contract method
+	DPOSVersion3_9 = "dpos:v3.9"
 
 	// Enables rewards to be distributed even when a delegator owns less than 0.01% of the validator's stake
 	// Also makes whitelists give bonuses correctly if whitelist locktime tier is set to be 0-3 (else defaults to 5%)


### PR DESCRIPTION
This parameter is useful for setting up various DPOS scenarios on testnets.
The `dpos:v3.9` feature flag must be enabled for this parameter to have effect.