### PR TITLE
Add ability to copy out the currently used state from the app DB to a new DB

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -300,12 +300,12 @@
   version = "v0.14.0"
 
 [[projects]]
-  branch = "mutable-tree-with-version"
+  branch = "loomchain2"
   digest = "1:616d73fa55bb6f54da4bfcf804a813f14c9d63a2bdfbb5d0966e5011f46f42ac"
   name = "github.com/tendermint/iavl"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6500a2aad8cd0f02c9818e879292045c052f2576"
+  revision = "f3e6af2bc85a1fff128df95122a09bc5f521e322"
   source = "https://github.com/loomnetwork/iavl.git"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -300,12 +300,12 @@
   version = "v0.14.0"
 
 [[projects]]
-  branch = "tmreal2"
-  digest = "1:5404ef08f18ff942573397a29a62fe03f35e94ec512c90b750ff06175fcf01f9"
+  branch = "mutable-tree-with-version"
+  digest = "1:89ba636c43f3da4fc728ab2eb4c0f1f9136aed36ed27dfb2f522efdbc1d84687"
   name = "github.com/tendermint/iavl"
   packages = ["."]
   pruneopts = "UT"
-  revision = "45ae3144d0e8f894502f09de56de2a65118651fe"
+  revision = "cdbc37ca3885076093f66cd45927f4f95e51d80c"
   source = "https://github.com/loomnetwork/iavl.git"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -301,11 +301,11 @@
 
 [[projects]]
   branch = "mutable-tree-with-version"
-  digest = "1:89ba636c43f3da4fc728ab2eb4c0f1f9136aed36ed27dfb2f522efdbc1d84687"
+  digest = "1:616d73fa55bb6f54da4bfcf804a813f14c9d63a2bdfbb5d0966e5011f46f42ac"
   name = "github.com/tendermint/iavl"
   packages = ["."]
   pruneopts = "UT"
