### PR TITLE
Add two more migration tx slots for testing

### DIFF
--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -861,6 +861,8 @@ func loadApp(
 			1: migrations.DPOSv3Migration,
 			2: migrations.GatewayMigration,
 			3: migrations.GatewayMigration,
+			4: migrations.GatewayMigration,
+			5: migrations.GatewayMigration,
 		},
 	}
 


### PR DESCRIPTION
Need more slots for testing on the testnet since we've previously used both gateway migration slots.