### PR TITLE
Load the bsc-gateway Go contract by default

### DIFF
--- a/cmd/loom/config.go
+++ b/cmd/loom/config.go
@@ -197,12 +197,19 @@ func defaultGenesis(cfg *config.Config, validator *loom.Validator) (*config.Gene
 	}
 
 	if cfg.BscTransferGateway.ContractEnabled {
+		initBytes, err := marshalInit(&tgtypes.TransferGatewayInitRequest{
+			Owner: contractOwner,
+		})
+		if err != nil {
+			return nil, err
+		}
 		contracts = append(contracts,
 			config.ContractConfig{
 				VMTypeName: "plugin",
 				Format:     "plugin",
 				Name:       "bsc-gateway",
 				Location:   "bsc-gateway:0.1.0",
+				Init:       initBytes,
 			})
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -446,7 +446,6 @@ func DefaultConfig() *Config {
 	cfg.LoomCoinTransferGateway = DefaultLoomCoinTGConfig(cfg.RPCProxyPort)
 	cfg.TronTransferGateway = DefaultTronTGConfig(cfg.RPCProxyPort)
 	cfg.BinanceTransferGateway = DefaultBinanceTGConfig()
-	//In theory binance smart chain should have no unique logic
 	cfg.BscTransferGateway = DefaultBscLoomCoinTGConfig(cfg.RPCProxyPort)
 	cfg.PlasmaCash = plasmacfg.DefaultConfig()
 	cfg.AppStore = store.DefaultConfig()

--- a/config/gateway_config.go
+++ b/config/gateway_config.go
@@ -29,7 +29,9 @@ func DefaultBinanceTGConfig() *TransferGatewayConfig {
 }
 
 func DefaultBscLoomCoinTGConfig(rpcProxyPort int32) *TransferGatewayConfig {
-	return gateway.DefaultLoomCoinTGConfig(rpcProxyPort)
+	cfg := gateway.DefaultLoomCoinTGConfig(rpcProxyPort)
+	cfg.ContractEnabled = true // enabled by default for easier production deployment
+	return cfg
 }
 
 func DefaultDPOS2OracleConfig() *OracleSerializableConfig {
@@ -170,16 +172,18 @@ TronTransferGateway:
   {{- end}}
 
 #
-# Binance Transfer Gateway
+# Binance Chain Transfer Gateway
 #
 BinanceTransferGateway:
   # Enables the Transfer Gateway Go contract on the node, must be the same on all nodes.
   ContractEnabled: {{ .BinanceTransferGateway.ContractEnabled }}
 
+#
+# Binance Smart Chain LOOM Transfer Gateway
+#
 BscTransferGateway:
   # Enables the Transfer Gateway Go contract on the node, must be the same on all nodes.
   ContractEnabled: {{ .BscTransferGateway.ContractEnabled }}
-
 
 #
 # Oracle serializable 


### PR DESCRIPTION
This makes it easier to deploy the contract to the production cluster because validators won't have to mess about with `loom.yml`.