-  revision = "cdbc37ca3885076093f66cd45927f4f95e51d80c"
+  revision = "6500a2aad8cd0f02c9818e879292045c052f2576"
   source = "https://github.com/loomnetwork/iavl.git"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -80,7 +80,7 @@ ignored = [
 [[override]]
   name = "github.com/tendermint/iavl"
   source = "https://github.com/loomnetwork/iavl.git"
-  branch = "tmreal2"
+  branch = "mutable-tree-with-version"
 
 [[override]]
   name = "github.com/tendermint/go-amino"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -80,7 +80,7 @@ ignored = [
 [[override]]
   name = "github.com/tendermint/iavl"
   source = "https://github.com/loomnetwork/iavl.git"
-  branch = "mutable-tree-with-version"
+  branch = "loomchain2"
 
 [[override]]
   name = "github.com/tendermint/go-amino"

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = app-store-clone-at-height
+GO_LOOM_GIT_REV = HEAD
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BINANCE_TGORACLE_DIR=$(GOPATH)/src/$(PKG_BINANCE_TGORACLE)
 # NOTE: To build on Jenkins using a custom go-loom branch update the `deps` target below to checkout
 #       that branch, you only need to update GO_LOOM_GIT_REV if you wish to lock the build to a
 #       specific commit.
-GO_LOOM_GIT_REV = HEAD
+GO_LOOM_GIT_REV = app-store-clone-at-height
 # Specifies the loomnetwork/transfer-gateway branch/revision to use.
 TG_GIT_REV = HEAD
 # loomnetwork/go-ethereum loomchain branch

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ GOFLAGS_NOEVM = -ldflags "$(GOFLAGS_BASE)"
 
 WINDOWS_BUILD_VARS = CC=x86_64-w64-mingw32-gcc CGO_ENABLED=1 GOOS=windows GOARCH=amd64 BIN_EXTENSION=.exe
 
-E2E_TESTS_TIMEOUT = 37m
+E2E_TESTS_TIMEOUT = 39m
 
 .PHONY: all clean test install get_lint update_lint deps proto builtin oracles tgoracle loomcoin_tgoracle bsc_tgoracle tron_tgoracle binance_tgoracle pcoracle dposv2_oracle basechain-cleveldb loom-cleveldb lint
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ make proto
 
 > See the [Go Generated Code](https://developers.google.com/protocol-buffers/docs/reference/go-generated) page for more details about how you can use the generated protobuf messages.
 
+## Update vendored Go dependencies
+
+Some of the Go dependencies are vendored using [Dep](https://golang.github.io/dep/). Most common
+operation when dealing with the vendored dependencies is to update the Tendermint or IAVL
+branch/revision. This can be done by updating the branch/revision in `Gopkg.toml` and then running
+`dep ensure -update`.
+
+For example:
+```shell
+dep ensure -v -update github.com/tendermint/iavl
+```
+
 ## Useful Links
 
 * [Developer Documentation](https://loomx.io/developers/)

--- a/cmd/loom/db/app.go
+++ b/cmd/loom/db/app.go
@@ -1,15 +1,23 @@
 package db
 
 import (
+	"bytes"
 	"fmt"
+	"math"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
+	"time"
 
+	"github.com/loomnetwork/go-loom"
+	"github.com/loomnetwork/go-loom/util"
 	"github.com/loomnetwork/loomchain/cmd/loom/common"
 	"github.com/loomnetwork/loomchain/store"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/tendermint/iavl"
 	dbm "github.com/tendermint/tendermint/libs/db"
 )
 
@@ -76,5 +84,227 @@ func newGetAppHeightCommand() *cobra.Command {
 			return nil
 		},
 	}
+	return cmd
+}
+
+type prefixStat struct {
+	NumKeys        int
+	TotalKeySize   int
+	TotalValueSize int
+}
+
+type contractPrefix struct {
+	Name    string
+	Address string
+	Prefix  []byte
+}
+
+func contractAddressToPrefix(contractAddr string) []byte {
+	addr, err := loom.LocalAddressFromHexString(contractAddr)
+	if err != nil {
+		panic(err)
+	}
+	return util.PrefixKey([]byte("contract"), []byte(addr))
+}
+
+func newAnalyzeCommand() *cobra.Command {
+	var logLevel int64
+	prefixes := [][]byte{
+		[]byte("nonce"),
+		[]byte("vm"),
+		[]byte("receipt"),
+		[]byte("txHash"),
+		[]byte("bloomFilter"),
+		[]byte("feature"),
+		[]byte("config"),
+		[]byte("registry"),
+		[]byte("reg_caddr"),
+		[]byte("reg_crec"),
+	}
+	// Native contracts deployed to Basechain
+	contracts := []contractPrefix{
+		{Name: "address-mapper", Prefix: contractAddressToPrefix("0xb9fA0896573A89cF4065c43563C069b3B3C15c37")},
+		{Name: "coin", Prefix: contractAddressToPrefix("0xe288d6eec7150D6a22FDE33F0AA2d81E06591C4d")},
+		{Name: "ethcoin", Prefix: contractAddressToPrefix("0xde28fb974f31dFbe759cFcB3d1D44C2eeFDFaDd1")},
+		{Name: "dposV1", Prefix: contractAddressToPrefix("0x01D10029c253fA02D76188b84b5846ab3D19510D")},
+		{Name: "dposV2", Prefix: contractAddressToPrefix("0x35754161AC4Bfa2A20eacf0EfB0f26CBdC418112")},
+		{Name: "dposV3", Prefix: contractAddressToPrefix("0xC72783049049c3D887A85dF8061f3141E2C931Cc")},
+		{Name: "gateway", Prefix: contractAddressToPrefix("0xC5d1847a03dA59407F27f8FE7981D240bff2dfD3")},
+		{Name: "loomcoin-gateway", Prefix: contractAddressToPrefix("0xbC968be1656396E568736D5a8E364ac8Ca430B43")},
+		{Name: "tron-gateway", Prefix: contractAddressToPrefix("0x4Dc5C9Cee0827630039Db5E59dfB18e5c679201c")},
+		{Name: "binance-gateway", Prefix: contractAddressToPrefix("0x7E0DF5C9fF8898F0e1B4Af4D133Ef557A0641AA8")},
+		{Name: "bsc-gateway", Prefix: contractAddressToPrefix("0x3125ca7E54f096A7898A8E14471b281581231724")},
+		{Name: "deployer-whitelist", Prefix: contractAddressToPrefix("0xe06AbE129e3fE698bbAB7E3185C798fa2b1a7A50")},
+		{Name: "user-deployer-whitelist", Prefix: contractAddressToPrefix("0x278A1C914c046E2d085a84Ee373091a4FB6e19F4")},
+		{Name: "chain-config", Prefix: contractAddressToPrefix("0x938312E21AC551251Bd9fCC5dFaa7A5278302339")},
+	}
+	cmd := &cobra.Command{
+		Use:   "analyze <path/to/app.db>",
+		Short: "Analyze how much space is taken up by data under the standard key prefixes",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, contract := range contracts {
+				prefixes = append(prefixes, contract.Prefix)
+			}
+
+			srcDBPath, err := filepath.Abs(args[0])
+			if err != nil {
+				return fmt.Errorf("Failed to resolve app.db path '%s'", args[0])
+			}
+			dbName := strings.TrimSuffix(path.Base(srcDBPath), ".db")
+			dbDir := path.Dir(srcDBPath)
+
+			db, err := dbm.NewGoLevelDBWithOpts(dbName, dbDir, &opt.Options{
+				ReadOnly: true,
+			})
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			mutableTree := iavl.NewMutableTree(db, 0)
+			treeVersion, err := mutableTree.Load()
+			if err != nil {
+				return errors.Wrap(err, "failed to load mutable tree")
+			}
+
+			immutableTree, err := mutableTree.GetImmutable(treeVersion)
+			if err != nil {
+				return errors.Wrapf(err, "failed to load immutable tree for version %v", treeVersion)
+			}
+
+			leaves := uint(immutableTree.Size())
+			var progressInterval uint64
+			if logLevel > 0 {
+				progressInterval = uint64(leaves / uint(math.Pow(10, float64(logLevel))))
+			}
+
+			fmt.Printf("IAVL tree height %v with %v keys\n", immutableTree.Height(), immutableTree.Size())
+
+			rawStats := map[string]*prefixStat{}
+			var miscStat prefixStat
+			var keyCount uint64
+			startTime := time.Now()
+			immutableTree.Iterate(func(key, value []byte) bool {
+				var stat *prefixStat
+				for _, prefix := range prefixes {
+					if util.HasPrefix(key, prefix) {
+						stat = rawStats[string(prefix)]
+						if stat == nil {
+							stat = &prefixStat{}
+							rawStats[string(prefix)] = stat
+						}
+
+						stat.NumKeys++
+						stat.TotalKeySize += len(key)
+						stat.TotalValueSize += len(value)
+						break
+					}
+				}
+
+				// track anything that didn't fall within one of the standard prefixes
+				if stat == nil {
+					miscStat.NumKeys++
+					miscStat.TotalKeySize += len(key)
+					miscStat.TotalValueSize += len(value)
+				}
+
+				keyCount++
+				if progressInterval > 0 && (keyCount%progressInterval) == 0 {
+					elapsed := time.Since(startTime).Minutes()
+					fractionDone := float64(keyCount) / float64(leaves)
+					expected := elapsed / fractionDone
+
+					fmt.Printf(
+						"%v%% done in %v mins. ETA %v mins.\n",
+						int(fractionDone*100), int(elapsed), int(expected-elapsed),
+					)
+				}
+				return false
+			})
+
+			stats := map[string]*prefixStat{}
+			sortedPrefixes := []string{}
+			for prefix, stat := range rawStats {
+				if util.HasPrefix([]byte(prefix), []byte("contract")) {
+					for _, c := range contracts {
+						if bytes.Compare(c.Prefix, []byte(prefix)) == 0 {
+							stats[c.Name] = stat
+							sortedPrefixes = append(sortedPrefixes, c.Name)
+							break
+						}
+					}
+				} else {
+					stats[string(prefix)] = stat
+					sortedPrefixes = append(sortedPrefixes, string(prefix))
+				}
+			}
+
+			sort.Strings(sortedPrefixes)
+			sortedPrefixes = append(sortedPrefixes, "misc")
+			stats["misc"] = &miscStat
+
+			var totalKeySize, totalValueSize int
+			for _, prefix := range sortedPrefixes {
+				if stat := stats[prefix]; stat != nil {
+					totalKeySize += stat.TotalKeySize
+					totalValueSize += stat.TotalValueSize
+				}
+			}
+
+			ml := struct {
+				Prefix   int
+				Keys     int
+				KSize    int
+				VSize    int
+				KPercent int
+				VPercent int
+			}{
+				Prefix:   20,
+				Keys:     20,
+				KSize:    20,
+				VSize:    20,
+				KPercent: 6,
+				VPercent: 6,
+			}
+
+			// ensure the longest prefix fits the first column
+			for _, prefix := range sortedPrefixes {
+				if len(prefix) > ml.Prefix {
+					ml.Prefix = len(prefix)
+				}
+			}
+
+			fmt.Printf(
+				"%-*s | %-*s | %-*s | %-*s | %-*s | %-*s\n",
+				ml.Prefix, "Prefix",
+				ml.Keys, "Keys",
+				ml.KSize, "K Size",
+				ml.VSize, "V Size",
+				ml.KPercent, "K %",
+				ml.VPercent, "V %",
+			)
+			fmt.Printf(strings.Repeat("-", ml.Prefix+ml.Keys+ml.KSize+ml.VSize+ml.KPercent+ml.VPercent+16) + "\n")
+
+			for _, prefix := range sortedPrefixes {
+				if stat := stats[prefix]; stat != nil {
+					keyPercentage := float64(stat.TotalKeySize) / float64(totalKeySize) * 100.0
+					valuePercentage := float64(stat.TotalValueSize) / float64(totalValueSize) * 100.0
+					fmt.Printf(
+						"%-*s | %-*d | %-*d | %-*d | %*.2f | %*.2f\n",
+						ml.Prefix, prefix,
+						ml.Keys, stat.NumKeys,
+						ml.KSize, stat.TotalKeySize,
+						ml.VSize, stat.TotalValueSize,
+						ml.KPercent, keyPercentage,
+						ml.VPercent, valuePercentage,
+					)
+				}
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().Int64Var(&logLevel, "log", 0, "How often progress output should be printed. 1 - every 10%, 2 - every 1%, 3 - every 0.1%.")
 	return cmd
 }

--- a/cmd/loom/db/db.go
+++ b/cmd/loom/db/db.go
@@ -21,6 +21,7 @@ func NewDBCommand() *cobra.Command {
 		newGetAppHeightCommand(),
 		newAnalyzeCommand(),
 		newExtractCurrentStateCommand(),
+		newCompareCurrentStateCommand(),
 	)
 	return cmd
 }

--- a/cmd/loom/db/db.go
+++ b/cmd/loom/db/db.go
@@ -20,6 +20,7 @@ func NewDBCommand() *cobra.Command {
 		newGetEvmHeightCommand(),
 		newGetAppHeightCommand(),
 		newAnalyzeCommand(),
+		newExtractCurrentStateCommand(),
 	)
 	return cmd
 }

--- a/cmd/loom/db/db.go
+++ b/cmd/loom/db/db.go
@@ -19,6 +19,7 @@ func NewDBCommand() *cobra.Command {
 		newDumpEVMStateFromEvmDB(),
 		newGetEvmHeightCommand(),
 		newGetAppHeightCommand(),
+		newAnalyzeCommand(),
 	)
 	return cmd
 }

--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -387,7 +387,6 @@ func newRunCommand() *cobra.Command {
 				return err
 			}
 
-			// TODO: Move this to loadAppStore?
 			// Load app height from app.db
 			appDB, err := cdb.LoadDB(
 				cfg.DBBackend, cfg.DBName, cfg.RootPath(), cfg.DBBackendConfig.CacheSizeMegs,

--- a/cmd/loom/loom.go
+++ b/cmd/loom/loom.go
@@ -387,6 +387,7 @@ func newRunCommand() *cobra.Command {
 				return err
 			}
 
+			// TODO: Move this to loadAppStore?
 			// Load app height from app.db
 			appDB, err := cdb.LoadDB(
 				cfg.DBBackend, cfg.DBName, cfg.RootPath(), cfg.DBBackendConfig.CacheSizeMegs,
@@ -608,25 +609,15 @@ func destroyBlockIndexDB(cfg *config.Config) error {
 }
 
 func loadAppStore(cfg *config.Config, logger *loom.Logger, targetVersion int64) (store.VersionedKVStore, error) {
-	db, err := cdb.LoadDB(
-		cfg.DBBackend, cfg.DBName, cfg.RootPath(), cfg.DBBackendConfig.CacheSizeMegs, cfg.DBBackendConfig.WriteBufferMegs, cfg.Metrics.Database,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	if cfg.AppStore.CompactOnLoad {
-		logger.Info("Compacting app store...")
-		if err := db.Compact(); err != nil {
-			// compaction erroring out may indicate larger issues with the db,
-			// but for now let's try loading the app store anyway...
-			logger.Error("Failed to compact app store", "DBName", cfg.DBName, "err", err)
-		}
-		logger.Info("Finished compacting app store")
-	}
-
 	var appStore store.VersionedKVStore
 	if cfg.AppStore.Version == 1 { // TODO: cleanup these hardcoded numbers
+		db, err := cdb.LoadDB(
+			cfg.DBBackend, cfg.DBName, cfg.RootPath(), cfg.DBBackendConfig.CacheSizeMegs,
+			cfg.DBBackendConfig.WriteBufferMegs, cfg.Metrics.Database,
+		)
+		if err != nil {
+			return nil, err
+		}
 		if cfg.AppStore.PruneInterval > int64(0) {
 			logger.Info("Loading Pruning IAVL Store")
 			appStore, err = store.NewPruningIAVLStore(db, store.PruningIAVLStoreConfig{
@@ -648,7 +639,29 @@ func loadAppStore(cfg *config.Config, logger *loom.Logger, targetVersion int64) 
 		}
 	} else if cfg.AppStore.Version == 3 {
 		logger.Info("Loading Multi-Writer App Store")
-		iavlStore, err := store.NewIAVLStore(db, cfg.AppStore.MaxVersions, targetVersion, cfg.AppStore.IAVLFlushInterval)
+		clonedDBName := cfg.DBName + "_v2"
+		if err := store.SwitchToLatestAppStoreDB(
+			cfg.DBBackend, cfg.DBName, clonedDBName, cfg.RootPath(),
+		); err != nil {
+			return nil, err
+		}
+		originalDB, err := cdb.LoadDB(
+			cfg.DBBackend, cfg.DBName, cfg.RootPath(), cfg.DBBackendConfig.CacheSizeMegs,
+			cfg.DBBackendConfig.WriteBufferMegs, cfg.Metrics.Database,
+		)
+		if err != nil {
+			return nil, err
+		}
+		clonedDB, err := cdb.LoadDB(
+			cfg.DBBackend, clonedDBName, cfg.RootPath(), cfg.DBBackendConfig.CacheSizeMegs,
+			cfg.DBBackendConfig.WriteBufferMegs, cfg.Metrics.Database,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load cloned AppStore DB")
+		}
+		iavlStore, err := store.NewIAVLStoreWithDualDBs(
+			originalDB, clonedDB, cfg.AppStore.MaxVersions, targetVersion, cfg.AppStore.IAVLFlushInterval,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -665,6 +678,7 @@ func loadAppStore(cfg *config.Config, logger *loom.Logger, targetVersion int64) 
 	}
 
 	if cfg.LogStateDB {
+		var err error
 		appStore, err = store.NewLogStore(appStore)
 		if err != nil {
 			return nil, err
@@ -672,6 +686,7 @@ func loadAppStore(cfg *config.Config, logger *loom.Logger, targetVersion int64) 
 	}
 
 	if cfg.CachingStoreConfig.CachingEnabled {
+		var err error
 		appStore, err = store.NewVersionedCachingStore(appStore, cfg.CachingStoreConfig, appStore.Version())
 		if err != nil {
 			return nil, err

--- a/db/goleveldb.go
+++ b/db/goleveldb.go
@@ -52,3 +52,14 @@ func LoadGoLevelDB(name, dir string, cacheSizeMeg int, bufferSizeMeg int, collec
 	}
 	return &GoLevelDB{GoLevelDB: db}, nil
 }
+
+func LoadReadOnlyGoLevelDB(name, dir string) (*GoLevelDB, error) {
+	db, err := dbm.NewGoLevelDBWithOpts(name, dir, &opt.Options{
+		ReadOnly: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &GoLevelDB{GoLevelDB: db}, nil
+}

--- a/e2e/app-db-switchover.genesis.json
+++ b/e2e/app-db-switchover.genesis.json
@@ -60,7 +60,8 @@
                         "pubKey": "d0tPCyhVkSDMmxqquEj+/rA1cVZDZrK3suMn/gPLWd0=",
                         "power": "10"
                     }
-                ]
+                ],
+                "initCandidates": true
             }
         }
     ],

--- a/e2e/app-db-switchover.genesis.json
+++ b/e2e/app-db-switchover.genesis.json
@@ -1,0 +1,72 @@
+{
+    "contracts": [
+        {
+            "vm": "plugin",
+            "format": "plugin",
+            "name": "coin",
+            "location": "coin:1.0.0",
+            "init": null
+        },
+        {
+            "vm": "plugin",
+            "format": "plugin",
+            "name": "chainconfig",
+            "location": "chainconfig:1.0.0",
+            "init": {
+                "owner": {
+                    "chainId":"default",
+                    "local":"1iDFloNUN+KiipnzQpOeXAmLQUk="
+                },
+                "params": {
+                    "voteThreshold":"100",
+                    "numBlockConfirmations":"1"
+                },
+                "features": [
+                    {
+                        "name":"dposv3",
+                        "status":"WAITING"
+                    },
+                    {
+                        "name":"chaincfg:v1.3",
+                        "status":"WAITING"
+                    }
+                ]
+            }
+        },
+        {
+            "vm": "plugin",
+            "format": "plugin",
+            "name": "dposV3",
+            "location": "dposV3:3.0.0",
+            "init": {
+                "params": {
+                    "validatorCount": "4",
+                    "electionCycleLength": "0"
+                },
+                "validators": [
+                    {
+                        "pubKey": "XvkW4a0U6o8x/SYtDx5RFTWcATdf9212+OodZWFR0mc=",
+                        "power": "10"
+                    },
+                    {
+                        "pubKey": "YOVrdKhgPrRp0oy2NCHkJv0MQBdVWbbsnwH2FUkOPng=",
+                        "power": "10"
+                    },
+                    {
+                        "pubKey": "tlO6quUK0AKU3wAIs0llQzunJtl+6jMRn+hWkC6VlZk=",
+                        "power": "10"
+                    },
+                    {
+                        "pubKey": "d0tPCyhVkSDMmxqquEj+/rA1cVZDZrK3suMn/gPLWd0=",
+                        "power": "10"
+                    }
+                ]
+            }
+        }
+    ],
+    "config": {
+        "app_store": {
+            "clone_state_at_height": 15
+        }
+    }
+}

--- a/e2e/app-db-switchover.genesis.json
+++ b/e2e/app-db-switchover.genesis.json
@@ -27,6 +27,14 @@
                         "status":"WAITING"
                     },
                     {
+                        "name":"chaincfg:v1.1",
+                        "status":"WAITING"
+                    },
+                    {
+                        "name":"chaincfg:v1.2",
+                        "status":"WAITING"
+                    },
+                    {
                         "name":"chaincfg:v1.3",
                         "status":"WAITING"
                     }
@@ -67,7 +75,7 @@
     ],
     "config": {
         "app_store": {
-            "clone_state_at_height": 15
+            "clone_state_at_height": 10
         }
     }
 }

--- a/e2e/app-db-switchover.toml
+++ b/e2e/app-db-switchover.toml
@@ -3,21 +3,16 @@
   Condition = "excludes"
   Excluded = ["Error"]
 
-# This just creates a pending action... that never seems to get applied for some reason
-#[[TestCases]]
-#  RunCmd = "{{ $.LoomPath }} chain-cfg set-setting AppStore.CloneStateAtHeight --value 20 --build 0 -k {{index $.NodePrivKeyPathList 0}}"
-#  Condition = "excludes"
-#  Excluded = ["Error", "RPC error"]
-
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} chain-cfg config"
   Condition = "excludes"
   Excluded = ["Error", "RPC error"]
 
-# wait 310s (~5m) for 2 new blocks to be generated (310000ms)
+# app.db cloning will take place at block 10, so wait until that happens...
 [[TestCases]]
-  RunCmd = "wait_for_block_height_to_reach 0 17"
+  RunCmd = "wait_for_block_height_to_reach 0 12"
 
+# kill node 1 for 1s, it will swap out the app.db on restart
 [[TestCases]]
   RunCmd = "kill_and_restart_node 1 1"
 
@@ -25,8 +20,33 @@
 [[TestCases]]
   RunCmd = "wait_for_node_to_catch_up 1"
 
+# send through a tx, doesn't matter what it does, just need to change app state
 [[TestCases]]
-  Delay = 10000
-  RunCmd = "{{ $.LoomPath }} dpos3 downtime-record"
+  RunCmd = "{{ $.LoomPath }} dpos3 change-fee 2000 -k {{index $.NodePrivKeyPathList 0}}"
   Condition = "excludes"
   Excluded = ["Error", "RPC error"]
+
+# make sure node 1 keeps up over the next 2 blocks
+[[TestCases]]
+  RunCmd = "wait_for_block_height_to_increase 1 2"
+
+# kill node 1 again for 1s, it will not swap out the app.db this time
+[[TestCases]]
+  RunCmd = "kill_and_restart_node 1 1"
+
+# wait for node 1 to catch up
+[[TestCases]]
+  RunCmd = "wait_for_node_to_catch_up 1"
+
+# send through another tx to change app state
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} dpos3 change-fee 3000 -k {{index $.NodePrivKeyPathList 0}}"
+  Condition = "excludes"
+  Excluded = ["Error", "RPC error"]
+
+# make sure node 1 keeps up over the next 2 blocks
+[[TestCases]]
+  RunCmd = "wait_for_block_height_to_increase 1 2"
+
+[[TestCases]]
+  RunCmd = "checkapphash"

--- a/e2e/app-db-switchover.toml
+++ b/e2e/app-db-switchover.toml
@@ -1,0 +1,42 @@
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} dpos3 list-validators"
+  Condition = "excludes"
+  Excluded = ["Error"]
+
+# Doesn't work because the validators haven't registered themselves with chain-cfg at this point
+#[[TestCases]]
+#  Delay = 5000
+#  RunCmd = "{{ $.LoomPath }} chain-cfg list-validators"
+#  Condition = "excludes"
+#  Excluded = ["Error"]
+
+# This just creates a pending action... that never seems to get applied for some reason
+#[[TestCases]]
+#  RunCmd = "{{ $.LoomPath }} chain-cfg set-setting AppStore.CloneStateAtHeight --value 20 --build 0 -k {{index $.NodePrivKeyPathList 0}}"
+#  Condition = "excludes"
+#  Excluded = ["Error", "RPC error"]
+
+#[[TestCases]]
+#  RunCmd = "{{ $.LoomPath }} chain-cfg list-pending-actions"
+#  Condition = "excludes"
+#  Excluded = ["Error", "RPC error"]
+
+
+# wait for block height to increase by at least 2 blocks
+[[TestCases]]
+  RunCmd = "wait_for_block_height_to_increase 0 2"
+
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} chain-cfg config"
+  Condition = "excludes"
+  Excluded = ["Error", "RPC error"]
+
+# wait 310s (~5m) for 2 new blocks to be generated
+[[TestCases]]
+  Delay = 310000
+  RunCmd = "wait_for_block_height_to_increase 0 2"
+
+[[TestCases]]
+  RunCmd = "{{ $.LoomPath }} dpos3 downtime-record"
+  Condition = "excludes"
+  Excluded = ["Error", "RPC error"]

