### PR TITLE
Add dpos3 redelegate-all command

### DIFF
--- a/cmd/loom/dposV3_commands.go
+++ b/cmd/loom/dposV3_commands.go
@@ -804,7 +804,7 @@ func RedelegateAllDelegationsCmd() *cobra.Command {
 	var flags cli.ContractCallFlags
 	cmd := &cobra.Command{
 		Use:     "redelegate-all [validator address]",
-		Short:   "randomly redelegate all delegations from one validator to other validators",
+		Short:   "Randomly redelegate all delegations from one validator to other validators",
 		Example: redelegateAllCmdExample,
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -949,6 +949,11 @@ func RedelegateAllDelegationsCmd() *cobra.Command {
 					}, nil,
 				)
 				if err != nil {
+					out, marshalErr := json.MarshalIndent(summary, "", "  ")
+					if marshalErr != nil {
+						return err
+					}
+					fmt.Println(string(out))
 					return errors.Wrapf(
 						err, "failed to redelegate delegation at index %d to %s",
 						d.Index, destValidatorAddr.String(),

--- a/cmd/loom/dposV3_commands.go
+++ b/cmd/loom/dposV3_commands.go
@@ -2,16 +2,19 @@ package main
 
 import (
 	"encoding/base64"
-	"errors"
+	"encoding/json"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	loom "github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/builtin/types/dposv3"
 	"github.com/loomnetwork/go-loom/cli"
 	"github.com/loomnetwork/go-loom/types"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -783,6 +786,177 @@ func UnbondAllDelegationsCmdV3() *cobra.Command {
 	return cmd
 }
 
+const redelegateAllCmdExample = `
+loom dpos3 redelegate-all 0x7262d4c97c7B93937E4810D289b7320e9dA82857 -k path/to/private_key
+`
+
+func RedelegateAllDelegationsCmd() *cobra.Command {
+	var flags cli.ContractCallFlags
+	cmd := &cobra.Command{
+		Use:     "redelegate-all [validator address]",
+		Short:   "randomly redelegate all delegations from one validator to other validators",
+		Example: redelegateAllCmdExample,
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			srcValidatorAddr, err := cli.ParseAddress(args[0], flags.ChainID)
+			if err != nil {
+				return err
+			}
+
+			// check the key matches the oracle
+			signer, err := cli.GetSigner(flags.PrivFile, flags.HsmConfigFile, flags.Algo)
+			if err != nil {
+				return err
+			}
+			signerAddr := loom.LocalAddressFromPublicKey(signer.PublicKey())
+
+			var stateResp dposv3.GetStateResponse
+			err = cli.StaticCallContractWithFlags(
+				&flags, DPOSV3ContractName, "GetState", &dposv3.GetStateRequest{}, &stateResp,
+			)
+			if err != nil {
+				return errors.Wrap(err, "failed to fetch DPOS contract state")
+			}
+
+			if stateResp.State.Params.OracleAddress.Local.Compare(signerAddr) != 0 {
+				return errors.New("private key doesn't match oracle")
+			}
+
+			if len(stateResp.State.Validators) < 2 {
+				return errors.New("insufficient number of validators")
+			}
+
+			var candidatesResp dposv3.ListCandidatesResponse
+			err = cli.StaticCallContractWithFlags(
+				&flags, DPOSV3ContractName, "ListCandidates",
+				&dposv3.ListCandidatesRequest{}, &candidatesResp,
+			)
+			if err != nil {
+				return errors.Wrap(err, "failed to fetch candidates")
+			}
+
+			type redelegationInfo struct {
+				Delegator   string
+				FromIndex   uint64
+				ToValidator string
+				Amount      string
+			}
+			type validatorInfo struct {
+				Name    string
+				Address string
+			}
+			summary := struct {
+				FromValidator string
+				ToValidators  []validatorInfo
+				Redelegations []redelegationInfo
+			}{
+				FromValidator: srcValidatorAddr.String(),
+			}
+
+			// if the validator is no longer a candidate there's no way to figure out what their
+			// fee was so just assume it was 100%
+			currentFee := uint64(10000)
+			for _, c := range candidatesResp.Candidates {
+				if srcValidatorAddr.Compare(loom.UnmarshalAddressPB(c.Candidate.Address)) == 0 {
+					currentFee = c.Candidate.Fee
+					break
+				}
+			}
+
+			// make a list of all the other validators we'll be redelegating to
+			validators := make([]loom.Address, 0, len(stateResp.State.Validators))
+			for _, v := range stateResp.State.Validators {
+				validatorAddr := loom.Address{
+					ChainID: flags.ChainID,
+					Local:   loom.LocalAddressFromPublicKey(v.PubKey),
+				}
+				if validatorAddr.Compare(srcValidatorAddr) == 0 {
+					continue
+				}
+				// only redelegate to validators with the same or lower fee as the original validator
+				for _, c := range candidatesResp.Candidates {
+					if validatorAddr.Compare(loom.UnmarshalAddressPB(c.Candidate.Address)) == 0 {
+						if !c.Statistic.Jailed && (c.Candidate.Fee <= currentFee) {
+							validators = append(validators, validatorAddr)
+							summary.ToValidators = append(summary.ToValidators, validatorInfo{
+								Name:    c.Candidate.Name,
+								Address: validatorAddr.String(),
+							})
+						}
+						break
+					}
+				}
+			}
+
+			var delegationsResp dposv3.ListDelegationsResponse
+			err = cli.StaticCallContractWithFlags(
+				&flags, DPOSV3ContractName, "ListDelegations",
+				&dposv3.ListDelegationsRequest{Candidate: srcValidatorAddr.MarshalPB()}, &delegationsResp,
+			)
+			if err != nil {
+				return errors.Wrap(err, "failed to fetch delegations")
+			}
+
+			destValidatorPerDelegator := map[string]loom.Address{}
+
+			// randomly redelegate all the validator's delegations
+			rand.Seed(time.Now().UTC().UnixNano())
+			for _, d := range delegationsResp.Delegations {
+				// don't bother redelegating worthless delegations
+				if d.State != dposv3.Delegation_BONDED || d.Amount == nil || d.Amount.Value.Int.Sign() <= 0 {
+					continue
+				}
+				delegatorAddr := loom.UnmarshalAddressPB(d.Delegator)
+				// don't redelegate the validator rewards delegation
+				if d.Index == 0 && delegatorAddr.Compare(srcValidatorAddr) == 0 {
+					continue
+				}
+
+				// if a delegator has multiple delegations to the original validator move them all to
+				// a single validator instead of dispersing them across all the other validators,
+				// this will allow the delegator to easily consolidate them all later if they want
+				var destValidatorAddr loom.Address
+				var exists bool
+				if destValidatorAddr, exists = destValidatorPerDelegator[delegatorAddr.String()]; !exists {
+					destValidatorAddr = validators[rand.Intn(len(validators))]
+					destValidatorPerDelegator[delegatorAddr.String()] = destValidatorAddr
+				}
+
+				summary.Redelegations = append(summary.Redelegations, redelegationInfo{
+					Delegator:   delegatorAddr.String(),
+					FromIndex:   d.Index,
+					ToValidator: destValidatorAddr.String(),
+					Amount:      d.Amount.Value.Int.String(),
+				})
+
+				err = cli.CallContractWithFlags(
+					&flags, DPOSV3ContractName, "Redelegate",
+					&dposv3.RedelegateRequest{
+						DelegatorAddress:       d.Delegator,
+						Index:                  d.Index,
+						ValidatorAddress:       destValidatorAddr.MarshalPB(),
+						FormerValidatorAddress: srcValidatorAddr.MarshalPB(),
+					}, nil,
+				)
+				if err != nil {
+					return errors.Wrapf(
+						err, "failed to redelegate delegation at index %d to %s",
+						d.Index, destValidatorAddr.String(),
+					)
+				}
+			}
+			out, err := json.MarshalIndent(summary, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+			return nil
+		},
+	}
+	cli.AddContractCallFlags(cmd.Flags(), &flags)
+	return cmd
+}
+
 const claimDelegatorRewardsCmdExample = `
 loom dpos3 claim-delegator-rewards --key path/to/private_key
 `
@@ -1438,6 +1612,7 @@ func NewDPOSV3Command() *cobra.Command {
 		DowntimeRecordCmdV3(),
 		UnbondCmdV3(),
 		UnbondAllDelegationsCmdV3(),
+		RedelegateAllDelegationsCmd(),
 		RegisterReferrerCmdV3(),
 		SetDowntimePeriodCmdV3(),
 		SetElectionCycleCmdV3(),

--- a/cmd/loom/dposV3_commands.go
+++ b/cmd/loom/dposV3_commands.go
@@ -28,17 +28,27 @@ var (
 
 const unregisterCandidateCmdExample = ` 
 loom dpos3 unregister-candidate --key path/to/private_key
+loom dpos3 unregister-candidate <candidate address> --key path/to/oracle_private_key
 `
 
 func UnregisterCandidateCmdV3() *cobra.Command {
 	var flags cli.ContractCallFlags
 	cmd := &cobra.Command{
 		Use:     "unregister-candidate",
-		Short:   "Unregisters the candidate (only called if previously registered)",
+		Short:   "Unregister a previously registered candidate",
 		Example: unregisterCandidateCmdExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			var candidateAddrPB *types.Address
+			if len(args) == 1 {
+				addr, err := cli.ParseAddress(args[0], flags.ChainID)
+				if err != nil {
+					return err
+				}
+				candidateAddrPB = addr.MarshalPB()
+			}
 			return cli.CallContractWithFlags(
-				&flags, DPOSV3ContractName, "UnregisterCandidate", &dposv3.UnregisterCandidateRequest{}, nil,
+				&flags, DPOSV3ContractName, "UnregisterCandidate",
+				&dposv3.UnregisterCandidateRequest{Candidate: candidateAddrPB}, nil,
 			)
 		},
 	}


### PR DESCRIPTION
`redelegate-all` can be used to randomly redistribute delegations from former validators to currently active validators.