### PR TITLE
Disable key sorting in the EVM by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,8 +161,8 @@ type GethConfig struct {
 
 func DefaultGethConfig() *GethConfig {
 	return &GethConfig{
-		EnableStateObjectDirtyStorageKeysSorting: true,
-		EnableTrieDatabasePreimageKeysSorting:    true,
+		EnableStateObjectDirtyStorageKeysSorting: false,
+		EnableTrieDatabasePreimageKeysSorting:    false,
 	}
 }
 


### PR DESCRIPTION
Had this sorting disabled on our Basechain nodes for a few weeks now, so should be safe to make it the default.