--- a/e2e/app-db-switchover.toml
+++ b/e2e/app-db-switchover.toml
@@ -3,40 +3,30 @@
   Condition = "excludes"
   Excluded = ["Error"]
 
-# Doesn't work because the validators haven't registered themselves with chain-cfg at this point
-#[[TestCases]]
-#  Delay = 5000
-#  RunCmd = "{{ $.LoomPath }} chain-cfg list-validators"
-#  Condition = "excludes"
-#  Excluded = ["Error"]
-
 # This just creates a pending action... that never seems to get applied for some reason
 #[[TestCases]]
 #  RunCmd = "{{ $.LoomPath }} chain-cfg set-setting AppStore.CloneStateAtHeight --value 20 --build 0 -k {{index $.NodePrivKeyPathList 0}}"
 #  Condition = "excludes"
 #  Excluded = ["Error", "RPC error"]
 
-#[[TestCases]]
-#  RunCmd = "{{ $.LoomPath }} chain-cfg list-pending-actions"
-#  Condition = "excludes"
-#  Excluded = ["Error", "RPC error"]
-
-
-# wait for block height to increase by at least 2 blocks
-[[TestCases]]
-  RunCmd = "wait_for_block_height_to_increase 0 2"
-
 [[TestCases]]
   RunCmd = "{{ $.LoomPath }} chain-cfg config"
   Condition = "excludes"
   Excluded = ["Error", "RPC error"]
 
-# wait 310s (~5m) for 2 new blocks to be generated
+# wait 310s (~5m) for 2 new blocks to be generated (310000ms)
 [[TestCases]]
-  Delay = 310000
-  RunCmd = "wait_for_block_height_to_increase 0 2"
+  RunCmd = "wait_for_block_height_to_reach 0 17"
 
 [[TestCases]]
+  RunCmd = "kill_and_restart_node 1 1"
+
+# wait for node 1 to catch up
+[[TestCases]]
+  RunCmd = "wait_for_node_to_catch_up 1"
+
+[[TestCases]]
+  Delay = 10000
   RunCmd = "{{ $.LoomPath }} dpos3 downtime-record"
   Condition = "excludes"
   Excluded = ["Error", "RPC error"]

--- a/e2e/app-db-switchover.yaml
+++ b/e2e/app-db-switchover.yaml
@@ -3,8 +3,6 @@ DPOSVersion: 3
 CreateEmptyBlocks: false
 ChainConfig: 
   ContractEnabled: true
-  EnableFeatureStartupDelay: 5
-  EnableFeatureInterval: 5
 ContractLogLevel: "debug"
 LoomLogLevel: "debug"
 AppStore:

--- a/e2e/app-db-switchover.yaml
+++ b/e2e/app-db-switchover.yaml
@@ -1,0 +1,14 @@
+ReceiptsVersion: 2
+DPOSVersion: 3
+CreateEmptyBlocks: false
+ChainConfig: 
+  ContractEnabled: true
+  EnableFeatureStartupDelay: 5
+  EnableFeatureInterval: 5
+ContractLogLevel: "debug"
+LoomLogLevel: "debug"
+AppStore:
+  Version: 3
+  SaveEVMStateToIAVL: false
+CachingStore:
+  CachingEnabled: true

--- a/e2e/chainconfig_test.go
+++ b/e2e/chainconfig_test.go
@@ -18,32 +18,42 @@ type Test struct {
 }
 
 func TestContractChainConfig(t *testing.T) {
-	test1 := Test{
-		"chainconfig",
-		"chainconfig.toml",
-		4,
-		4,
-		"chainconfig.genesis.json",
-		"chainconfig-loom.yaml",
+	tests := []Test{
+		/*
+			{
+				"chainconfig",
+				"chainconfig.toml",
+				4,
+				4,
+				"chainconfig.genesis.json",
+				"chainconfig-loom.yaml",
+			},
+			{
+				"enable-receipts-v2-feature",
+				"enable-receipts-v2-feature.toml",
+				1,
+				1,
+				"enable-receipts-v2-feature-genesis.json",
+				"enable-receipts-v2-feature-loom.yaml",
+			},
+			{
+				"chainconfig-routine",
+				"chainconfig-routine.toml",
+				4,
+				4,
+				"chainconfig.genesis.json",
+				"chainconfig-routine-loom.yaml",
+			},
+		*/
+		{
+			"app-db-switchover",
+			"app-db-switchover.toml",
+			4,
+			4,
+			"app-db-switchover.genesis.json",
+			"app-db-switchover.yaml",
+		},
 	}
-	test2 := Test{
-		"enable-receipts-v2-feature",
-		"enable-receipts-v2-feature.toml",
-		1,
-		1,
-		"enable-receipts-v2-feature-genesis.json",
-		"enable-receipts-v2-feature-loom.yaml",
-	}
-	test3 := Test{
-		"chainconfig-routine",
-		"chainconfig-routine.toml",
-		4,
-		4,
-		"chainconfig.genesis.json",
-		"chainconfig-routine-loom.yaml",
-	}
-	tests := make([]Test, 0)
-	tests = append(tests, test1, test2, test3)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			config, err := common.NewConfig(test.name, test.testFile, test.genFile, test.yamlFile, test.validators, test.accounts, 0, false)

--- a/e2e/chainconfig_test.go
+++ b/e2e/chainconfig_test.go
@@ -19,32 +19,30 @@ type Test struct {
 
 func TestContractChainConfig(t *testing.T) {
 	tests := []Test{
-		/*
-			{
-				"chainconfig",
-				"chainconfig.toml",
-				4,
-				4,
-				"chainconfig.genesis.json",
-				"chainconfig-loom.yaml",
-			},
-			{
-				"enable-receipts-v2-feature",
-				"enable-receipts-v2-feature.toml",
-				1,
-				1,
-				"enable-receipts-v2-feature-genesis.json",
-				"enable-receipts-v2-feature-loom.yaml",
-			},
-			{
-				"chainconfig-routine",
-				"chainconfig-routine.toml",
-				4,
-				4,
-				"chainconfig.genesis.json",
-				"chainconfig-routine-loom.yaml",
-			},
-		*/
+		{
+			"chainconfig",
+			"chainconfig.toml",
+			4,
+			4,
+			"chainconfig.genesis.json",
+			"chainconfig-loom.yaml",
+		},
+		{
+			"enable-receipts-v2-feature",
+			"enable-receipts-v2-feature.toml",
+			1,
+			1,
+			"enable-receipts-v2-feature-genesis.json",
+			"enable-receipts-v2-feature-loom.yaml",
+		},
+		{
+			"chainconfig-routine",
+			"chainconfig-routine.toml",
+			4,
+			4,
+			"chainconfig.genesis.json",
+			"chainconfig-routine-loom.yaml",
+		},
 		{
 			"app-db-switchover",
 			"app-db-switchover.toml",

--- a/e2e/node/cluster.go
+++ b/e2e/node/cluster.go
@@ -249,7 +249,7 @@ func CreateCluster(nodes []*Node, account []*Account, fnconsensus bool) error {
 					ChainId: "default",
 					Local:   oracleAddr,
 				}
-				init.InitCandidates = false
+				init.InitCandidates = true
 				jsonInit, err := marshalInit(&init)
 				if err != nil {
 					return err

--- a/e2e/node/cluster.go
+++ b/e2e/node/cluster.go
@@ -249,7 +249,6 @@ func CreateCluster(nodes []*Node, account []*Account, fnconsensus bool) error {
 					ChainId: "default",
 					Local:   oracleAddr,
 				}
-				init.InitCandidates = true
 				jsonInit, err := marshalInit(&init)
 				if err != nil {
 					return err

--- a/e2e/node/node.go
+++ b/e2e/node/node.go
@@ -276,6 +276,12 @@ func (n *Node) Run(ctx context.Context, eventC chan *Event) error {
 				time.Sleep(dur)
 				cmd = exec.CommandContext(ctx, n.LoomPath, "run", "--persistent-peers", n.PersistentPeers)
 				cmd.Dir = n.Dir
+				cmd.Env = append(os.Environ(),
+					"CONTRACT_LOG_DESTINATION=file://contract.log",
+					"CONTRACT_LOG_LEVEL=debug",
+				)
+				cmd.Stderr = os.Stderr
+				cmd.Stdout = os.Stdout
 				go func() {
 					fmt.Printf("starting node %d after %v\n", n.ID, dur)
 					errC <- cmd.Run()

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -337,6 +337,7 @@ func (s *IAVLStore) cloneStateToDB() ([]byte, int64, error) {
 	// copy out all the keys under the prefixes that are still in use
 	for _, prefix := range prefixes {
 		var itError *error
+		numKeysInRange := uint64(0)
 		oldTree.IterateRange(
 			prefix,
 			prefixRangeEnd(prefix),
@@ -353,13 +354,19 @@ func (s *IAVLStore) cloneStateToDB() ([]byte, int64, error) {
 				}
 
 				newTree.Set(key, value)
-				numKeys++
+				numKeysInRange++
 				return false
 			},
 		)
 		if itError != nil {
 			return nil, 0, *itError
 		}
+		numKeys += numKeysInRange
+		log.Debug(
+			"[IAVLStore] cloneStateToDB processed store prefix",
+			"prefix", fmt.Sprintf("%x", prefix),
+			"numKeys", numKeysInRange,
+		)
 	}
 
 	// copy out the misc keys
@@ -368,6 +375,10 @@ func (s *IAVLStore) cloneStateToDB() ([]byte, int64, error) {
 			_, value := oldTree.Get(key)
 			newTree.Set(key, value)
 			numKeys++
+			log.Debug(
+				"[IAVLStore] cloneStateToDB processed store key",
+				"key", fmt.Sprintf("%x", key),
+			)
 		}
 	}
 

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -264,12 +264,12 @@ var (
 		[]byte("minbuild"),
 		[]byte("vmroot"),
 	}
-	// Native contracts deployed to Basechain
+	// names of native contracts that can be resolved to an address via the contract registry
 	nativeContractNames = []string{
-		"address-mapper",
+		"addressmapper",
 		"coin",
 		"ethcoin",
-		"dposV1",
+		"dpos",
 		"dposV2",
 		"dposV3",
 		"gateway",
@@ -277,9 +277,11 @@ var (
 		"tron-gateway",
 		"binance-gateway",
 		"bsc-gateway",
-		"deployer-whitelist",
+		"deployerwhitelist",
 		"user-deployer-whitelist",
-		"chain-config",
+		"chainconfig",
+		"karma",
+		"plasmacash",
 	}
 )
 

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -2,12 +2,18 @@ package store
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/go-kit/kit/metrics"
 	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
+	"github.com/gogo/protobuf/proto"
+	loom "github.com/loomnetwork/go-loom"
 	"github.com/loomnetwork/go-loom/plugin"
+	"github.com/loomnetwork/go-loom/types"
 	"github.com/loomnetwork/go-loom/util"
+	cdb "github.com/loomnetwork/loomchain/db"
 	"github.com/loomnetwork/loomchain/log"
 	"github.com/pkg/errors"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
@@ -48,6 +54,7 @@ type IAVLStore struct {
 	tree          *iavl.MutableTree
 	maxVersions   int64 // maximum number of versions to keep when pruning
 	flushInterval int64 // how often we persist to disk
+	clonedDB      dbm.DB
 }
 
 func (s *IAVLStore) Delete(key []byte) {
@@ -151,11 +158,12 @@ func (s *IAVLStore) SaveVersion() ([]byte, int64, error) {
 
 	// TODO: Rather than loading the on-chain config here the flush interval override should be passed
 	//       in as a parameter to SaveVersion().
+	cfg, err := LoadOnChainConfig(s)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "failed to load on-chain config")
+	}
+
 	if flushInterval == 0 {
-		cfg, err := LoadOnChainConfig(s)
-		if err != nil {
-			return nil, 0, errors.Wrap(err, "failed to load on-chain config")
-		}
 		if cfg.GetAppStore().GetIAVLFlushInterval() != 0 {
 			flushInterval = int64(cfg.GetAppStore().GetIAVLFlushInterval())
 		}
@@ -166,7 +174,8 @@ func (s *IAVLStore) SaveVersion() ([]byte, int64, error) {
 	var version int64
 	var hash []byte
 	// Every X versions we should persist to disk
-	if flushInterval == 0 || ((oldVersion+1)%flushInterval == 0) {
+	flushToDisk := flushInterval == 0 || ((oldVersion+1)%flushInterval == 0)
+	if flushToDisk {
 		if flushInterval != 0 {
 			log.Info("[IAVLStore] Flushing mem to disk", "version", oldVersion+1)
 			hash, version, err = s.tree.FlushMemVersionDisk()
@@ -180,6 +189,31 @@ func (s *IAVLStore) SaveVersion() ([]byte, int64, error) {
 	if err != nil {
 		return nil, 0, errors.Wrapf(err, "failed to save tree version %d", oldVersion+1)
 	}
+
+	// check if this is the block/version at which we must switch over to a new app.db
+	cloneAtHeight := int64(cfg.GetAppStore().GetCloneStateAtHeight())
+	if (cloneAtHeight > 0) && (cloneAtHeight == version) {
+		// NOTE: Skip cloning if...
+		// - The version being cloned hasn't been flushed to disk, this is done as a precaution
+		//   because cloning of in-memory versions hasn't been tested.
+		// - The destination DB isn't set, which means that the cloning & switchover has already
+		//   happened, and shouldn't be done again because cloning to a DB that isn't empty is
+		//   probably a bad idea.
+		if !flushToDisk || (s.clonedDB == nil) {
+			log.Warn(
+				"[IAVLStore] Skipping cloning state",
+				"version", version,
+				"flushed", flushToDisk,
+				"dbSet", s.clonedDB != nil,
+			)
+			return hash, version, nil
+		}
+		hash, version, err = s.cloneStateToDB()
+		if err != nil {
+			return nil, 0, errors.Wrapf(err, "failed to clone tree version %d", version)
+		}
+	}
+
 	return hash, version, nil
 }
 
@@ -216,6 +250,144 @@ func (s *IAVLStore) GetSnapshot() Snapshot {
 	}
 }
 
+var (
+	standardStorePrefixes = [][]byte{
+		[]byte("nonce"),
+		[]byte("feature"),
+		[]byte("registry"),
+		[]byte("reg_caddr"),
+		[]byte("reg_crec"),
+		[]byte("migrationId"),
+	}
+	standardStoreKeys = [][]byte{
+		[]byte("config"),
+		[]byte("minbuild"),
+		[]byte("vmroot"),
+	}
+	// Native contracts deployed to Basechain
+	nativeContractNames = []string{
+		"address-mapper",
+		"coin",
+		"ethcoin",
+		"dposV1",
+		"dposV2",
+		"dposV3",
+		"gateway",
+		"loomcoin-gateway",
+		"tron-gateway",
+		"binance-gateway",
+		"bsc-gateway",
+		"deployer-whitelist",
+		"user-deployer-whitelist",
+		"chain-config",
+	}
+)
+
+func (s *IAVLStore) getContractStorePrefix(contractName string) ([]byte, error) {
+	contractAddrKeyPrefix := []byte("reg_caddr") // registry v2
+	data := s.Get(util.PrefixKey(contractAddrKeyPrefix, []byte(contractName)))
+	if len(data) == 0 {
+		return nil, nil // contract is probably not deployed on this chain
+	}
+	var contractAddrPB types.Address
+	if err := proto.Unmarshal(data, &contractAddrPB); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal contract address")
+	}
+	contractAddr := loom.UnmarshalAddressPB(&contractAddrPB)
+	return util.PrefixKey([]byte("contract"), []byte(contractAddr.Local)), nil
+}
+
+func (s *IAVLStore) cloneStateToDB() ([]byte, int64, error) {
+	// The version of the new tree will be incremented by one before it's saved to disk, so
+	// to retain the same version number as the original tree when the new tree is saved to
+	// disk we have to initialize the new tree with a lower version than the original.
+	oldTree := s.tree
+	newTree := iavl.NewMutableTreeWithVersion(s.clonedDB, 10000, oldTree.Version()-1)
+
+	log.Info(
+		"[IAVLStore] Started cloning state",
+		"treeHeight", oldTree.Height(),
+		"treeSize", oldTree.Size(),
+		"treeVersion", oldTree.Version(),
+		"treeHash", fmt.Sprintf("%x", oldTree.Hash()),
+	)
+
+	prefixes := append([][]byte{}, standardStorePrefixes...)
+	// each native contract has its own prefix in the store
+	for _, contractName := range nativeContractNames {
+		prefix, err := s.getContractStorePrefix(contractName)
+		if err != nil {
+			return nil, 0, err
+		}
+		if prefix != nil {
+			log.Debug(
+				"[IAVLStore] Resolved contract store prefix",
+				"contract", contractName,
+				"prefix", fmt.Sprintf("%x", prefix),
+			)
+			prefixes = append(prefixes, prefix)
+		}
+	}
+
+	numKeys := uint64(0)
+	startTime := time.Now()
+
+	// copy out all the keys under the prefixes that are still in use
+	for _, prefix := range prefixes {
+		var itError *error
+		oldTree.IterateRange(
+			prefix,
+			prefixRangeEnd(prefix),
+			true,
+			func(key, value []byte) bool {
+				// This is just a sanity check, should never actually happen!
+				if !util.HasPrefix(key, prefix) {
+					err := errors.Errorf(
+						"key does not have prefix, skipped key: %x prefix: %x",
+						key, prefix,
+					)
+					itError = &err
+					return true // stop iteration
+				}
+
+				newTree.Set(key, value)
+				numKeys++
+				return false
+			},
+		)
+		if itError != nil {
+			return nil, 0, *itError
+		}
+	}
+
+	// copy out the misc keys
+	for _, key := range standardStoreKeys {
+		if oldTree.Has(key) {
+			_, value := oldTree.Get(key)
+			newTree.Set(key, value)
+			numKeys++
+		}
+	}
+
+	hash, version, err := newTree.SaveVersion()
+	if err != nil {
+		return nil, version, errors.Wrap(err, "failed to save cloned tree")
+	}
+	log.Info(
+		"[IAVLStore] Finished cloning state",
+		"keys", numKeys,
+		"mins", time.Since(startTime).Minutes(),
+		"treeHeight", newTree.Height(),
+		"treeSize", newTree.Size(),
+		"treeVersion", newTree.Version(),
+		"treeHash", fmt.Sprintf("%x", hash),
+	)
+
+	s.tree = newTree // discard the old tree
+	s.clonedDB = nil // ensure cloning can't be repeated by accident
+	return hash, version, nil
+}
+
 // NewIAVLStore creates a new IAVLStore.
 // maxVersions can be used to specify how many versions should be retained, if set to zero then
 // old versions will never been deleted.
@@ -246,6 +418,87 @@ func NewIAVLStore(db dbm.DB, maxVersions, targetVersion, flushInterval int64) (*
 		maxVersions:   maxVersions,
 		flushInterval: flushInterval,
 	}, nil
+}
+
+// NewIAVLStoreWithDualDBs creates a new IAVLStore.
+// Initially the store will use the original DB and may switch over to the cloned DB when triggered
+// by the CloneStateAtHeight on-chain config setting.
+func NewIAVLStoreWithDualDBs(
+	originalDB dbm.DB, clonedDB dbm.DB, maxVersions, targetVersion, flushInterval int64,
+) (*IAVLStore, error) {
+	store, err := NewIAVLStore(originalDB, maxVersions, targetVersion, flushInterval)
+	if err != nil {
+		return nil, err
+	}
+	store.clonedDB = clonedDB
+	return store, nil
+}
+
+// Replace the old app.db (firstDBName) with the cloned app.db (secondDBName),
+// but only if the cloned one contains the most recent state / version.
+func SwitchToLatestAppStoreDB(dbBackend, firstDBName, secondDBName, directory string) error {
+	if _, err := os.Stat(filepath.Join(directory, secondDBName+".db")); err != nil {
+		if os.IsNotExist(err) {
+			return nil // cloned app.db doesn't exist yet, so there's no need to do anything
+		}
+	}
+
+	var firstDB, secondDB dbm.DB
+	var err error
+	switch dbBackend {
+	case cdb.GoLevelDBBackend:
+		firstDB, err = cdb.LoadReadOnlyGoLevelDB(firstDBName, directory)
+		if err != nil {
+			return err
+		}
+		secondDB, err = cdb.LoadReadOnlyGoLevelDB(secondDBName, directory)
+		if err != nil {
+			return err
+		}
+	case cdb.CLevelDBBackend:
+		firstDB, err = cdb.LoadCLevelDB(firstDBName, directory)
+		if err != nil {
+			return err
+		}
+		secondDB, err = cdb.LoadCLevelDB(secondDBName, directory)
+		if err != nil {
+			return err
+		}
+	default:
+		return nil
+	}
+
+	firstTree := iavl.NewMutableTree(firstDB, 0)
+	firstTreeVersion, err := firstTree.LazyLoadVersion(0) // load latest version of the tree
+	if err != nil {
+		return errors.Wrap(err, "[IAVLStore] failed to load latest IAVL tree version from original DB")
+	}
+	secondTree := iavl.NewMutableTree(secondDB, 0)
+	secondTreeVersion, err := secondTree.LazyLoadVersion(0)
+	if err != nil {
+		return errors.Wrap(err, "[IAVLStore] failed to load latest IAVL tree version from cloned DB")
+	}
+
+	firstDB.Close()
+	secondDB.Close()
+
+	if (secondTreeVersion > 0) && (secondTreeVersion >= firstTreeVersion) {
+		// app.db -> old_app_<timestamp>.db
+		srcName := firstDBName + ".db"
+		destName := fmt.Sprintf("old_%s_%d.db", firstDBName, time.Now().Unix())
+		log.Info("[IAVLStore] Moving app DB", "src", srcName, "dest", destName)
+		if err := os.Rename(filepath.Join(directory, srcName), filepath.Join(directory, destName)); err != nil {
+			return errors.Wrapf(err, "[IAVLStore] failed to move %s -> %s", srcName, destName)
+		}
+		// app_v2.db -> app.db
+		srcName = secondDBName + ".db"
+		destName = firstDBName + ".db"
+		log.Info("[IAVLStore] Moving app DB", "src", srcName, "dest", destName)
+		if err := os.Rename(filepath.Join(directory, srcName), filepath.Join(directory, destName)); err != nil {
+			return errors.Wrapf(err, "[IAVLStore] failed to move %s -> %s", srcName, destName)
+		}
+	}
+	return nil
 }
 
 type iavlStoreSnapshot struct {

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -199,18 +199,18 @@ func (s *IAVLStore) SaveVersion() ([]byte, int64, error) {
 		// - The destination DB isn't set, which means that the cloning & switchover has already
 		//   happened, and shouldn't be done again because cloning to a DB that isn't empty is
 		//   probably a bad idea.
-		if !flushToDisk || (s.clonedDB == nil) {
+		if flushToDisk && (s.clonedDB != nil) {
+			hash, version, err = s.cloneStateToDB()
+			if err != nil {
+				return nil, 0, errors.Wrapf(err, "failed to clone tree version %d", version)
+			}
+		} else {
 			log.Warn(
 				"[IAVLStore] Skipping cloning state",
 				"version", version,
 				"flushed", flushToDisk,
 				"dbSet", s.clonedDB != nil,
 			)
-			return hash, version, nil
-		}
-		hash, version, err = s.cloneStateToDB()
-		if err != nil {
-			return nil, 0, errors.Wrapf(err, "failed to clone tree version %d", version)
 		}
 	}
 

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -207,9 +207,20 @@ func (s *MultiWriterAppStore) SaveVersion() ([]byte, int64, error) {
 			return nil, 0, err
 		}
 	}
+
 	hash, version, err := s.appStore.SaveVersion()
-	s.setLastSavedTreeToVersion(version)
-	return hash, version, err
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if err := s.setLastSavedTreeToVersion(version); err != nil {
+		// TODO: Should return the error, which would force the app to panic, but since the
+		//       original implementation didn't even check for an error here fixing this properly
+		//       will require putting the fix behind a new feature flag.
+		log.Error("[MultiWriterAppStore] Failed set last saved tree", "err", err)
+	}
+
+	return hash, version, nil
 }
 
 func (s *MultiWriterAppStore) pruneOldEVMKeys() error {

--- a/store/multi_writer_app_store.go
+++ b/store/multi_writer_app_store.go
@@ -217,7 +217,7 @@ func (s *MultiWriterAppStore) SaveVersion() ([]byte, int64, error) {
 		// TODO: Should return the error, which would force the app to panic, but since the
 		//       original implementation didn't even check for an error here fixing this properly
 		//       will require putting the fix behind a new feature flag.
-		log.Error("[MultiWriterAppStore] Failed set last saved tree", "err", err)
+		log.Error("[MultiWriterAppStore] Failed to set last saved tree", "err", err)
 	}
 
 	return hash, version, nil


### PR DESCRIPTION
To copy the currently used state at a particular height set `AppStore.CloneStateAtHeight` in the on-chain config, when the app reaches that height it will copy out the current state from the `app.db` to `app_v2.db` (omitting ancient keys that are no longer needed), and will save all further IAVL tree versions to the new `app_v2.db`.

Each time a node starts it will check if `app_v2.db` contains the most recent state, if it does it will rename:
1. `app.db` -> `old_app_timestamp.db`
2. `app_v2.db` -> `app.db`
And will then proceed to use `app.db` as usual.

Depends on:
https://github.com/loomnetwork/iavl/pull/15
https://github.com/loomnetwork/go-loom/pull/477